### PR TITLE
Clean up Q-Chem recipes

### DIFF
--- a/src/quacc/calculators/qchem.py
+++ b/src/quacc/calculators/qchem.py
@@ -179,7 +179,7 @@ class QChem(FileIOCalculator):
     def read_results(self):
         data = QCOutput("mol.qout").data
         self.results["energy"] = data["final_energy"] * units.Hartree
-        if self.job_type == "force":
+        if self.job_type in ["opt", "force"]:
             tmp_grad_data = []
             # Read the gradient scratch file in 8 byte chunks
             with zopen("131.0", mode="rb") as file:

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -66,7 +66,8 @@ def static_job(
     RunSchema
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
-
+    atoms = fetch_atoms(atoms)
+    calc_swaps = calc_swaps or {}
     defaults = {
         "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
@@ -138,7 +139,8 @@ def relax_job(
     RunSchema
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
-
+    atoms = fetch_atoms(atoms)
+    calc_swaps = calc_swaps or {}
     defaults = {
         "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
@@ -164,7 +166,7 @@ def relax_job(
 
 
 def _base_job(
-    atoms: Atoms | dict,
+    atoms: Atoms,
     flags: dict | None = None,
     additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
@@ -175,8 +177,7 @@ def _base_job(
     Parameters
     ----------
     atoms
-        Atoms object or a dictionary with the key "atoms" and an Atoms object as
-        the value
+        Atoms object
     flags
         The calculator flags to use.
     additional_fields
@@ -189,7 +190,6 @@ def _base_job(
     RunSchema
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
-    atoms = fetch_atoms(atoms)
     flags = flags or {}
 
     atoms.calc = Dftb(**flags)

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -80,7 +80,8 @@ def static_job(
     cclibSchema
         Dictionary of results, as specified in [quacc.schemas.cclib.summarize_run][]
     """
-
+    atoms = fetch_atoms(atoms)
+    calc_swaps = calc_swaps or {}
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
@@ -168,7 +169,7 @@ def relax_job(
     cclibSchema
         Dictionary of results, as specified in [quacc.schemas.cclib.summarize_run][]
     """
-
+    calc_swaps = calc_swaps or {}
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
@@ -195,7 +196,7 @@ def relax_job(
 
 
 def _base_job(
-    atoms: Atoms | dict,
+    atoms: Atoms,
     flags: dict | None = None,
     copy_files: list[str] | None = None,
     additional_fields: dict | None = None,
@@ -206,8 +207,7 @@ def _base_job(
     Parameters
     ----------
     atoms
-        Atoms object or a dictionary with the key "atoms" and an Atoms object as
-        the value
+        Atoms object
     flags
         Flags to use in the calculator.
     copy_files
@@ -220,12 +220,7 @@ def _base_job(
     cclibSchema
         Dictionary of results, as specified in [quacc.schemas.cclib.summarize_run][]
     """
-
-    atoms = fetch_atoms(atoms)
-    calc_swaps = calc_swaps or {}
     flags = flags or {}
-
-    flags = merge_dicts(flags, calc_swaps)
 
     atoms.calc = Gaussian(**flags)
     atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -98,7 +98,7 @@ def static_job(
         overwrite_inputs=overwrite_inputs,
         copy_files=copy_files,
         job_type="force",
-        additional_fields={"name": "Q-Chem Statix"},
+        additional_fields={"name": "Q-Chem Static"},
     )
 
 

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -221,7 +221,7 @@ def internal_relax_job(
     charge: int,
     spin_multiplicity: int,
     method: str = "wb97mv",
-    basis: str = "def2-tzvpd",
+    basis: str = "def2-svpd",
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
@@ -230,8 +230,7 @@ def internal_relax_job(
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
-    Perform a frequency calculation on a molecular structure using Q-Chem
-    optimizers.
+    Optimize aka "relax" a molecular structure with Q-Chem optimizers.
 
     Parameters
     ----------

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -421,6 +421,10 @@ def _base_job(
         See QChemDictSet documentation for more details.
     copy_files
         Files to copy to the runtime directory.
+    job_type
+        The job type accepeted by pymatgen.
+    additional_fields
+        The additional_fields parameters to inject into the summary.
 
     Returns
     -------

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -41,7 +41,7 @@ def static_job(
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
-    Perform a frequency calculation on a molecular structure.
+    Carry out a single-point calculation.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def static_job(
         DFT exchange-correlation functional or other electronic structure
         method. Defaults to wB97M-V.
     basis
-        Basis set. Defaults to def2-SVPD.
+        Basis set. Defaults to def2-TZVPD.
     scf_algorithm
         Algorithm used to converge the SCF. Defaults to "diis", but for
         particularly difficult cases, "gdm" should be employed instead.

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -14,6 +14,8 @@ from quacc.utils.calc import run_ase_opt, run_calc
 from quacc.utils.dicts import merge_dicts, remove_dict_empties
 
 try:
+    from typing import Literal
+
     from sella import Sella
 
     has_sella = True
@@ -379,7 +381,7 @@ def _base_job(
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     copy_files: list[str] | None = None,
-    job_type: str = "force",
+    job_type: Literal["opt", "sp", "freq", "force"] = "force",
     additional_fields: dict | None = None,
 ) -> RunSchema:
     """

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -213,7 +213,7 @@ def relax_job(
     return summarize_opt_run(
         dyn,
         charge_and_multiplicity=(charge, spin_multiplicity),
-        additional_fields={"name": "Q-Chem ASE Optimization"},
+        additional_fields={"name": "Q-Chem Optimization"},
     )
 
 
@@ -289,7 +289,7 @@ def internal_relax_job(
         overwrite_inputs=overwrite_inputs,
         copy_files=copy_files,
         job_type="opt",
-        additional_fields={"name": "Q-Chem Optimization"},
+        additional_fields={"name": "Q-Chem Optimization (Internal)"},
     )
 
 

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -41,7 +41,7 @@ def static_job(
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
-    Carry out a single-point calculation.
+    Perform a frequency calculation on a molecular structure.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def static_job(
         DFT exchange-correlation functional or other electronic structure
         method. Defaults to wB97M-V.
     basis
-        Basis set. Defaults to def2-TZVPD.
+        Basis set. Defaults to def2-SVPD.
     scf_algorithm
         Algorithm used to converge the SCF. Defaults to "diis", but for
         particularly difficult cases, "gdm" should be employed instead.
@@ -84,32 +84,21 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-    atoms = fetch_atoms(atoms)
 
-    qchem_defaults = {
-        "basis_set": basis,
-        "scf_algorithm": scf_algorithm,
-        "method": method,
-        "charge": charge,
-        "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
-        "qchem_input_params": {
-            "pcm_dielectric": pcm_dielectric,
-            "smd_solvent": smd_solvent,
-            "overwrite_inputs": overwrite_inputs,
-            "max_scf_cycles": 200 if scf_algorithm.lower() == "gdm" else None,
-        },
-    }
-    qchem_flags = remove_dict_empties(qchem_defaults)
-
-    atoms.calc = QChem(atoms, **qchem_flags)
-    final_atoms = run_calc(atoms, copy_files=copy_files)
-
-    return summarize_run(
-        final_atoms,
-        input_atoms=atoms,
-        charge_and_multiplicity=(charge, spin_multiplicity),
-        additional_fields={"name": "Q-Chem Static"},
+    return _base_job(
+        atoms,
+        charge,
+        spin_multiplicity,
+        method=method,
+        basis=basis,
+        scf_algorithm=scf_algorithm,
+        pcm_dielectric=pcm_dielectric,
+        smd_solvent=smd_solvent,
+        n_cores=n_cores,
+        overwrite_inputs=overwrite_inputs,
+        copy_files=copy_files,
+        job_type="force",
+        additional_fields={"name": "Q-Chem Statix"},
     )
 
 
@@ -129,7 +118,7 @@ def relax_job(
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
-    Optimize aka "relax" a molecular structure.
+    Optimize aka "relax" a molecular structure with an ASE optimizer.
 
     Parameters
     ----------
@@ -222,6 +211,83 @@ def relax_job(
     return summarize_opt_run(
         dyn,
         charge_and_multiplicity=(charge, spin_multiplicity),
+        additional_fields={"name": "Q-Chem ASE Optimization"},
+    )
+
+
+@job
+def internal_relax_job(
+    atoms: Atoms | dict,
+    charge: int,
+    spin_multiplicity: int,
+    method: str = "wb97mv",
+    basis: str = "def2-tzvpd",
+    scf_algorithm: str = "diis",
+    pcm_dielectric: str | None = None,
+    smd_solvent: str | None = None,
+    n_cores: int | None = None,
+    overwrite_inputs: dict | None = None,
+    copy_files: list[str] | None = None,
+) -> RunSchema:
+    """
+    Perform a frequency calculation on a molecular structure using Q-Chem
+    optimizers.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object or a dictionary with the key "atoms" and an Atoms object as
+        the value
+    charge
+        Charge of the system.
+    spin_multiplicity
+        Multiplicity of the system.
+    method
+        DFT exchange-correlation functional or other electronic structure
+        method. Defaults to wB97M-V.
+    basis
+        Basis set. Defaults to def2-SVPD.
+    scf_algorithm
+        Algorithm used to converge the SCF. Defaults to "diis", but for
+        particularly difficult cases, "gdm" should be employed instead.
+    pcm_dielectric
+        Dielectric constant of the optional polarizable continuum impicit
+        solvation model. Defaults to None, in which case PCM will not be
+        employed.
+    smd_solvent
+        Solvent to use for SMD implicit solvation model. Examples include
+        "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
+        manual for a complete list of solvents available. Defaults to None, in
+        which case SMD will not be employed.
+    n_cores
+        Number of cores to use for the Q-Chem calculation. Defaults to use all
+        cores available on a given node.
+    overwrite_inputs
+        Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
+        default values set therein as well as set additional Q-Chem parameters.
+        See QChemDictSet documentation for more details.
+    copy_files
+        Files to copy to the runtime directory.
+
+    Returns
+    -------
+    RunSchema
+        Dictionary of results from [quacc.schemas.ase.summarize_run][]
+    """
+
+    return _base_job(
+        atoms,
+        charge,
+        spin_multiplicity,
+        method=method,
+        basis=basis,
+        scf_algorithm=scf_algorithm,
+        pcm_dielectric=pcm_dielectric,
+        smd_solvent=smd_solvent,
+        n_cores=n_cores,
+        overwrite_inputs=overwrite_inputs,
+        copy_files=copy_files,
+        job_type="opt",
         additional_fields={"name": "Q-Chem Optimization"},
     )
 
@@ -285,10 +351,86 @@ def freq_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
 
+    return _base_job(
+        atoms,
+        charge,
+        spin_multiplicity,
+        method=method,
+        basis=basis,
+        scf_algorithm=scf_algorithm,
+        pcm_dielectric=pcm_dielectric,
+        smd_solvent=smd_solvent,
+        n_cores=n_cores,
+        overwrite_inputs=overwrite_inputs,
+        copy_files=copy_files,
+        job_type="freq",
+        additional_fields={"name": "Q-Chem Frequency"},
+    )
+
+
+def _base_job(
+    atoms: Atoms | dict,
+    charge: int,
+    spin_multiplicity: int,
+    method: str = "wb97mv",
+    basis: str = "def2-tzvpd",
+    scf_algorithm: str = "diis",
+    pcm_dielectric: str | None = None,
+    smd_solvent: str | None = None,
+    n_cores: int | None = None,
+    overwrite_inputs: dict | None = None,
+    copy_files: list[str] | None = None,
+    job_type: str = "force",
+    additional_fields: dict | None = None,
+) -> RunSchema:
+    """
+    Carry out a single-point calculation.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object or a dictionary with the key "atoms" and an Atoms object as
+        the value
+    charge
+        Charge of the system.
+    spin_multiplicity
+        Multiplicity of the system.
+    method
+        DFT exchange-correlation functional or other electronic structure
+        method. Defaults to wB97M-V.
+    basis
+        Basis set. Defaults to def2-TZVPD.
+    scf_algorithm
+        Algorithm used to converge the SCF. Defaults to "diis", but for
+        particularly difficult cases, "gdm" should be employed instead.
+    pcm_dielectric
+        Dielectric constant of the optional polarizable continuum impicit
+        solvation model. Defaults to None, in which case PCM will not be
+        employed.
+    smd_solvent
+        Solvent to use for SMD implicit solvation model. Examples include
+        "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
+        manual for a complete list of solvents available. Defaults to None, in
+        which case SMD will not be employed.
+    n_cores
+        Number of cores to use for the Q-Chem calculation. Defaults to use all
+        cores available on a given node.
+    overwrite_inputs
+        Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
+        default values set therein as well as set additional Q-Chem parameters.
+        See QChemDictSet documentation for more details.
+    copy_files
+        Files to copy to the runtime directory.
+
+    Returns
+    -------
+    RunSchema
+        Dictionary of results from [quacc.schemas.ase.summarize_run][]
+    """
     atoms = fetch_atoms(atoms)
 
     qchem_defaults = {
-        "job_type": "freq",
+        "job_type": job_type,
         "basis_set": basis,
         "scf_algorithm": scf_algorithm,
         "method": method,
@@ -311,5 +453,5 @@ def freq_job(
         final_atoms,
         input_atoms=atoms,
         charge_and_multiplicity=(charge, spin_multiplicity),
-        additional_fields={"name": "Q-Chem Frequency"},
+        additional_fields=additional_fields,
     )

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -384,7 +384,8 @@ def _base_job(
     additional_fields: dict | None = None,
 ) -> RunSchema:
     """
-    Carry out a single-point calculation.
+    A commonly used base job for various Q-Chem calculations not relying on
+    ASE optimizers.
 
     Parameters
     ----------

--- a/tests/recipes/qchem/test_qchem_recipes.py
+++ b/tests/recipes/qchem/test_qchem_recipes.py
@@ -213,7 +213,7 @@ def test_internal_relax_job(monkeypatch, tmpdir):
     assert output["results"]["energy"] == pytest.approx(-606.1616819641 * units.Hartree)
     assert output["results"]["forces"][0][0] == pytest.approx(-1.3826330655069403)
 
-    qcin = QCInput.from_file("mol.qin.gz")
+    qcin = QCInput.from_file("mol.qin.gz").as_dict()
     assert qcin["basis"] == "def2-svpd"
     assert qcin["geom_opt_max_cycles"] == "200"
     assert qcin["job_type"] == "opt"

--- a/tests/recipes/qchem/test_qchem_recipes.py
+++ b/tests/recipes/qchem/test_qchem_recipes.py
@@ -214,9 +214,9 @@ def test_internal_relax_job(monkeypatch, tmpdir):
     assert output["results"]["forces"][0][0] == pytest.approx(-1.3826330655069403)
 
     qcin = QCInput.from_file("mol.qin.gz").as_dict()
-    assert qcin["basis"] == "def2-svpd"
-    assert qcin["geom_opt_max_cycles"] == "200"
-    assert qcin["job_type"] == "opt"
+    assert qcin["rem"]["basis"] == "def2-svpd"
+    assert qcin["rem"]["geom_opt_max_cycles"] == "200"
+    assert qcin["rem"]["job_type"] == "opt"
 
 
 @pytest.mark.skipif(

--- a/tests/recipes/qchem/test_qchem_recipes.py
+++ b/tests/recipes/qchem/test_qchem_recipes.py
@@ -13,7 +13,7 @@ from pymatgen.io.qchem.inputs import QCInput
 
 from quacc import SETTINGS
 from quacc.calculators.qchem import QChem
-from quacc.recipes.qchem.core import freq_job, relax_job, static_job
+from quacc.recipes.qchem.core import freq_job, internal_relax_job, relax_job, static_job
 from quacc.recipes.qchem.ts import irc_job, quasi_irc_job, ts_job
 from quacc.utils import check_charge_and_spin
 
@@ -195,6 +195,27 @@ def test_static_job_v5(tmpdir):
 
     with pytest.raises(ValueError):
         static_job(TEST_ATOMS, 0, 1, pcm_dielectric="3.0", smd_solvent="water")
+
+
+def test_internal_relax_job(monkeypatch, tmpdir):
+    tmpdir.chdir()
+
+    monkeypatch.setattr(FileIOCalculator, "execute", mock_execute1)
+    charge, spin_multiplicity = check_charge_and_spin(TEST_ATOMS)
+    output = internal_relax_job(TEST_ATOMS, charge, spin_multiplicity)
+    assert output["atoms"] == TEST_ATOMS
+    assert output["charge"] == 0
+    assert output["spin_multiplicity"] == 1
+    assert output["formula_alphabetical"] == "C4 H4 O6"
+    assert output["nelectrons"] == 76
+    assert output["parameters"]["charge"] == 0
+    assert output["parameters"]["spin_multiplicity"] == 1
+    assert output["results"]["energy"] == pytest.approx(-606.1616819641 * units.Hartree)
+    assert output["results"]["forces"][0][0] == pytest.approx(-1.3826330655069403)
+
+    qcin = QCInput.from_file("mol.qin.gz")
+    ref_qcin = QCInput.from_file(os.path.join(QCHEM_DIR, "mol.qin.basic"))
+    qcinput_nearly_equal(qcin, ref_qcin)
 
 
 @pytest.mark.skipif(

--- a/tests/recipes/qchem/test_qchem_recipes.py
+++ b/tests/recipes/qchem/test_qchem_recipes.py
@@ -214,8 +214,8 @@ def test_internal_relax_job(monkeypatch, tmpdir):
     assert output["results"]["forces"][0][0] == pytest.approx(-1.3826330655069403)
 
     qcin = QCInput.from_file("mol.qin.gz")
-    ref_qcin = QCInput.from_file(os.path.join(QCHEM_DIR, "mol.qin.basic"))
-    qcinput_nearly_equal(qcin, ref_qcin)
+    assert qcin["basis"] == "def2-svpd"
+    assert qcin["geom_opt_max_cycles"] == "200"
 
 
 @pytest.mark.skipif(

--- a/tests/recipes/qchem/test_qchem_recipes.py
+++ b/tests/recipes/qchem/test_qchem_recipes.py
@@ -216,6 +216,7 @@ def test_internal_relax_job(monkeypatch, tmpdir):
     qcin = QCInput.from_file("mol.qin.gz")
     assert qcin["basis"] == "def2-svpd"
     assert qcin["geom_opt_max_cycles"] == "200"
+    assert qcin["job_type"] == "opt"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
@samblau: I refactored the Q-Chem recipes since the `static_job` and `freq_job` were nearly identical, with the exception of the `job_type`, `additional_fields`, and the basis set kwarg. They now both operate from a common base function to minimize code duplication.

I also added `qchem_internal_relax_job` that does a geom opt using Q-Chem's optimizers. Obviously we think this is going to be less efficient than Sella, but since it was so trivial to add, I included it.