### PR TITLE
Better handling of dict merging for swaps

### DIFF
--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -9,7 +9,7 @@ from quacc import job
 from quacc.schemas.ase import summarize_run
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_calc
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts
 from quacc.util.files import check_logfile
 
 if TYPE_CHECKING:
@@ -59,7 +59,7 @@ def static_job(
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
         "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
     }
-    flags = remove_dict_empties(defaults | calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
 
     atoms.calc = Dftb(**flags)
     final_atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)
@@ -120,7 +120,7 @@ def relax_job(
         "Driver_AppendGeometries": "Yes",
         "Driver_MaxSteps": 2000,
     }
-    flags = remove_dict_empties(defaults | calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
 
     atoms.calc = Dftb(**flags)
     final_atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -59,7 +59,7 @@ def static_job(
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
         "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
     }
-    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Dftb(**flags)
     final_atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)
@@ -120,7 +120,7 @@ def relax_job(
         "Driver_AppendGeometries": "Yes",
         "Driver_MaxSteps": 2000,
     }
-    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Dftb(**flags)
     final_atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -14,6 +14,7 @@ from quacc import job
 from quacc.schemas.ase import summarize_opt_run, summarize_run
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_ase_opt, run_calc
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -91,7 +92,7 @@ def relax_job(
     opt_swaps = opt_swaps or {}
 
     opt_defaults = {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
-    opt_flags = opt_defaults | opt_swaps
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     atoms.calc = EMT(**calc_swaps)
 

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -11,7 +11,7 @@ from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.cclib import summarize_run
 from quacc.util.atoms import get_charge, get_multiplicity
 from quacc.util.calc import run_calc
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -78,7 +78,7 @@ def static_job(
         "gfinput": "",
         "ioplist": ["6/7=3", "2/9=2000"],  # see ASE issue #660
     }
-    flags = remove_dict_empties(defaults | calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Gaussian(**flags)
     atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)
@@ -149,7 +149,7 @@ def relax_job(
         "freq": "" if freq else None,
         "ioplist": ["2/9=2000"],  # ASE issue #660
     }
-    flags = remove_dict_empties(defaults | calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Gaussian(**flags)
     atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)

--- a/src/quacc/recipes/gulp/core.py
+++ b/src/quacc/recipes/gulp/core.py
@@ -10,7 +10,7 @@ from quacc import job
 from quacc.schemas.ase import summarize_run
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_calc
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -66,8 +66,8 @@ def static_job(
         f"output xyz {GEOM_FILE_NOPBC}": None if atoms.pbc.any() else True,
     }
 
-    keywords = remove_dict_empties(default_keywords | keyword_swaps)
-    options = remove_dict_empties(default_options | option_swaps)
+    keywords = merge_dicts(default_keywords, keyword_swaps)
+    options = merge_dicts(default_options, option_swaps)
 
     gulp_keywords = " ".join(list(keywords.keys()))
     gulp_options = list(options.keys())
@@ -145,8 +145,8 @@ def relax_job(
         f"output xyz {GEOM_FILE_NOPBC}": None if atoms.pbc.any() else True,
     }
 
-    keywords = remove_dict_empties(default_keywords | keyword_swaps)
-    options = remove_dict_empties(default_options | option_swaps)
+    keywords = merge_dicts(default_keywords, keyword_swaps)
+    options = merge_dicts(default_options, option_swaps)
 
     gulp_keywords = " ".join(list(keywords.keys()))
     gulp_options = list(options.keys())

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -19,6 +19,7 @@ from quacc.schemas.ase import (
 )
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_ase_opt, run_ase_vib, run_calc
+from quacc.util.dicts import merge_dicts
 from quacc.util.thermo import ideal_gas
 
 if TYPE_CHECKING:
@@ -93,7 +94,7 @@ def relax_job(
 
     opt_defaults = {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
 
-    opt_flags = opt_defaults | opt_swaps
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     atoms.calc = LennardJones(**calc_swaps)
     dyn = run_ase_opt(atoms, copy_files=copy_files, **opt_flags)

--- a/src/quacc/recipes/newtonnet/core.py
+++ b/src/quacc/recipes/newtonnet/core.py
@@ -20,6 +20,7 @@ from quacc.schemas.ase import (
 )
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_ase_opt, run_calc
+from quacc.util.dicts import merge_dicts
 from quacc.util.thermo import ideal_gas
 
 try:
@@ -234,12 +235,7 @@ def ts_job(
         "optimizer_kwargs": {"diag_every_n": 0} if use_custom_hessian else {},
     }
 
-    if "optimizer_kwargs" in opt_swaps:
-        opt_swaps["optimizer_kwargs"] = (
-            opt_defaults["optimizer_kwargs"] | opt_swaps["optimizer_kwargs"]
-        )
-
-    opt_flags = opt_defaults | opt_swaps
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     # Define calculator
     atoms.calc = NewtonNet(
@@ -330,11 +326,8 @@ def irc_job(
             "direction": "forward",
         },
     }
-    if "optimizer_kwargs" in opt_swaps:
-        opt_swaps["optimizer_kwargs"] = (
-            opt_defaults["optimizer_kwargs"] | opt_swaps["optimizer_kwargs"]
-        )
-    opt_flags = opt_defaults | opt_swaps
+
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     # Define calculator
     atoms.calc = NewtonNet(
@@ -397,11 +390,11 @@ def quasi_irc_job(
     opt_swaps = opt_swaps or {}
 
     irc_defaults = {"run_kwargs": {"direction": direction.lower()}}
-    irc_flags = irc_defaults | irc_swaps
+    irc_flags = merge_dicts(irc_defaults, irc_swaps)
     opt_swaps = opt_swaps or {}
 
     opt_defaults = {}
-    opt_flags = opt_defaults | opt_swaps
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     # Run IRC
     irc_summary = irc_job.original_func(atoms, max_steps=5, opt_swaps=irc_flags)

--- a/src/quacc/recipes/newtonnet/core.py
+++ b/src/quacc/recipes/newtonnet/core.py
@@ -271,10 +271,8 @@ def ts_job(
     ts_summary = _add_stdev_and_hess(ts_summary)
 
     # Run a frequency calculation
-    thermo_summary = freq_job(
-        ts_summary["atoms"],
-        temperature=temperature,
-        pressure=pressure,
+    thermo_summary = freq_job.original_func(
+        ts_summary, temperature=temperature, pressure=pressure
     )
 
     return {"ts": ts_summary, "thermo": thermo_summary}
@@ -355,10 +353,8 @@ def irc_job(
     summary_irc = _add_stdev_and_hess(summary_irc)
 
     # Run frequency job
-    thermo_summary = freq_job(
-        summary_irc["atoms"],
-        temperature=temperature,
-        pressure=pressure,
+    thermo_summary = freq_job.original_func(
+        summary_irc, temperature=temperature, pressure=pressure
     )
     return {"irc": summary_irc, "thermo": thermo_summary}
 

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -88,8 +88,8 @@ def static_job(
     }
     default_blocks = {}
 
-    inputs = merge_dicts(default_inputs, input_swaps, remove_empties=True)
-    blocks = merge_dicts(default_blocks, block_swaps, remove_empties=True)
+    inputs = merge_dicts(default_inputs, input_swaps)
+    blocks = merge_dicts(default_blocks, block_swaps)
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
@@ -177,8 +177,8 @@ def relax_job(
     }
     default_blocks = {}
 
-    inputs = merge_dicts(default_inputs, input_swaps, remove_empties=True)
-    blocks = merge_dicts(default_blocks, block_swaps, remove_empties=True)
+    inputs = merge_dicts(default_inputs, input_swaps)
+    blocks = merge_dicts(default_blocks, block_swaps)
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -12,7 +12,7 @@ from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.cclib import summarize_run
 from quacc.util.atoms import get_charge, get_multiplicity
 from quacc.util.calc import run_calc
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -88,8 +88,8 @@ def static_job(
     }
     default_blocks = {}
 
-    inputs = remove_dict_empties(default_inputs | input_swaps)
-    blocks = remove_dict_empties(default_blocks | block_swaps)
+    inputs = merge_dicts(default_inputs, input_swaps, remove_empties=True)
+    blocks = merge_dicts(default_blocks, block_swaps, remove_empties=True)
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 
@@ -177,8 +177,8 @@ def relax_job(
     }
     default_blocks = {}
 
-    inputs = remove_dict_empties(default_inputs | input_swaps)
-    blocks = remove_dict_empties(default_blocks | block_swaps)
+    inputs = merge_dicts(default_inputs, input_swaps, remove_empties=True)
+    blocks = merge_dicts(default_blocks, block_swaps, remove_empties=True)
     orcasimpleinput = " ".join(list(inputs.keys()))
     orcablocks = " ".join(list(blocks.keys()))
 

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -78,7 +78,7 @@ def static_job(
         "multiplicity": multiplicity,
         "reference": "uks" if multiplicity > 1 else "rks",
     }
-    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Psi4(**flags)
     final_atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -11,7 +11,7 @@ from quacc.schemas.ase import summarize_run
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.atoms import get_charge, get_multiplicity
 from quacc.util.calc import run_calc
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -78,7 +78,7 @@ def static_job(
         "multiplicity": multiplicity,
         "reference": "uks" if multiplicity > 1 else "rks",
     }
-    flags = remove_dict_empties(defaults | calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=True)
 
     atoms.calc = Psi4(**flags)
     final_atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/tblite/core.py
+++ b/src/quacc/recipes/tblite/core.py
@@ -15,6 +15,7 @@ from quacc.schemas.ase import (
 )
 from quacc.schemas.atoms import fetch_atoms
 from quacc.util.calc import run_ase_opt, run_ase_vib, run_calc
+from quacc.util.dicts import merge_dicts
 from quacc.util.thermo import ideal_gas
 
 if TYPE_CHECKING:
@@ -105,7 +106,7 @@ def relax_job(
     opt_swaps = opt_swaps or {}
 
     opt_defaults = {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
-    opt_flags = opt_defaults | opt_swaps
+    opt_flags = merge_dicts(opt_defaults, opt_swaps)
 
     atoms.calc = TBLite(method=method, **calc_swaps)
     dyn = run_ase_opt(atoms, relax_cell=relax_cell, copy_files=copy_files, **opt_flags)

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -53,7 +53,7 @@ def static_job(
         "nedos": 5001,
         "nsw": 0,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=False)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)
@@ -103,7 +103,7 @@ def relax_job(
         "lwave": False,
         "nsw": 200,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -8,6 +8,7 @@ from quacc.calculators.vasp import Vasp
 from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.vasp import summarize_run
 from quacc.util.calc import run_calc
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -52,7 +53,7 @@ def static_job(
         "nedos": 5001,
         "nsw": 0,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)
@@ -102,7 +103,7 @@ def relax_job(
         "lwave": False,
         "nsw": 200,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -54,7 +54,7 @@ def mp_prerelax_job(
     calc_swaps = calc_swaps or {}
 
     defaults = {"ediffg": -0.05, "xc": "pbesol"}
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=False)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -15,6 +15,7 @@ from quacc.calculators.vasp import Vasp
 from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.vasp import summarize_run
 from quacc.util.calc import run_calc
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -53,7 +54,7 @@ def mp_prerelax_job(
     calc_swaps = calc_swaps or {}
 
     defaults = {"ediffg": -0.05, "xc": "pbesol"}
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -152,7 +152,7 @@ def _prerelax(
         "nelm": 225,
         "nsw": 0,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     dyn = run_ase_opt(atoms, fmax=fmax, optimizer=BFGSLineSearch)
 
@@ -196,7 +196,7 @@ def _loose_relax_positions(
         "lwave": True,
         "nsw": 250,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms)
 
@@ -240,7 +240,7 @@ def _loose_relax_cell(
         "lwave": True,
         "nsw": 500,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
 
@@ -290,7 +290,7 @@ def _double_relax(
     }
 
     # Run first relaxation
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     calc1 = Vasp(atoms, preset=preset, **flags)
     atoms.calc = calc1
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
@@ -305,7 +305,7 @@ def _double_relax(
     del defaults["lreal"]
 
     # Run second relaxation
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     calc2 = Vasp(atoms, preset=preset, **flags)
     atoms.calc = calc2
 
@@ -355,7 +355,7 @@ def _static(
     }
 
     # Run static calculation
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps,remove_empties=False)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
 

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -16,6 +16,7 @@ from quacc.schemas.ase import summarize_opt_run
 from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.vasp import summarize_run
 from quacc.util.calc import run_ase_opt, run_calc
+from quacc.util.dicts import merge_dicts
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -151,7 +152,7 @@ def _prerelax(
         "nelm": 225,
         "nsw": 0,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     dyn = run_ase_opt(atoms, fmax=fmax, optimizer=BFGSLineSearch)
 
@@ -195,7 +196,7 @@ def _loose_relax_positions(
         "lwave": True,
         "nsw": 250,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms)
 
@@ -239,7 +240,7 @@ def _loose_relax_cell(
         "lwave": True,
         "nsw": 500,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
 
@@ -289,7 +290,7 @@ def _double_relax(
     }
 
     # Run first relaxation
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     calc1 = Vasp(atoms, preset=preset, **flags)
     atoms.calc = calc1
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
@@ -304,7 +305,7 @@ def _double_relax(
     del defaults["lreal"]
 
     # Run second relaxation
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     calc2 = Vasp(atoms, preset=preset, **flags)
     atoms.calc = calc2
 
@@ -354,7 +355,7 @@ def _static(
     }
 
     # Run static calculation
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=["WAVECAR"])
 

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -56,7 +56,7 @@ def slab_static_job(
         "nedos": 5001,
         "nsw": 0,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=False)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)
@@ -103,7 +103,7 @@ def slab_relax_job(
         "lwave": False,
         "nsw": 200,
     }
-    flags = merge_dicts(defaults, calc_swaps)
+    flags = merge_dicts(defaults, calc_swaps, remove_empties=False)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -8,6 +8,7 @@ from quacc.calculators.vasp import Vasp
 from quacc.schemas.atoms import fetch_atoms
 from quacc.schemas.vasp import summarize_run
 from quacc.util.calc import run_calc
+from quacc.util.dicts import merge_dicts
 from quacc.util.slabs import make_adsorbate_structures, make_max_slabs_from_bulk
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ def slab_static_job(
         "nedos": 5001,
         "nsw": 0,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)
@@ -102,7 +103,7 @@ def slab_relax_job(
         "lwave": False,
         "nsw": 200,
     }
-    flags = defaults | calc_swaps
+    flags = merge_dicts(defaults, calc_swaps)
 
     atoms.calc = Vasp(atoms, preset=preset, **flags)
     atoms = run_calc(atoms, copy_files=copy_files)

--- a/src/quacc/util/dicts.py
+++ b/src/quacc/util/dicts.py
@@ -28,7 +28,7 @@ def merge_dicts(dict1: dict, dict2: dict, remove_empties: bool = True) -> dict:
     for key, value in dict2.items():
         if key in merged:
             if isinstance(merged[key], dict) and isinstance(value, dict):
-                merged[key] = recursive_merge(merged[key], value)
+                merged[key] = merge_dicts(merged[key], value)
             else:
                 merged[key] = value
         else:

--- a/src/quacc/util/dicts.py
+++ b/src/quacc/util/dicts.py
@@ -4,6 +4,35 @@ Utility functions for dealing with dictionaries
 from __future__ import annotations
 
 
+def merge_dicts(dict1: dict, dict2: dict, remove_empties: bool = False) -> dict:
+    """
+    Merge two dictionaries recursively.
+
+    Parameters
+    ----------
+    dict1
+        First dictionary
+    dict2
+        Second dictionary
+
+    Returns
+    -------
+    dict
+        Merged dictionary
+    """
+
+    merged = dict1.copy()
+    for k, v in dict2.items():
+        if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
+            merged[k] = merge_dicts(merged[k], v)
+        else:
+            merged[k] = v
+    if remove_empties:
+        merged = remove_dict_empties(merged)
+    
+    return merged
+
+
 def clean_dict(start_dict: dict, remove_empties: bool = False) -> dict:
     """
     For a given dictionary, recursively remove all items that are None

--- a/src/quacc/util/dicts.py
+++ b/src/quacc/util/dicts.py
@@ -4,29 +4,36 @@ Utility functions for dealing with dictionaries
 from __future__ import annotations
 
 
-def merge_dicts(dict1: dict, dict2: dict, remove_empties: bool = False) -> dict:
+def merge_dicts(dict1: dict, dict2: dict, remove_empties: bool = True) -> dict:
     """
-    Merge two dictionaries recursively.
+    Recursively merges two dictionaries.
 
     Parameters
     ----------
+
     dict1
         First dictionary
     dict2
         Second dictionary
+    remove_empties
+        If True, remove empty lists and dictionaries
 
     Returns
     -------
     dict
         Merged dictionary
     """
-
     merged = dict1.copy()
-    for k, v in dict2.items():
-        if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
-            merged[k] = merge_dicts(merged[k], v)
+
+    for key, value in dict2.items():
+        if key in merged:
+            if isinstance(merged[key], dict) and isinstance(value, dict):
+                merged[key] = recursive_merge(merged[key], value)
+            else:
+                merged[key] = value
         else:
-            merged[k] = v
+            merged[key] = value
+
     if remove_empties:
         merged = remove_dict_empties(merged)
 

--- a/src/quacc/util/dicts.py
+++ b/src/quacc/util/dicts.py
@@ -29,7 +29,7 @@ def merge_dicts(dict1: dict, dict2: dict, remove_empties: bool = False) -> dict:
             merged[k] = v
     if remove_empties:
         merged = remove_dict_empties(merged)
-    
+
     return merged
 
 

--- a/src/quacc/util/wflows.py
+++ b/src/quacc/util/wflows.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ase.atoms import Atoms
     from covalent import electron as ct_electron
     from covalent import lattice as ct_lattice
     from dask_jobqueue.core import DaskJobqueueJob
@@ -35,36 +36,40 @@ def job(
         which is the undecorated function.
     """
 
-    from quacc import SETTINGS
+    def _fetch_atoms(atoms: Atoms | dict) -> Atoms:
+        return atoms if isinstance(atoms, Atoms) else atoms["atoms"]
 
-    wflow_engine = (
-        SETTINGS.WORKFLOW_ENGINE.lower() if SETTINGS.WORKFLOW_ENGINE else None
-    )
-    if wflow_engine == "covalent":
-        import covalent as ct
+    def decorator(fun):
+        from quacc import SETTINGS
 
-        decorated = ct.electron(_func, **kwargs)
-    elif wflow_engine == "jobflow":
-        from jobflow import job as jf_job
+        wflow_engine = (
+            SETTINGS.WORKFLOW_ENGINE.lower() if SETTINGS.WORKFLOW_ENGINE else None
+        )
+        if wflow_engine == "covalent":
+            import covalent as ct
 
-        decorated = jf_job(_func, **kwargs)
-    elif wflow_engine == "parsl":
-        from parsl import python_app
+            decorated = ct.electron(_func, **kwargs)
+        elif wflow_engine == "jobflow":
+            from jobflow import job as jf_job
 
-        decorated = python_app(_func, **kwargs)
-    elif wflow_engine == "prefect":
-        from prefect import task
+            decorated = jf_job(_func, **kwargs)
+        elif wflow_engine == "parsl":
+            from parsl import python_app
 
-        decorated = task(_func, **kwargs)
-    elif not wflow_engine:
-        decorated = _func
-    else:
-        msg = f"Unknown workflow engine: {wflow_engine}"
-        raise ValueError(msg)
+            decorated = python_app(_func, **kwargs)
+        elif wflow_engine == "prefect":
+            from prefect import task
 
-    decorated.original_func = _func
+            decorated = task(_func, **kwargs)
+        elif not wflow_engine:
+            decorated = _func
+        else:
+            msg = f"Unknown workflow engine: {wflow_engine}"
+            raise ValueError(msg)
 
-    return decorated
+        decorated.original_func = _func
+
+    return decorator
 
 
 def flow(

--- a/tests/util/test_dicts.py
+++ b/tests/util/test_dicts.py
@@ -1,4 +1,4 @@
-from quacc.util.dicts import remove_dict_empties
+from quacc.util.dicts import merge_dicts, remove_dict_empties
 
 
 def test_remove_dict_empties():
@@ -9,3 +9,13 @@ def test_remove_dict_empties():
     d = {"output": {"output": {"test": {}, "test2": 1}}}
     d = remove_dict_empties(d)
     assert d == {"output": {"output": {"test2": 1}}}
+
+
+def test_merge_dicts():
+    defaults = {"a": 1, "b": {"a": 1, "b": 2}}
+    calc_swaps = {"c": 3, "b": {"b": 3, "d": 1}}
+    assert merge_dicts(defaults, calc_swaps) == {
+        "a": 1,
+        "b": {"a": 1, "b": 3, "d": 1},
+        "c": 3,
+    }


### PR DESCRIPTION
Closes #733. Tagging @kumaranu.

Now, when you pass a list of swaps to any recipe, it will only replace the designated items even if it's in a nested dictionary.

For instance:

```python
defaults = {"a": 1, "b": {"a": 1, "b": 2}}
calc_swaps = {"c": 3, "b": {"b": 3}}
```

would resolve to

```python
{"a": 1, "b": {"a": 1, "b": 3}, "c": 3}
```