### PR TITLE
Better storing of charge/mult in `Atoms` schema

### DIFF
--- a/docs/src/install/codes.md
+++ b/docs/src/install/codes.md
@@ -57,7 +57,7 @@ As noted in the [ASE documentation](https://wiki.fysik.dtu.dk/ase/ase/calculator
 ## Psi4
 
 ```{note}
-[Psi4](https://github.com/psi4/psi4) is especially useful for constructing and testing out new functionals, like DeepMind's DM21 functional.
+[Psi4](https://github.com/psi4/psi4) is an open-source quantum chemistry electronic structure package.
 ```
 
 If you plan to use Psi4 with Quacc, you will need to install it prior to use. This can be done via `conda install -c psi4 psi4`.

--- a/quacc/recipes/gaussian/core.py
+++ b/quacc/recipes/gaussian/core.py
@@ -55,8 +55,8 @@ def static_job(
                 "nprocshared": multiprocessing.cpu_count(),
                 "xc": xc,
                 "basis": basis,
-                "charge": charge or round(sum(atoms.get_initial_charges())),
-                "mult": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+                "charge": charge or int(sum(atoms.get_initial_charges())),
+                "mult": mult or int(1 + sum(atoms.get_initial_magnetic_moments())),
                 "sp": "",
                 "scf": ["maxcycle=250", "xqc"],
                 "integral": "ultrafine",
@@ -76,14 +76,16 @@ def static_job(
 
     swaps = swaps or {}
 
+    charge = charge or int(sum(atoms.get_initial_charges()))
+    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
         "nprocshared": multiprocessing.cpu_count(),
         "xc": xc,
         "basis": basis,
-        "charge": charge or round(sum(atoms.get_initial_charges())),
-        "mult": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+        "charge": charge,
+        "mult": mult,
         "sp": "",
         "scf": ["maxcycle=250", "xqc"],
         "integral": "ultrafine",
@@ -99,7 +101,15 @@ def static_job(
     atoms.calc = Gaussian(**flags)
     atoms = run_calc(atoms, geom_file=GEOM_FILE)
 
-    return summarize_run(atoms, LOG_FILE, additional_fields={"name": "Gaussian Static"})
+    return summarize_run(
+        atoms,
+        LOG_FILE,
+        additional_fields={
+            "name": "Gaussian Static",
+            "charge": charge,
+            "spin_multiplicity": mult,
+        },
+    )
 
 
 @ct.electron
@@ -139,8 +149,8 @@ def relax_job(
                 "nprocshared": multiprocessing.cpu_count(),
                 "xc": xc,
                 "basis": basis,
-                "charge": charge or round(sum(atoms.get_initial_charges())),
-                "mult": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+                "charge": charge or int(sum(atoms.get_initial_charges())),
+                "mult": mult or int(1 + sum(atoms.get_initial_magnetic_moments())),
                 "opt": "",
                 "scf": ["maxcycle=250", "xqc"],
                 "integral": "ultrafine",
@@ -157,14 +167,17 @@ def relax_job(
 
     swaps = swaps or {}
 
+    charge = charge or int(sum(atoms.get_initial_charges()))
+    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
         "nprocshared": multiprocessing.cpu_count(),
         "xc": xc,
         "basis": basis,
-        "charge": charge or round(sum(atoms.get_initial_charges())),
-        "mult": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+        "charge": charge,
+        "mult": mult,
         "opt": "",
         "scf": ["maxcycle=250", "xqc"],
         "integral": "ultrafine",
@@ -177,4 +190,12 @@ def relax_job(
     atoms.calc = Gaussian(**flags)
     atoms = run_calc(atoms, geom_file=GEOM_FILE)
 
-    return summarize_run(atoms, LOG_FILE, additional_fields={"name": "Gaussian Relax"})
+    return summarize_run(
+        atoms,
+        LOG_FILE,
+        additional_fields={
+            "name": "Gaussian Relax",
+            "charge": charge,
+            "spin_multiplicity": mult,
+        },
+    )

--- a/quacc/recipes/gaussian/core.py
+++ b/quacc/recipes/gaussian/core.py
@@ -76,8 +76,8 @@ def static_job(
 
     swaps = swaps or {}
 
-    charge = charge or int(sum(atoms.get_initial_charges()))
-    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+    charge = charge or int(atoms.get_initial_charges().sum())
+    mult = mult or int(1 + atoms.get_initial_magnetic_moments().sum())
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
@@ -167,8 +167,8 @@ def relax_job(
 
     swaps = swaps or {}
 
-    charge = charge or int(sum(atoms.get_initial_charges()))
-    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+    charge = charge or int(atoms.get_initial_charges().sum())
+    mult = mult or int(1 + atoms.get_initial_magnetic_moments().sum())
 
     defaults = {
         "mem": "16GB",

--- a/quacc/recipes/gulp/core.py
+++ b/quacc/recipes/gulp/core.py
@@ -35,20 +35,9 @@ def static_job(
         Filename of the potential library file, if required.
     keyword_swaps
         dictionary of custom keyword swap kwargs for the calculator.
-            defaults = {
-                "mem": "16GB",
-                "chk": "Gaussian.chk",
-                "nprocshared": multiprocessing.cpu_count(),
-                "xc": xc,
-                "basis": basis,
-                "charge": charge or round(sum(atoms.get_initial_charges())),
-                "mult": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
-                "opt": "",
-                "scf": ["maxcycle=250", "xqc"],
-                "integral": "ultrafine",
-                "nosymmetry": "",
-                "freq": "" if freq else None,
-                "ioplist": ["2/9=2000"],  # ASE issue #660
+            default_keywords = {
+                "gfnff": True if gfnff else None,
+                "gwolf": True if gfnff and atoms.pbc.any() else None,
             }
     option_swaps
         dictionary of custom option swap kwargs for the calculator.

--- a/quacc/recipes/orca/core.py
+++ b/quacc/recipes/orca/core.py
@@ -88,8 +88,8 @@ def static_job(
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
-    charge = charge or int(sum(atoms.get_initial_charges()))
-    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+    charge = charge or int(atoms.get_initial_charges().sum())
+    mult = mult or int(1 + atoms.get_initial_magnetic_moments().sum())
 
     atoms.calc = ORCA(
         charge=charge,
@@ -188,8 +188,8 @@ def relax_job(
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
-    charge = charge or int(sum(atoms.get_initial_charges()))
-    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+    charge = charge or int(atoms.get_initial_charges().sum())
+    mult = mult or int(1 + atoms.get_initial_magnetic_moments().sum())
 
     atoms.calc = ORCA(
         charge=charge,

--- a/quacc/recipes/orca/core.py
+++ b/quacc/recipes/orca/core.py
@@ -88,15 +88,26 @@ def static_job(
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
+    charge = charge or int(sum(atoms.get_initial_charges()))
+    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+
     atoms.calc = ORCA(
-        charge=charge or round(sum(atoms.get_initial_charges())),
-        mult=mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+        charge=charge,
+        mult=mult,
         orcasimpleinput=orcasimpleinput,
         orcablocks=orcablocks,
     )
     atoms = run_calc(atoms, geom_file=GEOM_FILE)
 
-    return summarize_run(atoms, LOG_FILE, additional_fields={"name": "ORCA Static"})
+    return summarize_run(
+        atoms,
+        LOG_FILE,
+        additional_fields={
+            "name": "ORCA Static",
+            "charge": charge,
+            "spin_multiplicity": mult,
+        },
+    )
 
 
 @ct.electron
@@ -177,12 +188,23 @@ def relax_job(
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
+    charge = charge or int(sum(atoms.get_initial_charges()))
+    mult = mult or int(1 + sum(atoms.get_initial_magnetic_moments()))
+
     atoms.calc = ORCA(
-        charge=charge or round(sum(atoms.get_initial_charges())),
-        mult=mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+        charge=charge,
+        mult=mult,
         orcasimpleinput=orcasimpleinput,
         orcablocks=orcablocks,
     )
     atoms = run_calc(atoms, geom_file=GEOM_FILE)
 
-    return summarize_run(atoms, LOG_FILE, additional_fields={"name": "ORCA Relax"})
+    return summarize_run(
+        atoms,
+        LOG_FILE,
+        additional_fields={
+            "name": "ORCA Relax",
+            "charge": charge,
+            "spin_multiplicity": mult,
+        },
+    )

--- a/quacc/recipes/psi4/core.py
+++ b/quacc/recipes/psi4/core.py
@@ -50,8 +50,8 @@ def static_job(
                 "num_threads": "max",
                 "method": method,
                 "basis": basis,
-                "charge": charge or round(sum(atoms.get_initial_charges())),
-                "multiplicity": mult or round(1 + sum(atoms.get_initial_magnetic_moments())),
+                "charge": charge or int(sum(atoms.get_initial_charges())),
+                "multiplicity": mult or int(1 + sum(atoms.get_initial_magnetic_moments())),
                 "reference": "uhf" if mult > 1 else None,
             }
 
@@ -62,14 +62,16 @@ def static_job(
     """
 
     swaps = swaps or {}
-    multiplicity = multiplicity or round(1 + sum(atoms.get_initial_magnetic_moments()))
+
+    charge = charge or round(int(atoms.get_initial_charges()))
+    multiplicity = multiplicity or round(1 + int(atoms.get_initial_magnetic_moments()))
 
     defaults = {
         "mem": "16GB",
         "num_threads": "max",
         "method": method,
         "basis": basis,
-        "charge": charge or round(sum(atoms.get_initial_charges())),
+        "charge": charge,
         "multiplicity": multiplicity,
         "reference": "uhf" if multiplicity > 1 else None,
     }
@@ -79,5 +81,11 @@ def static_job(
     new_atoms = run_calc(atoms)
 
     return summarize_run(
-        new_atoms, input_atoms=atoms, additional_fields={"name": "Psi4 Static"}
+        new_atoms,
+        input_atoms=atoms,
+        additional_fields={
+            "name": "Psi4 Static",
+            "charge": charge,
+            "spin_multiplicity": multiplicity,
+        },
     )

--- a/quacc/recipes/psi4/core.py
+++ b/quacc/recipes/psi4/core.py
@@ -63,8 +63,10 @@ def static_job(
 
     swaps = swaps or {}
 
-    charge = charge or round(int(atoms.get_initial_charges()))
-    multiplicity = multiplicity or round(1 + int(atoms.get_initial_magnetic_moments()))
+    charge = charge or round(int(atoms.get_initial_charges().sum()))
+    multiplicity = multiplicity or round(
+        1 + int(atoms.get_initial_magnetic_moments().sum())
+    )
 
     defaults = {
         "mem": "16GB",

--- a/tests/recipes/gaussian/test_gaussian_recipes.py
+++ b/tests/recipes/gaussian/test_gaussian_recipes.py
@@ -43,6 +43,8 @@ def test_static_Job():
         "6/7=3",
         "2/9=2000",
     ]  # see ASE issue #660
+    assert output["spin_multiplicity"] == 1
+    assert output["charge"] == 0
 
     output = static_job(
         atoms,
@@ -64,6 +66,8 @@ def test_static_Job():
     assert "gfinput" not in output["parameters"]
     assert output["parameters"]["ioplist"] == ["2/9=2000"]  # see ASE issue #660
     assert "opt" not in output["parameters"]
+    assert output["spin_multiplicity"] == 3
+    assert output["charge"] == -2
 
 
 def test_relax_Job():

--- a/tests/recipes/orca/test_orca_recipes.py
+++ b/tests/recipes/orca/test_orca_recipes.py
@@ -41,6 +41,8 @@ def test_static_Job():
     assert output["parameters"]["orcablocks"] == f"%pal nprocs {nprocs} end"
     assert output["parameters"]["charge"] == 0
     assert output["parameters"]["mult"] == 1
+    assert output["spin_multiplicity"] == 1
+    assert output["charge"] == 0
 
     output = static_job(
         atoms,
@@ -60,6 +62,8 @@ def test_static_Job():
         output["parameters"]["orcablocks"]
         == f"%scf maxiter 300 end %pal nprocs {nprocs} end"
     )
+    assert output["spin_multiplicity"] == 3
+    assert output["charge"] == -2
 
 
 def test_relax_Job():

--- a/tests/recipes/psi4/test_psi4_recipes.py
+++ b/tests/recipes/psi4/test_psi4_recipes.py
@@ -40,6 +40,8 @@ def test_static_maker():
     assert output["parameters"]["method"] == "wb97x-v"
     assert output["parameters"]["basis"] == "def2-tzvp"
     assert output["parameters"]["num_threads"] == "max"
+    assert output["spin_multiplicity"] == 1
+    assert output["charge"] == 0
 
     output = static_job(
         atoms,
@@ -57,3 +59,5 @@ def test_static_maker():
     assert output["parameters"]["num_threads"] == 1
     assert output["parameters"]["pop"] == "regular"
     assert "mem" not in output["parameters"]
+    assert output["spin_multiplicity"] == 3
+    assert output["charge"] == -2

--- a/tests/util/test_atoms.py
+++ b/tests/util/test_atoms.py
@@ -2,6 +2,7 @@ import os
 from copy import deepcopy
 from pathlib import Path
 
+from ase.atoms import Atoms
 from ase.build import bulk, molecule
 from ase.io import read
 
@@ -21,6 +22,14 @@ ATOMS_NOMAG = read(
 ATOMS_NOSPIN = read(
     os.path.join(FILE_DIR, "..", "calculators", "vasp", "OUTCAR_nospin.gz")
 )
+
+
+def test_init():
+    atoms = bulk("Cu")
+    assert Atoms.from_dict(atoms.as_dict()) == atoms
+
+    atoms = molecule("CH3")
+    assert Atoms.from_dict(atoms.as_dict()) == atoms
 
 
 def test_get_atoms_id():


### PR DESCRIPTION
Closes #421, where in the charge and spin multiplicity flags in the output schema were always set to the default values.

The solution is simple. In the `additional_fields` parameter in the `summarize_run` function, just pass the charge and spin multiplicity so it overrides the default values from the `Molecule` metadata.

For instance, 
```
additional_fields={
    "name": "Gaussian Relax",
    "charge": charge,
    "spin_multiplicity": mult,
},
```

No need to over-engineer here.