### PR TITLE
Remove redundant `Path()` calls when using `.resolve()`

### DIFF
--- a/src/quacc/calculators/qchem.py
+++ b/src/quacc/calculators/qchem.py
@@ -141,7 +141,7 @@ class QChem(FileIOCalculator):
         """
 
         # Return the command flag
-        run_qchem_custodian_file = Path.resolve(Path(inspect.getfile(custodian_qchem)))
+        run_qchem_custodian_file = Path(inspect.getfile(custodian_qchem)).resolve()
         return f"python {run_qchem_custodian_file} {self.cores}"
 
     def write_input(self, atoms, properties=None, system_changes=None):

--- a/src/quacc/calculators/vasp.py
+++ b/src/quacc/calculators/vasp.py
@@ -237,9 +237,7 @@ class Vasp(Vasp_):
         # are set
         if self.use_custodian:
             # Return the command flag
-            run_vasp_custodian_file = Path.resolve(
-                Path(inspect.getfile(custodian_vasp))
-            )
+            run_vasp_custodian_file = Path(inspect.getfile(custodian_vasp)).resolve()
             return f"python {run_vasp_custodian_file}"
 
         if "ASE_VASP_COMMAND" not in os.environ and "VASP_SCRIPT" not in os.environ:

--- a/src/quacc/utils/calc.py
+++ b/src/quacc/utils/calc.py
@@ -262,7 +262,7 @@ def _calc_setup(
     )
 
     # Create a tmpdir for the calculation within the scratch_dir
-    tmpdir = Path.resolve(Path(mkdtemp(prefix="quacc-tmp-", dir=SETTINGS.SCRATCH_DIR)))
+    tmpdir = Path(mkdtemp(prefix="quacc-tmp-", dir=SETTINGS.SCRATCH_DIR)).resolve()
 
     # Create a symlink (if not on Windows) to the tmpdir in the results_dir
     symlink = os.path.join(job_results_dir, f"{tmpdir.name}-symlink")

--- a/src/quacc/utils/files.py
+++ b/src/quacc/utils/files.py
@@ -163,11 +163,11 @@ def find_recent_logfile(dir_name: Path | str, logfile_extensions: str | list[str
     if isinstance(logfile_extensions, str):
         logfile_extensions = [logfile_extensions]
     for f in os.listdir(dir_name):
-        f_path = Path(dir_name) / f
+        f_path = Path(dir_name, f)
         for ext in logfile_extensions:
             if ext in f and os.path.getmtime(f_path) > mod_time:
                 mod_time = os.path.getmtime(f_path)
-                logfile = Path.resolve(f_path)
+                logfile = f_path.resolve()
     return logfile
 
 


### PR DESCRIPTION
FYI @OmAximani0.