### PR TITLE
Better indexing of parameters in output schemas

### DIFF
--- a/quacc/recipes/lj/core.py
+++ b/quacc/recipes/lj/core.py
@@ -12,8 +12,14 @@ from ase.atoms import Atoms
 from ase.calculators.lj import LennardJones
 from ase.optimize import FIRE
 
-from quacc.schemas.ase import summarize_opt_run, summarize_run
-from quacc.util.calc import run_ase_opt, run_calc
+from quacc.schemas.ase import (
+    summarize_opt_run,
+    summarize_run,
+    summarize_thermo_run,
+    summarize_vib_run,
+)
+from quacc.util.calc import run_ase_opt, run_ase_vib, run_calc
+from quacc.util.thermo import ideal_gas
 
 
 @ct.electron
@@ -82,3 +88,58 @@ def relax_job(
     dyn = run_ase_opt(atoms, **opt_flags)
 
     return summarize_opt_run(dyn, additional_fields={"name": "LJ Relax"})
+
+
+@ct.electron
+def freq_job(
+    atoms: Atoms,
+    energy: float = 0.0,
+    temperature: float = 298.15,
+    pressure: float = 1.0,
+    calc_kwargs: dict | None = None,
+    vib_kwargs: dict | None = None,
+) -> dict:
+    """
+    Run a frequency job and calculate thermochemistry.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    energy
+        Potential energy in eV. If 0, then the output is just the correction.
+    temperature
+        Temperature in Kelvins.
+    pressure
+        Pressure in bar.
+    calc_kwargs
+        dictionary of custom kwargs for the LJ calculator.
+    vib_kwargs
+        dictionary of custom kwargs for the Vibrations object
+
+    Returns
+    -------
+    dict
+        Dictionary of results from quacc.schemas.ase.summarize_vib_run and
+        quacc.schemas.ase.summarize_thermo_run
+    """
+
+    calc_kwargs = calc_kwargs or {}
+    vib_kwargs = vib_kwargs or {}
+
+    atoms.calc = LennardJones(**calc_kwargs)
+    vibrations = run_ase_vib(atoms, vib_kwargs=vib_kwargs)
+
+    igt = ideal_gas(atoms, vibrations.get_frequencies(), energy=energy)
+
+    return {
+        "vib": summarize_vib_run(
+            vibrations, additional_fields={"name": "LJ Vibrations"}
+        ),
+        "thermo": summarize_thermo_run(
+            igt,
+            temperature=temperature,
+            pressure=pressure,
+            additional_fields={"name": "LJ Thermo"},
+        ),
+    }

--- a/quacc/recipes/tblite/core.py
+++ b/quacc/recipes/tblite/core.py
@@ -111,7 +111,7 @@ def freq_job(
     energy: float = 0.0,
     temperature: float = 298.15,
     pressure: float = 1.0,
-    xtb_kwargs: dict | None = None,
+    calc_kwargs: dict | None = None,
     vib_kwargs: dict | None = None,
 ) -> dict:
     """
@@ -129,7 +129,7 @@ def freq_job(
         Temperature in Kelvins.
     pressure
         Pressure in bar.
-    xtb_kwargs
+    calc_kwargs
         dictionary of custom kwargs for the xTB calculator.
     vib_kwargs
         dictionary of custom kwargs for the Vibrations object
@@ -141,10 +141,10 @@ def freq_job(
         quacc.schemas.ase.summarize_thermo_run
     """
 
-    xtb_kwargs = xtb_kwargs or {}
+    calc_kwargs = calc_kwargs or {}
     vib_kwargs = vib_kwargs or {}
 
-    atoms.calc = TBLite(method=method, **xtb_kwargs)
+    atoms.calc = TBLite(method=method, **calc_kwargs)
     vibrations = run_ase_vib(atoms, vib_kwargs=vib_kwargs)
 
     igt = ideal_gas(atoms, vibrations.get_frequencies(), energy=energy)

--- a/quacc/schemas/ase.py
+++ b/quacc/schemas/ase.py
@@ -495,7 +495,6 @@ def summarize_thermo_run(
             - pull_request: int = Field(None, description="The pull request number associated with this data build.")
         - dir_name: str = Field(None, description="Directory where the output is parsed")
         - nid: str = Field(None, title = "The node ID representing the machine where the calculation was run.")
-        - parameters: dict = Field(None, title = "the parameters used to run the calculation.")
         - thermo_parameters: dict = Field(None, title = "the parameters used to run the thermo calculation.")
             - temperature: float = Temperature in Kelvins
             - pressure: float = Pressure in bar
@@ -540,7 +539,6 @@ def summarize_thermo_run(
     spin_multiplicity = int(2 * igt.spin + 1)
 
     inputs = {
-        "parameters": igt.atoms.calc.parameters,
         "thermo_parameters": {
             "temperature": temperature,
             "pressure": pressure,

--- a/quacc/schemas/ase.py
+++ b/quacc/schemas/ase.py
@@ -192,6 +192,7 @@ def summarize_opt_run(
         - input_structure: Molecule | Structure = Field(None, title = "The Pymatgen Structure or Molecule object from the input Atoms object if input_atoms is not None.")
         - nid: str = Field(None, title = "The node ID representing the machine where the calculation was run.")
         - parameters: dict = Field(None, title = "the parameters used to run the calculation.")
+        - opt_parameters: dict = Field(None, title = "the parameters used to run the optimization.")
         - results: dict = Field(None, title = "The results from the calculation.")
         - trajectory: List[Atoms] = Trajectory of Atoms objects
         - trajectory_results: List[dict] = List of ase.calc.results from the trajectory
@@ -240,8 +241,7 @@ def summarize_opt_run(
     """
 
     additional_fields = additional_fields or {}
-    dyn_parameters = dyn.todict()
-    parameters = dyn.atoms.calc.parameters
+    opt_parameters = dyn.todict()
 
     # Check trajectory
     if not os.path.exists(dyn.trajectory.filename):
@@ -268,7 +268,8 @@ def summarize_opt_run(
     # Get the calculator inputs
     uri = get_uri(os.getcwd())
     inputs = {
-        "parameters": dyn_parameters | parameters,
+        "parameters": dyn.atoms.calc.parameters,
+        "opt_parameters": opt_parameters,
         "nid": uri.split(":")[0],
         "dir_name": ":".join(uri.split(":")[1:]),
     }
@@ -329,6 +330,7 @@ def summarize_vib_run(
         - dir_name: str = Field(None, description="Directory where the output is parsed")
         - nid: str = Field(None, title = "The node ID representing the machine where the calculation was run.")
         - parameters: dict = Field(None, title = "the parameters used to run the calculation.")
+        - vib_parameters: dict = Field(None, title = "the parameters used to run the vibrations.")
             - delta: float = the Vibrations delta value
             - direction: str = the Vibrations direction value
             - method: str = the Vibrations method value
@@ -388,6 +390,7 @@ def summarize_vib_run(
 
     vib_freqs_raw = vib.get_frequencies().tolist()
     vib_energies_raw = vib.get_energies().tolist()
+    atoms = vib.atoms
 
     # Convert imaginary modes to negative values for DB storage
     for i, f in enumerate(vib_freqs_raw):
@@ -400,7 +403,8 @@ def summarize_vib_run(
 
     uri = get_uri(os.getcwd())
     inputs = {
-        "parameters": {
+        "parameters": atoms.calc.parameters,
+        "vib_parameters": {
             "delta": vib.delta,
             "direction": vib.direction,
             "method": vib.method,
@@ -411,7 +415,6 @@ def summarize_vib_run(
         "dir_name": ":".join(uri.split(":")[1:]),
     }
 
-    atoms = vib.atoms
     atoms_db = atoms_to_metadata(atoms, charge_and_multiplicity=charge_and_multiplicity)
 
     # Get the true vibrational modes
@@ -493,13 +496,15 @@ def summarize_thermo_run(
         - dir_name: str = Field(None, description="Directory where the output is parsed")
         - nid: str = Field(None, title = "The node ID representing the machine where the calculation was run.")
         - parameters: dict = Field(None, title = "the parameters used to run the calculation.")
+        - thermo_parameters: dict = Field(None, title = "the parameters used to run the thermo calculation.")
             - temperature: float = Temperature in Kelvins
             - pressure: float = Pressure in bar
             - sigma: float = The rotational symmetry number of the molecule
             - spin_multiplicity: int = The spin multiplicity of the molecule
-        - results: dict = Field(None, title = "The results from the calculation.")
             - vib_freqs: List[float] = Vibrational frequencies in cm^-1
             - vib_energies: List[float] = Vibrational energies in eV
+            - n_imag: int = Number of imaginary vibrational frequencies
+        - results: dict = Field(None, title = "The results from the calculation.")
             - energy: float = The potential energy of the system in eV
             - enthalpy: float = The enthalpy of the system in eV
             - entropy: float = The entropy of the system in eV/K
@@ -532,14 +537,18 @@ def summarize_thermo_run(
     additional_fields = additional_fields or {}
 
     uri = get_uri(os.getcwd())
-
     spin_multiplicity = int(2 * igt.spin + 1)
+
     inputs = {
-        "parameters": {
+        "parameters": igt.atoms.calc.parameters,
+        "thermo_parameters": {
             "temperature": temperature,
             "pressure": pressure,
             "sigma": igt.sigma,
             "spin_multiplicity": spin_multiplicity,
+            "vib_freqs": [e / units.invcm for e in igt.vib_energies],
+            "vib_energies": igt.vib_energies.tolist(),
+            "n_imag": igt.n_imag,
         },
         "nid": uri.split(":")[0],
         "dir_name": ":".join(uri.split(":")[1:]),
@@ -547,9 +556,6 @@ def summarize_thermo_run(
 
     results = {
         "results": {
-            "vib_freqs": [e / units.invcm for e in igt.vib_energies],
-            "vib_energies": igt.vib_energies.tolist(),
-            "n_imag": igt.n_imag,
             "energy": igt.potentialenergy,
             "enthalpy": igt.get_enthalpy(temperature, verbose=True),
             "entropy": igt.get_entropy(temperature, pressure * 10**5, verbose=True),

--- a/tests/recipes/lj/test_lj_recipes.py
+++ b/tests/recipes/lj/test_lj_recipes.py
@@ -69,18 +69,14 @@ def test_relax_job():
 def test_freq_job():
     atoms = molecule("H2O")
 
-    output_all = freq_job(relax_job(atoms)["atoms"])
-    for k in {"vib", "thermo"}:
-        output = output_all[k]
-        assert output["natoms"] == len(atoms)
-        assert output["parameters"]["epsilon"] == 1.0
-        assert output["parameters"]["sigma"] == 1.0
-        assert output["parameters"]["rc"] == 3
-        assert output["parameters"]["ro"] == 0.66 * 3
-    assert len(output_all["vib"]["results"]["vib_freqs_raw"]) == 3 * len(atoms)
-    assert len(output_all["vib"]["results"]["vib_freqs"]) == 3 * len(atoms) - 6
-    assert (
-        len(output_all["thermo"]["thermo_parameters"]["vib_freqs"])
-        == 3 * len(atoms) - 6
-    )
-    assert output_all["thermo"]["thermo_parameters"]["n_imag"] == 0
+    output = freq_job(relax_job(atoms)["atoms"])
+    assert output["vib"]["natoms"] == len(atoms)
+    assert output["thermo"]["natoms"] == len(atoms)
+    assert output["vib"]["parameters"]["epsilon"] == 1.0
+    assert output["vib"]["parameters"]["sigma"] == 1.0
+    assert output["vib"]["parameters"]["rc"] == 3
+    assert output["vib"]["parameters"]["ro"] == 0.66 * 3
+    assert len(output["vib"]["results"]["vib_freqs_raw"]) == 3 * len(atoms)
+    assert len(output["vib"]["results"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert len(output["thermo"]["thermo_parameters"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert output["thermo"]["thermo_parameters"]["n_imag"] == 0

--- a/tests/recipes/lj/test_lj_recipes.py
+++ b/tests/recipes/lj/test_lj_recipes.py
@@ -83,4 +83,4 @@ def test_freq_job():
         len(output_all["thermo"]["thermo_parameters"]["vib_freqs"])
         == 3 * len(atoms) - 6
     )
-    assert len(output_all["thermo"]["thermo_parameters"]["n_imag"]) == 0
+    assert output_all["thermo"]["thermo_parameters"]["n_imag"] == 0

--- a/tests/recipes/lj/test_lj_recipes.py
+++ b/tests/recipes/lj/test_lj_recipes.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from ase.build import molecule
 
-from quacc.recipes.lj.core import relax_job, static_job
+from quacc.recipes.lj.core import freq_job, relax_job, static_job
 
 
 def teardown_module():
@@ -22,7 +22,7 @@ def teardown_module():
             rmtree(f)
 
 
-def test_static_Job():
+def test_static_job():
     atoms = molecule("H2O")
 
     output = static_job(atoms)
@@ -42,7 +42,7 @@ def test_static_Job():
     assert output["results"]["energy"] == pytest.approx(0.0)
 
 
-def test_relax_Job():
+def test_relax_job():
     atoms = molecule("H2O")
 
     output = relax_job(atoms)
@@ -64,3 +64,20 @@ def test_relax_Job():
     assert output["parameters"]["ro"] == 0.66 * 0.5
     assert output["results"]["energy"] == pytest.approx(0.0)
     assert np.max(np.linalg.norm(output["results"]["forces"], axis=1)) < 0.03
+
+
+def test_freq_job():
+    atoms = molecule("H2O")
+
+    output_all = freq_job(atoms)
+    for k in {"vib", "thermo"}:
+        output = output_all[k]
+        assert output["natoms"] == len(atoms)
+        assert output["parameters"]["epsilon"] == 1.0
+        assert output["parameters"]["sigma"] == 1.0
+        assert output["parameters"]["rc"] == 3
+        assert output["parameters"]["ro"] == 0.66 * 3
+    assert len(output["vib"]["vib_freqs_raw"]) == 3 * len(atoms)
+    assert len(output["vib"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert len(output["thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert len(output["thermo"]["n_imag"]) == 0

--- a/tests/recipes/lj/test_lj_recipes.py
+++ b/tests/recipes/lj/test_lj_recipes.py
@@ -77,7 +77,10 @@ def test_freq_job():
         assert output["parameters"]["sigma"] == 1.0
         assert output["parameters"]["rc"] == 3
         assert output["parameters"]["ro"] == 0.66 * 3
-    assert len(output["vib"]["vib_freqs_raw"]) == 3 * len(atoms)
-    assert len(output["vib"]["vib_freqs"]) == 3 * len(atoms) - 6
-    assert len(output["thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
-    assert len(output["thermo"]["n_imag"]) == 0
+    assert len(output_all["vib"]["results"]["vib_freqs_raw"]) == 3 * len(atoms)
+    assert len(output_all["vib"]["results"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert (
+        len(output_all["thermo"]["thermo_parameters"]["vib_freqs"])
+        == 3 * len(atoms) - 6
+    )
+    assert len(output_all["thermo"]["thermo_parameters"]["n_imag"]) == 0

--- a/tests/recipes/lj/test_lj_recipes.py
+++ b/tests/recipes/lj/test_lj_recipes.py
@@ -69,7 +69,7 @@ def test_relax_job():
 def test_freq_job():
     atoms = molecule("H2O")
 
-    output_all = freq_job(atoms)
+    output_all = freq_job(relax_job(atoms)["atoms"])
     for k in {"vib", "thermo"}:
         output = output_all[k]
         assert output["natoms"] == len(atoms)

--- a/tests/recipes/tblite/test_tblite_recipes.py
+++ b/tests/recipes/tblite/test_tblite_recipes.py
@@ -160,10 +160,10 @@ def test_freq_job():
     assert output["vib"]["results"]["imag_vib_freqs"] == []
 
     assert output["thermo"]["atoms"] == initial_atoms
-    assert output["thermo"]["parameters"]["temperature"] == 1000.0
-    assert output["thermo"]["parameters"]["pressure"] == 20.0
-    assert output["thermo"]["parameters"]["sigma"] == 6
-    assert output["thermo"]["parameters"]["spin_multiplicity"] == 2
+    assert output["thermo"]["thermo_parameters"]["temperature"] == 1000.0
+    assert output["thermo"]["thermo_parameters"]["pressure"] == 20.0
+    assert output["thermo"]["thermo_parameters"]["sigma"] == 6
+    assert output["thermo"]["thermo_parameters"]["spin_multiplicity"] == 2
     assert output["thermo"]["symmetry"]["linear"] is False
     assert output["thermo"]["symmetry"]["rotation_number"] == 6
     assert len(output["thermo"]["results"]["vib_freqs"]) == 6

--- a/tests/recipes/tblite/test_tblite_recipes.py
+++ b/tests/recipes/tblite/test_tblite_recipes.py
@@ -98,7 +98,7 @@ def test_freq_job():
     assert output["thermo"]["symmetry"]["point_group"] == "C2v"
     assert output["thermo"]["symmetry"]["rotation_number"] == 2
     assert output["thermo"]["symmetry"]["linear"] is False
-    assert len(output["thermo"]["results"]["vib_freqs"]) == 3
+    assert len(output["thermo"]["thermo_parameters"]["vib_freqs"]) == 3
     assert output["vib"]["results"]["vib_freqs"][0] == pytest.approx(1586.623114694335)
     assert output["thermo"]["thermo_parameters"]["vib_freqs"][-1] == pytest.approx(
         3526.9940431752034

--- a/tests/recipes/tblite/test_tblite_recipes.py
+++ b/tests/recipes/tblite/test_tblite_recipes.py
@@ -100,7 +100,7 @@ def test_freq_job():
     assert output["thermo"]["symmetry"]["linear"] is False
     assert len(output["thermo"]["results"]["vib_freqs"]) == 3
     assert output["vib"]["results"]["vib_freqs"][0] == pytest.approx(1586.623114694335)
-    assert output["thermo"]["results"]["vib_freqs"][-1] == pytest.approx(
+    assert output["thermo"]["thermo_parameters"]["vib_freqs"][-1] == pytest.approx(
         3526.9940431752034
     )
     assert output["thermo"]["results"]["energy"] == 0.0
@@ -128,7 +128,7 @@ def test_freq_job():
     assert output["thermo"]["atoms"] == initial_atoms
     assert output["thermo"]["symmetry"]["linear"] is False
     assert output["thermo"]["symmetry"]["rotation_number"] == np.inf
-    assert len(output["thermo"]["results"]["vib_freqs"]) == 0
+    assert len(output["thermo"]["thermo_parameters"]["vib_freqs"]) == 0
     assert output["thermo"]["results"]["energy"] == -1.0
     assert output["thermo"]["results"]["enthalpy"] == pytest.approx(-0.9357685739989672)
     assert output["thermo"]["results"]["entropy"] == pytest.approx(
@@ -166,7 +166,7 @@ def test_freq_job():
     assert output["thermo"]["thermo_parameters"]["spin_multiplicity"] == 2
     assert output["thermo"]["symmetry"]["linear"] is False
     assert output["thermo"]["symmetry"]["rotation_number"] == 6
-    assert len(output["thermo"]["results"]["vib_freqs"]) == 6
+    assert len(output["thermo"]["thermo_parameters"]["vib_freqs"]) == 6
     assert output["thermo"]["results"]["energy"] == -10.0
     assert output["thermo"]["results"]["enthalpy"] == pytest.approx(-8.749341973959462)
     assert output["thermo"]["results"]["entropy"] == pytest.approx(

--- a/tests/schemas/test_ase.py
+++ b/tests/schemas/test_ase.py
@@ -170,11 +170,11 @@ def test_summarize_vib_run():
     results = summarize_vib_run(vib)
     assert results["atoms"] == input_atoms
     assert results["natoms"] == len(atoms)
-    assert results["parameters"]["delta"] == vib.delta
-    assert results["parameters"]["direction"] == "central"
-    assert results["parameters"]["method"] == "standard"
-    assert results["parameters"]["ndof"] == 6
-    assert results["parameters"]["nfree"] == 2
+    assert results["vib_parameters"]["delta"] == vib.delta
+    assert results["vib_parameters"]["direction"] == "central"
+    assert results["vib_parameters"]["method"] == "standard"
+    assert results["vib_parameters"]["ndof"] == 6
+    assert results["vib_parameters"]["nfree"] == 2
     assert "nid" in results
     assert "dir_name" in results
     assert "pull_request" in results["builder_meta"]
@@ -207,11 +207,11 @@ def test_summarize_vib_run():
     results = summarize_vib_run(vib, remove_empties=True)
     assert results["atoms"] == input_atoms
     assert results["natoms"] == len(atoms)
-    assert results["parameters"]["delta"] == vib.delta
-    assert results["parameters"]["direction"] == "central"
-    assert results["parameters"]["method"] == "standard"
-    assert results["parameters"]["ndof"] == 6
-    assert results["parameters"]["nfree"] == 2
+    assert results["vib_parameters"]["delta"] == vib.delta
+    assert results["vib_parameters"]["direction"] == "central"
+    assert results["vib_parameters"]["method"] == "standard"
+    assert results["vib_parameters"]["ndof"] == 6
+    assert results["vib_parameters"]["nfree"] == 2
     assert "nid" in results
     assert "dir_name" in results
     assert "pull_request" not in results["builder_meta"]
@@ -242,7 +242,7 @@ def test_summarize_vib_run():
     results = summarize_vib_run(vib)
     assert results["atoms"] == input_atoms
     assert results["nsites"] == len(atoms)
-    assert results["parameters"]["delta"] == vib.delta
+    assert results["vib_parameters"]["delta"] == vib.delta
     assert len(results["results"]["vib_freqs_raw"]) == 6
     assert len(results["results"]["vib_energies_raw"]) == 6
     assert len(results["results"]["vib_freqs"]) == 6
@@ -256,8 +256,8 @@ def test_summarize_thermo_run():
     results = summarize_thermo_run(igt)
     assert results["natoms"] == len(atoms)
     assert results["atoms"] == atoms
-    assert results["results"]["vib_energies"] == [0.34]
-    assert results["results"]["vib_freqs"] == [0.34 / invcm]
+    assert results["thermo_parameters"]["vib_energies"] == [0.34]
+    assert results["thermo_parameters"]["vib_freqs"] == [0.34 / invcm]
     assert results["results"]["energy"] == 0
     assert "pull_request" in results["builder_meta"]
 
@@ -267,8 +267,8 @@ def test_summarize_thermo_run():
     results = summarize_thermo_run(igt, remove_empties=True)
     assert results["natoms"] == len(atoms)
     assert results["atoms"] == atoms
-    assert results["results"]["vib_energies"] == [0.34]
-    assert results["results"]["vib_freqs"] == [0.34 / invcm]
+    assert results["thermo_parameters"]["vib_energies"] == [0.34]
+    assert results["thermo_parameters"]["vib_freqs"] == [0.34 / invcm]
     assert results["results"]["energy"] == 0
     assert "pull_request" not in results["builder_meta"]
 
@@ -280,8 +280,8 @@ def test_summarize_thermo_run():
     results = summarize_thermo_run(igt)
     assert results["natoms"] == len(atoms)
     assert results["atoms"] == atoms
-    assert results["results"]["vib_energies"] == [0.34]
-    assert results["results"]["vib_freqs"] == [0.34 / invcm]
+    assert results["thermo_parameters"]["vib_energies"] == [0.34]
+    assert results["thermo_parameters"]["vib_freqs"] == [0.34 / invcm]
     assert results["results"]["energy"] == -1
 
     # # Make sure info tags are handled appropriately
@@ -323,17 +323,17 @@ def test_summarize_thermo_run():
     results = summarize_thermo_run(igt, temperature=1000.0, pressure=20.0)
     assert results["natoms"] == len(atoms)
     assert results["atoms"] == atoms
-    assert len(results["results"]["vib_energies"]) == 6
-    assert results["results"]["vib_energies"][0] == vib_energies[-6]
-    assert results["results"]["vib_energies"][-1] == vib_energies[-1]
+    assert len(results["thermo_parameters"]["vib_energies"]) == 6
+    assert results["thermo_parameters"]["vib_energies"][0] == vib_energies[-6]
+    assert results["thermo_parameters"]["vib_energies"][-1] == vib_energies[-1]
     assert results["results"]["energy"] == -10.0
     assert results["results"]["enthalpy"] == pytest.approx(-8.749341973959462)
     assert results["results"]["entropy"] == pytest.approx(0.0023506788982171896)
     assert results["results"]["gibbs_energy"] == pytest.approx(-11.100020872176652)
-    assert results["parameters"]["temperature"] == 1000.0
-    assert results["parameters"]["pressure"] == 20.0
-    assert results["parameters"]["sigma"] == 6
-    assert results["parameters"]["spin_multiplicity"] == 2
+    assert results["thermo_parameters"]["temperature"] == 1000.0
+    assert results["thermo_parameters"]["pressure"] == 20.0
+    assert results["thermo_parameters"]["sigma"] == 6
+    assert results["thermo_parameters"]["spin_multiplicity"] == 2
     assert "nid" in results
     assert "dir_name" in results
 


### PR DESCRIPTION
There are two main changes:
- This PR splits up the `"parameters"` key in the output schemas into `"parameters"` (for calculator parameters) and `"opt_parameters"`/`"thermo_parameters"`/`"vib_parameters"` for module-specific parameters.
- This PR adds an LJ frequency job.