### PR TITLE
Set `NPAR=1` for `LELF = .TRUE.` in `Vasp` calculator; fix Parsl on HPC

### DIFF
--- a/quacc/calculators/vasp.py
+++ b/quacc/calculators/vasp.py
@@ -536,7 +536,7 @@ class Vasp(Vasp_):
         ):
             if self.verbose:
                 warnings.warn(
-                    "Copilot: Setting ISYM = -1 because you are running a SOC calculation.",
+                    "Copilot: Setting ISYM = -1 because you are running an SOC calculation.",
                     UserWarning,
                 )
             calc.set(isym=-1)

--- a/quacc/calculators/vasp.py
+++ b/quacc/calculators/vasp.py
@@ -529,13 +529,29 @@ class Vasp(Vasp_):
                 )
             calc.set(isym=3)
 
-        if calc.bool_params["lsorbit"]:
+        if (
+            calc.bool_params["lsorbit"]
+            and calc.int_params["isym"]
+            and calc.int_params["isym"] != -1
+        ):
             if self.verbose:
                 warnings.warn(
                     "Copilot: Setting ISYM = -1 because you are running a SOC calculation.",
                     UserWarning,
                 )
             calc.set(isym=-1)
+
+        if (
+            (calc.int_params["ncore"] and calc.int_params["ncore"] > 1)
+            or (calc.int_params["npar"] and calc.int_params["npar"] > 1)
+        ) and (calc.bool_params["lelf"] is True):
+            if self.verbose:
+                warnings.warn(
+                    "Copilot: Setting NPAR = 1 because NCORE/NPAR is not compatible with this job type.",
+                    UserWarning,
+                )
+            calc.set(nnpar=1)
+            calc.set(ncore=None)
 
         if calc.string_params["efermi"]:
             if (

--- a/quacc/calculators/vasp.py
+++ b/quacc/calculators/vasp.py
@@ -550,7 +550,7 @@ class Vasp(Vasp_):
                     "Copilot: Setting NPAR = 1 because NCORE/NPAR is not compatible with this job type.",
                     UserWarning,
                 )
-            calc.set(nnpar=1)
+            calc.set(npar=1)
             calc.set(ncore=None)
 
         if calc.string_params["efermi"]:

--- a/quacc/recipes/emt/parsl/slabs.py
+++ b/quacc/recipes/emt/parsl/slabs.py
@@ -13,8 +13,8 @@ from quacc.util.slabs import make_max_slabs_from_bulk
 def bulk_to_slabs_flow(
     atoms: Atoms | dict,
     slabgen_kwargs: dict | None = None,
-    slab_relax_app: PythonApp = python_app(relax_job),
-    slab_static_app: PythonApp | None = python_app(static_job),
+    slab_relax_app: PythonApp = python_app(relax_job.electron_object.function),
+    slab_static_app: PythonApp | None = python_app(static_job.electron_object.function),
     slab_relax_kwargs: dict | None = None,
     slab_static_kwargs: dict | None = None,
 ) -> AppFuture:

--- a/quacc/recipes/emt/parsl/slabs.py
+++ b/quacc/recipes/emt/parsl/slabs.py
@@ -10,6 +10,8 @@ from quacc.recipes.emt.core import relax_job, static_job
 from quacc.util.slabs import make_max_slabs_from_bulk
 
 
+# See https://github.com/Parsl/parsl/issues/2793 for why we need to strip the @ct.electron
+# decorator off the PythonApp kwargs
 def bulk_to_slabs_flow(
     atoms: Atoms | dict,
     slabgen_kwargs: dict | None = None,

--- a/tests/calculators/vasp/test_vasp.py
+++ b/tests/calculators/vasp/test_vasp.py
@@ -511,6 +511,7 @@ def test_ncore():
     assert calc.int_params["ncore"] is None
 
 
+
 def test_ismear():
     atoms = bulk("Cu")
 

--- a/tests/calculators/vasp/test_vasp.py
+++ b/tests/calculators/vasp/test_vasp.py
@@ -511,7 +511,6 @@ def test_ncore():
     assert calc.int_params["ncore"] is None
 
 
-
 def test_ismear():
     atoms = bulk("Cu")
 

--- a/tests/calculators/vasp/test_vasp.py
+++ b/tests/calculators/vasp/test_vasp.py
@@ -505,11 +505,11 @@ def test_ncore():
 
     calc = Vasp(atoms, npar=4, lelf=True)
     assert calc.int_params["npar"] == 1
-    assert calc.int_params["ncore"] is None
 
     calc = Vasp(atoms, ncore=4, lelf=True)
     assert calc.int_params["npar"] == 1
     assert calc.int_params["ncore"] is None
+
 
 def test_ismear():
     atoms = bulk("Cu")

--- a/tests/calculators/vasp/test_vasp.py
+++ b/tests/calculators/vasp/test_vasp.py
@@ -503,6 +503,13 @@ def test_ncore():
     assert calc.int_params["ncore"] == 1
     assert calc.int_params["npar"] is None
 
+    calc = Vasp(atoms, npar=4, lelf=True)
+    assert calc.int_params["npar"] == 1
+    assert calc.int_params["ncore"] is None
+
+    calc = Vasp(atoms, ncore=4, lelf=True)
+    assert calc.int_params["npar"] == 1
+    assert calc.int_params["ncore"] is None
 
 def test_ismear():
     atoms = bulk("Cu")


### PR DESCRIPTION
Source: https://www.vasp.at/wiki/index.php/LELF.

Also closes #524.