### PR TITLE
Fix Molecule schemas... again!

### DIFF
--- a/quacc/recipes/gaussian/core.py
+++ b/quacc/recipes/gaussian/core.py
@@ -104,11 +104,7 @@ def static_job(
     return summarize_run(
         atoms,
         LOG_FILE,
-        additional_fields={
-            "name": "Gaussian Static",
-            "charge": charge,
-            "spin_multiplicity": mult,
-        },
+        additional_fields={"name": "Gaussian Static"},
     )
 
 
@@ -193,9 +189,5 @@ def relax_job(
     return summarize_run(
         atoms,
         LOG_FILE,
-        additional_fields={
-            "name": "Gaussian Relax",
-            "charge": charge,
-            "spin_multiplicity": mult,
-        },
+        additional_fields={"name": "Gaussian Relax"},
     )

--- a/quacc/recipes/orca/core.py
+++ b/quacc/recipes/orca/core.py
@@ -102,11 +102,7 @@ def static_job(
     return summarize_run(
         atoms,
         LOG_FILE,
-        additional_fields={
-            "name": "ORCA Static",
-            "charge": charge,
-            "spin_multiplicity": mult,
-        },
+        additional_fields={"name": "ORCA Static"},
     )
 
 
@@ -202,9 +198,5 @@ def relax_job(
     return summarize_run(
         atoms,
         LOG_FILE,
-        additional_fields={
-            "name": "ORCA Relax",
-            "charge": charge,
-            "spin_multiplicity": mult,
-        },
+        additional_fields={"name": "ORCA Relax"},
     )

--- a/quacc/recipes/psi4/core.py
+++ b/quacc/recipes/psi4/core.py
@@ -85,5 +85,6 @@ def static_job(
     return summarize_run(
         new_atoms,
         input_atoms=atoms,
+        charge_and_multiplicity=(charge, multiplicity),
         additional_fields={"name": "Psi4 Static"},
     )

--- a/quacc/recipes/psi4/core.py
+++ b/quacc/recipes/psi4/core.py
@@ -85,9 +85,5 @@ def static_job(
     return summarize_run(
         new_atoms,
         input_atoms=atoms,
-        additional_fields={
-            "name": "Psi4 Static",
-            "charge": charge,
-            "spin_multiplicity": multiplicity,
-        },
+        additional_fields={"name": "Psi4 Static"},
     )

--- a/quacc/schemas/ase.py
+++ b/quacc/schemas/ase.py
@@ -23,6 +23,7 @@ from quacc.util.dicts import clean_dict
 def summarize_run(
     atoms: Atoms,
     input_atoms: Atoms | None = None,
+    charge_and_multiplicity: tuple[int, int] | None = None,
     prep_next_run: bool = True,
     remove_empties: bool = False,
     additional_fields: dict | None = None,
@@ -37,6 +38,8 @@ def summarize_run(
         ASE Atoms following a calculation. A calculator must be attached.
     input_atoms
         Input ASE Atoms object to store.
+    charge_and_multiplicity
+        Charge and spin multiplicity of the Atoms object, only used for Molecule metadata.
     prep_next_run
         Whether the Atoms object stored in {"atoms": atoms} should be prepared for the next run
         This clears out any attached calculator and moves the final magmoms to the initial magmoms.
@@ -124,7 +127,9 @@ def summarize_run(
         "dir_name": ":".join(uri.split(":")[1:]),
     }
     if input_atoms:
-        input_atoms_db = atoms_to_metadata(input_atoms)
+        input_atoms_db = atoms_to_metadata(
+            input_atoms, charge_and_multiplicity=charge_and_multiplicity
+        )
         inputs["input_atoms"] = input_atoms_db
 
     # Prepares the Atoms object for the next run by moving the
@@ -134,7 +139,7 @@ def summarize_run(
         atoms = prep_next_run_(atoms)
 
     # Get tabulated properties of the structure itself
-    atoms_db = atoms_to_metadata(atoms)
+    atoms_db = atoms_to_metadata(atoms, charge_and_multiplicity=charge_and_multiplicity)
 
     # Create a dictionary of the inputs/outputs
     task_doc = atoms_db | inputs | results | additional_fields
@@ -145,6 +150,7 @@ def summarize_run(
 def summarize_opt_run(
     dyn: Optimizer,
     check_convergence: bool = True,
+    charge_and_multiplicity: tuple[int, int] | None = None,
     prep_next_run: bool = True,
     remove_empties: bool = False,
     additional_fields: dict | None = None,
@@ -159,6 +165,8 @@ def summarize_opt_run(
         ASE Optimizer object.
     check_convergence
         Whether to check the convergence of the calculation.
+    charge_and_multiplicity
+        Charge and spin multiplicity of the Atoms object, only used for Molecule metadata.
     prep_next_run
         Whether the Atoms object stored in {"atoms": atoms} should be prepared for the next run
         This clears out any attached calculator and moves the final magmoms to the initial magmoms.
@@ -249,7 +257,10 @@ def summarize_opt_run(
     # Get results
     traj_results = {
         "trajectory_results": [atoms.calc.results for atoms in traj],
-        "trajectory": [atoms_to_metadata(atoms) for atoms in traj],
+        "trajectory": [
+            atoms_to_metadata(atoms, charge_and_multiplicity=charge_and_multiplicity)
+            for atoms in traj
+        ],
     }
     results = {"results": final_atoms.calc.results}
 
@@ -260,7 +271,9 @@ def summarize_opt_run(
         "nid": uri.split(":")[0],
         "dir_name": ":".join(uri.split(":")[1:]),
     }
-    input_atoms_db = atoms_to_metadata(initial_atoms)
+    input_atoms_db = atoms_to_metadata(
+        initial_atoms, charge_and_multiplicity=charge_and_multiplicity
+    )
     inputs["input_structure"] = input_atoms_db
 
     # Prepares the Atoms object for the next run by moving the
@@ -270,7 +283,9 @@ def summarize_opt_run(
         final_atoms = prep_next_run_(final_atoms)
 
     # Get tabulated properties of the structure itself
-    atoms_db = atoms_to_metadata(final_atoms)
+    atoms_db = atoms_to_metadata(
+        final_atoms, charge_and_multiplicity=charge_and_multiplicity
+    )
 
     # Create a dictionary of the inputs/outputs
     task_doc = atoms_db | inputs | results | traj_results | additional_fields
@@ -280,6 +295,7 @@ def summarize_opt_run(
 
 def summarize_vib_run(
     vib: Vibrations,
+    charge_and_multiplicity: tuple[int, int] | None = None,
     remove_empties: bool = False,
     additional_fields: dict | None = None,
 ) -> dict:
@@ -290,6 +306,8 @@ def summarize_vib_run(
     ----------
     vib
         ASE Vibrations object.
+    charge_and_multiplicity
+        Charge and spin multiplicity of the Atoms object, only used for Molecule metadata.
     remove_empties
         Whether to remove None values and empty lists/dicts from the task document.
     additional_fields
@@ -393,7 +411,7 @@ def summarize_vib_run(
     }
 
     atoms = vib.atoms
-    atoms_db = atoms_to_metadata(atoms)
+    atoms_db = atoms_to_metadata(atoms, charge_and_multiplicity=charge_and_multiplicity)
 
     # Get the true vibrational modes
     natoms = len(atoms)
@@ -437,6 +455,7 @@ def summarize_thermo_run(
     igt: IdealGasThermo,
     temperature: float = 298.15,
     pressure: float = 1.0,
+    charge_and_multiplicity: tuple[int, int] | None = None,
     remove_empties: bool = False,
     additional_fields: dict | None = None,
 ) -> dict:
@@ -451,6 +470,8 @@ def summarize_thermo_run(
         Temperature in Kelvins.
     pressure
         Pressure in bar.
+    charge_and_multiplicity
+        Charge and spin multiplicity of the Atoms object, only used for Molecule metadata.
     remove_empties
         Whether to remove None values and empty lists/dicts from the task document.
     additional_fields
@@ -535,7 +556,9 @@ def summarize_thermo_run(
         }
     }
 
-    atoms_db = atoms_to_metadata(igt.atoms)
+    atoms_db = atoms_to_metadata(
+        igt.atoms, charge_and_multiplicity=charge_and_multiplicity
+    )
 
     task_doc = atoms_db | inputs | results | additional_fields
 

--- a/quacc/schemas/ase.py
+++ b/quacc/schemas/ase.py
@@ -245,6 +245,7 @@ def summarize_opt_run(
     traj = read(dyn.trajectory.filename, index=":")
     initial_atoms = traj[0]
     final_atoms = dyn.atoms.atoms if isinstance(dyn.atoms, Filter) else dyn.atoms
+
     # Get results
     traj_results = {
         "trajectory_results": [atoms.calc.results for atoms in traj],

--- a/quacc/schemas/atoms.py
+++ b/quacc/schemas/atoms.py
@@ -21,6 +21,7 @@ def atoms_to_metadata(
     strip_info: bool = False,
     store_pmg: bool = True,
     remove_empties: bool = False,
+    additional_fields: dict | None = None,
 ) -> dict:
     """
     Convert an ASE Atoms object to a dict suitable for storage in MongoDB.
@@ -39,6 +40,8 @@ def atoms_to_metadata(
         or {"molecule": Molecule}, respectively.
     remove_empties
         Whether to remove None values and empty lists/dicts from the TaskDocument.
+    additional_fields
+        Additional fields to add to the document.
 
     Returns
     -------
@@ -96,6 +99,7 @@ def atoms_to_metadata(
             - tolerance: float = Field(None, title="Point Group Analyzer Tolerance", description="Distance tolerance to consider sites as symmetrically equivalent.")
     """
 
+    additional_fields = additional_fields or {}
     atoms = copy_atoms(atoms)
     results = {}
 
@@ -130,7 +134,7 @@ def atoms_to_metadata(
         results["atoms"] = atoms
 
     # Combine the metadata and results dictionaries
-    atoms_doc = metadata | results
+    atoms_doc = metadata | results | additional_fields
 
     return clean_dict(atoms_doc, remove_empties=remove_empties)
 

--- a/quacc/schemas/atoms.py
+++ b/quacc/schemas/atoms.py
@@ -17,6 +17,7 @@ from quacc.util.dicts import clean_dict
 
 def atoms_to_metadata(
     atoms: Atoms,
+    charge_and_multiplicity: tuple[int, int] | None = None,
     get_metadata: bool = True,
     strip_info: bool = False,
     store_pmg: bool = True,
@@ -30,6 +31,8 @@ def atoms_to_metadata(
     ----------
     atoms
         ASE Atoms object to store in {"atoms": atoms}
+    charge_and_multiplicity
+        Charge and spin multiplicity of the Atoms object, only used for Molecule metadata.
     get_metadata
         Whether to store atoms metadata in the returned dict.
     strip_info
@@ -102,6 +105,11 @@ def atoms_to_metadata(
     additional_fields = additional_fields or {}
     atoms = copy_atoms(atoms)
     results = {}
+
+    # Get any charge or multiplicity keys
+    if charge_and_multiplicity:
+        atoms.charge = charge_and_multiplicity[0]
+        atoms.spin_multiplicity = charge_and_multiplicity[1]
 
     # Get Atoms metadata, if requested. emmet already has built-in tools for
     # generating pymatgen Structure/Molecule metadata, so we'll just use that.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "monty>=2023.4.10",
             "numpy",
             "pydantic",
-            "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
+            "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056/head",  # waiting on PR 3056
         ],
         extras_require={
             "fireworks": ["fireworks"],
@@ -71,7 +71,7 @@ if __name__ == "__main__":
                 "monty==2023.5.8",
                 "numpy==1.24.3",
                 "pydantic==1.10.2",
-                "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
+                "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056/head",  # waiting on PR 3056
             ],
         },
         tests_require=["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "monty>=2023.4.10",
             "numpy",
             "pydantic",
-            "pymatgen @ https://github.com/materialsproject/pymatgen.git@arosen93:ase-dev",  # waiting on PR 3056
+            "pymatgen @ https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
         ],
         extras_require={
             "fireworks": ["fireworks"],
@@ -71,7 +71,7 @@ if __name__ == "__main__":
                 "monty==2023.5.8",
                 "numpy==1.24.3",
                 "pydantic==1.10.2",
-                "pymatgen @ https://github.com/materialsproject/pymatgen.git@arosen93:ase-dev",  # waiting on PR 3056
+                "pymatgen @ https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
             ],
         },
         tests_require=["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "monty>=2023.4.10",
             "numpy",
             "pydantic",
-            "pymatgen>=2022.7.8",
+            "pymatgen @ https://github.com/materialsproject/pymatgen.git@arosen93:ase-dev",  # waiting on PR 3056
         ],
         extras_require={
             "fireworks": ["fireworks"],
@@ -71,7 +71,7 @@ if __name__ == "__main__":
                 "monty==2023.5.8",
                 "numpy==1.24.3",
                 "pydantic==1.10.2",
-                "pymatgen==2023.5.31",
+                "pymatgen @ https://github.com/materialsproject/pymatgen.git@arosen93:ase-dev",  # waiting on PR 3056
             ],
         },
         tests_require=["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "monty>=2023.4.10",
             "numpy",
             "pydantic",
-            "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056/head",  # waiting on PR 3056
+            "pymatgen @ git+https://github.com/arosen93/pymatgen.git@ase-dev",  # waiting on PR 3056
         ],
         extras_require={
             "fireworks": ["fireworks"],
@@ -71,7 +71,7 @@ if __name__ == "__main__":
                 "monty==2023.5.8",
                 "numpy==1.24.3",
                 "pydantic==1.10.2",
-                "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056/head",  # waiting on PR 3056
+                "pymatgen @ git+https://github.com/arosen93/pymatgen.git@ase-dev",  # waiting on PR 3056
             ],
         },
         tests_require=["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "monty>=2023.4.10",
             "numpy",
             "pydantic",
-            "pymatgen @ https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
+            "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
         ],
         extras_require={
             "fireworks": ["fireworks"],
@@ -71,7 +71,7 @@ if __name__ == "__main__":
                 "monty==2023.5.8",
                 "numpy==1.24.3",
                 "pydantic==1.10.2",
-                "pymatgen @ https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
+                "pymatgen @ git+https://github.com/materialsproject/pymatgen.git@pull/3056",  # waiting on PR 3056
             ],
         },
         tests_require=["pytest"],

--- a/tests/recipes/gaussian/test_gaussian_recipes.py
+++ b/tests/recipes/gaussian/test_gaussian_recipes.py
@@ -43,8 +43,6 @@ def test_static_Job():
         "6/7=3",
         "2/9=2000",
     ]  # see ASE issue #660
-    assert output["spin_multiplicity"] == 1
-    assert output["charge"] == 0
 
     output = static_job(
         atoms,
@@ -66,8 +64,6 @@ def test_static_Job():
     assert "gfinput" not in output["parameters"]
     assert output["parameters"]["ioplist"] == ["2/9=2000"]  # see ASE issue #660
     assert "opt" not in output["parameters"]
-    assert output["spin_multiplicity"] == 3
-    assert output["charge"] == -2
 
 
 def test_relax_Job():

--- a/tests/recipes/orca/test_orca_recipes.py
+++ b/tests/recipes/orca/test_orca_recipes.py
@@ -62,8 +62,6 @@ def test_static_Job():
         output["parameters"]["orcablocks"]
         == f"%scf maxiter 300 end %pal nprocs {nprocs} end"
     )
-    assert output["spin_multiplicity"] == 3
-    assert output["charge"] == -2
 
 
 def test_relax_Job():
@@ -93,8 +91,6 @@ def test_relax_Job():
         block_swaps={"%scf maxiter 300 end": True},
     )
     assert output["natoms"] == len(atoms)
-    assert output["parameters"]["charge"] == -2
-    assert output["parameters"]["mult"] == 3
     assert (
         output["parameters"]["orcasimpleinput"]
         == "opt slowconv normalprint xyzfile hf def2-svp"


### PR DESCRIPTION
No more playing with `additional_fields`. This time, we are going straight to the source!

The new approach is as follows:

- Each `summarize_run()` style of function now takes a kwarg `charge_and_multiplicity` that is a `Tuple[int, int]` of the charge and spin multiplicity. Pass it to the summarizer, and everything will be taken care of for you downstream. Only has an effect for molecules because `Molecule` objects, not `Structure` objects, have a `charge` and `spin_multiplicity` property.

Note that the `setup.py` file has been updated, so please uninstall pymatgen and `pip install -e .` again. I'm waiting for my PR to be merged, which should be done next week I imagine. Then we can switch to a published release.