### PR TITLE
Better handling of ASE dependency

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -18,7 +18,9 @@ To contribute to quacc, we recommend doing the following:
 
 - [Clone this forked repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local machine, e.g. via `git clone <repo url>.git`.
 
-- In the newly downloaded `quacc` base directory, run `pip install -e .[dev]` to install quacc in editable mode and with the development dependencies. If you need to strictly match the versions of dependencies used in the GitHub actions test suite, you can find `reuqirements.txt` files in the `tests` directory.
+- Make sure your ASE dependency is up-to-date by running `pip install --upgrade https://gitlab.com/ase/ase/-/archive/master/ase-master.zip`.
+
+- In the newly downloaded `quacc` base directory, run `pip install -e .[dev]` to install quacc in editable mode and with the development dependencies. If you need to strictly match the versions of dependencies used in the GitHub actions test suite, you can find `requirements.txt` files in the `tests` directory.
 
 - [Commit your changes](https://github.com/git-guides/git-commit) and [push them](https://github.com/git-guides/git-push) to your personal forked repository _in a new branch_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,15 @@ newtonnet = ["newtonnet @ git+https://github.com/ericyuan00000/NewtonNet.git", "
 optimizers = ["sella>=2.3.2"]
 parsl = ["parsl>=2023.8.14"]
 tblite = ["tblite[ase]>=0.3.0; platform_system=='Linux'"]
-dev = ["black>=23.7.0", "codecov-cli>=0.2.0", "isort>=5.12.0", "pytest>=7.4.0", "pytest-cov>=3.0.0", "ruff>=0.0.285"]
+dev = [
+    "ase @ https://gitlab.com/ase/ase/-/archive/master/ase-master.zip", # remove after >3.22.1 is released
+    "black>=23.7.0",
+    "codecov-cli>=0.2.0",
+    "isort>=5.12.0",
+    "pytest>=7.4.0",
+    "pytest-cov>=3.0.0",
+    "ruff>=0.0.285"
+]
 docs = [
     "blacken-docs>=1.16.0",
     "mkdocs-material>=9.1.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,7 @@ newtonnet = ["newtonnet @ git+https://github.com/ericyuan00000/NewtonNet.git", "
 optimizers = ["sella>=2.3.2"]
 parsl = ["parsl>=2023.8.14"]
 tblite = ["tblite[ase]>=0.3.0; platform_system=='Linux'"]
-dev = [
-    "ase @ https://gitlab.com/ase/ase/-/archive/master/ase-master.zip", # remove after >3.22.1 is released
-    "black>=23.7.0",
-    "codecov-cli>=0.2.0",
-    "isort>=5.12.0",
-    "pytest>=7.4.0",
-    "pytest-cov>=3.0.0",
-    "ruff>=0.0.285"
-]
+dev = ["black>=23.7.0", "codecov-cli>=0.2.0", "isort>=5.12.0", "pytest>=7.4.0", "pytest-cov>=3.0.0", "ruff>=0.0.285"]
 docs = [
     "blacken-docs>=1.16.0",
     "mkdocs-material>=9.1.21",

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -38,7 +38,7 @@ Atoms.from_dict = atoms_from_dict
 
 if tuple(ase_version) <= tuple("3.22.1"):
     msg = f"Your ASE version ({ase_version}) is <= 3.22.1. Please upgrade your ASE version by running `pip install --upgrade https://gitlab.com/ase/ase/-/archive/master/ase-master.zip`"
-    raise ValueError(msg)
+    warnings.warn(msg, UserWarning)
 
 # Load the settings
 SETTINGS = QuaccSettings()

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from importlib.metadata import version
 
 from ase import Atoms
+from ase import __version__ as ase_version
 from ase.io.jsonio import decode, encode
 
 from quacc.settings import QuaccSettings
@@ -34,6 +35,10 @@ __version__ = version("quacc")
 # Make Atoms MSONable
 Atoms.as_dict = atoms_as_dict
 Atoms.from_dict = atoms_from_dict
+
+if tuple(ase_version) <= tuple("3.22.1"):
+    msg = f"Your ASE version ({ase_version}) is <= 3.22.1. Please upgrade your ASE version by running `pip install --upgrade https://gitlab.com/ase/ase/-/archive/master/ase-master.zip`"
+    raise ValueError(msg)
 
 # Load the settings
 SETTINGS = QuaccSettings()


### PR DESCRIPTION
@OmAximani0: Thanks for your report. I agree that the instructions were not clear for developers.

I have made the following changes:

- I have updated the contributor guide to include a step for installing the development version of ASE, just like in the regular installation instructions.
- I have added a check to the `__init__.py` of quacc that checks your ASE version and raises a warning if your version is incompatible.
