### PR TITLE
Ensure `atoms_to_metadata` does not crash if dummy atoms are present

### DIFF
--- a/quacc/schemas/atoms.py
+++ b/quacc/schemas/atoms.py
@@ -111,6 +111,9 @@ def atoms_to_metadata(
         atoms.charge = charge_and_multiplicity[0]
         atoms.spin_multiplicity = charge_and_multiplicity[1]
 
+    # Strip the dummy atoms, if present
+    del atoms[[atom.index for atom in atoms if atom.symbol == "X"]]
+
     # Get Atoms metadata, if requested. emmet already has built-in tools for
     # generating pymatgen Structure/Molecule metadata, so we'll just use that.
     if get_metadata:

--- a/tests/schemas/test_atoms.py
+++ b/tests/schemas/test_atoms.py
@@ -31,6 +31,15 @@ def test_atoms_to_metadata():
     assert "molecule" not in results
     assert "pull_request" not in results["builder_meta"]
 
+    atoms = bulk("Cu") * (2, 2, 2)
+    atoms[0].symbol = "X"
+    atoms_no_dummy = atoms.copy()
+    del atoms_no_dummy[[atom.index for atom in atoms if atom.symbol == "X"]]
+    atoms.info["test"] = "hi"
+    results = atoms_to_metadata(atoms)
+    assert results["atoms"].info.get("test", None) == "hi"
+    assert results["structure"] == AseAtomsAdaptor.get_structure(atoms_no_dummy)
+
     atoms = bulk("Cu")
     atoms.info["test"] = "hi"
     results = atoms_to_metadata(atoms, strip_info=True)

--- a/tests/schemas/test_atoms.py
+++ b/tests/schemas/test_atoms.py
@@ -33,9 +33,9 @@ def test_atoms_to_metadata():
 
     atoms = bulk("Cu") * (2, 2, 2)
     atoms[0].symbol = "X"
+    atoms.info["test"] = "hi"
     atoms_no_dummy = atoms.copy()
     del atoms_no_dummy[[atom.index for atom in atoms if atom.symbol == "X"]]
-    atoms.info["test"] = "hi"
     results = atoms_to_metadata(atoms)
     assert results["atoms"].info.get("test", None) == "hi"
     assert results["structure"] == AseAtomsAdaptor.get_structure(atoms_no_dummy)


### PR DESCRIPTION
Closes #480.