### PR TITLE
Remove unused `covalent_to_monty` DB scheme

### DIFF
--- a/quacc/util/calc.py
+++ b/quacc/util/calc.py
@@ -137,7 +137,7 @@ def run_ase_opt(
         "MDMin",
         "QuasiNewton",
         "Sella",
-        "Sella_IRC",
+        "SellaIRC",
     ] = "FIRE",
     optimizer_kwargs: dict | None = None,
     scratch_dir: str = SETTINGS.SCRATCH_DIR,

--- a/quacc/util/db.py
+++ b/quacc/util/db.py
@@ -37,11 +37,12 @@ def covalent_to_db(
     dispatch_ids = dispatch_ids or []
 
     # Get the dispatch IDs
-    if results_dir:
-        dispatch_ids = os.listdir(results_dir)
-    else:
-        config_results_dir = ct.get_config()["dispatcher"]["results_dir"]
-        dispatch_ids = os.listdir(config_results_dir)
+    if not dispatch_ids:
+        if results_dir:
+            dispatch_ids = os.listdir(results_dir)
+        else:
+            config_results_dir = ct.get_config()["dispatcher"]["results_dir"]
+            dispatch_ids = os.listdir(config_results_dir)
 
     # Populate the docs
     docs = []

--- a/quacc/util/db.py
+++ b/quacc/util/db.py
@@ -10,32 +10,10 @@ import warnings
 import covalent as ct
 from covalent._shared_files.exceptions import MissingLatticeRecordError
 from maggma.core import Store
-from maggma.stores.mongolike import MontyStore
-
-
-def covalent_to_montydb(db_path: str = None, collection_name: str = "covalent") -> None:
-    """
-    Parse the Covalent SQLite DB as a MontyDB
-
-    Parameters
-    ----------
-    db_path
-        Path to the dispatcher_db.sqlite file.
-        If None, the path from ct.get_config() will be used
-    collection_name
-        Name of the collection to create
-
-    Returns
-    -------
-    None
-    """
-    if db_path is None:
-        db_path = ct.get_config()["dispatcher"]["db_path"]
-    return MontyStore(collection_name, os.path.basename(db_path))
 
 
 def covalent_to_db(
-    store: Store, dispatch_id: str | None = None, results_dir: str | None = None
+    store: Store, dispatch_ids: list[str] | None = None, results_dir: str | None = None
 ) -> None:
     """
     Store the results of a Covalent database in a user-specified Maggma Store
@@ -44,8 +22,8 @@ def covalent_to_db(
     ----------
     store
         The Maggma Store object to store the results in
-    dispatch_id
-        A specific dispatch ID to store. If None, all dispatch IDs in the results_dir will be stored
+    dispatch_ids
+        Dispatch ID to store. If None, all dispatch IDs in the results_dir will be stored
     results_dir
         The Covalent results_dir to pull if dispatch_ID is None. If None, the results_dir from ct.get_config() will be used
 
@@ -54,14 +32,12 @@ def covalent_to_db(
     None
     """
 
-    if dispatch_id and results_dir:
+    if dispatch_ids and results_dir:
         raise ValueError("Cannot specify both dispatch_id and results_dir")
+    dispatch_ids = dispatch_ids or []
 
     # Get the dispatch IDs
-    dispatch_ids = []
-    if dispatch_id:
-        dispatch_ids = [dispatch_id]
-    elif results_dir:
+    if results_dir:
         dispatch_ids = os.listdir(results_dir)
     else:
         config_results_dir = ct.get_config()["dispatcher"]["results_dir"]

--- a/tests/util/test_db.py
+++ b/tests/util/test_db.py
@@ -20,7 +20,7 @@ def test_covalent_to_db():
     assert count1 > 0
 
     with pytest.warns(UserWarning):
-        covalent_to_db(store, dispatch_id="bad-value")
+        covalent_to_db(store, dispatch_ids=["bad-value"])
     assert store.count() == count1
 
     store = MemoryStore(collection_name="db2")
@@ -29,7 +29,7 @@ def test_covalent_to_db():
     assert count2 == count1
 
     with pytest.raises(ValueError):
-        covalent_to_db(store, dispatch_id="bad-value", results_dir="bad-value")
+        covalent_to_db(store, dispatch_ids=["bad-value"], results_dir="bad-value")
 
 
 def test_results_to_db():


### PR DESCRIPTION
Closes #392. It's not possible to do this. See https://github.com/materialsproject/maggma/issues/796