### PR TITLE
Allow for `~`-based paths in `RESULTS_DIR` and `SCRATCH_DIR`, and don't make a symlink if not necessary

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,6 @@ jobs:
         run: |
           pip install -r tests/requirements.txt
           pip install .[dev]
-          pip install sella
 
       - name: Run tests with pytest
         run: pytest --cov=quacc --cov-report=xml
@@ -228,7 +227,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.11"]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,7 @@ jobs:
         run: |
           pip install -r tests/requirements.txt
           pip install .[dev]
+          pip install sella
 
       - name: Run tests with pytest
         run: pytest --cov=quacc --cov-report=xml
@@ -227,7 +228,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.11"]
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     defaults:
       run:

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -18,7 +18,7 @@ for wflow_engine in ["covalent", "parsl", "prefect", "redun", "jobflow"]:
     except ImportError:
         continue
 
-_DEFAULT_CONFIG_FILE_PATH = Path("~", ".quacc.yaml").expanduser()
+_DEFAULT_CONFIG_FILE_PATH = Path("~", ".quacc.yaml").expanduser().resolve()
 
 
 class QuaccSettings(BaseSettings):
@@ -256,7 +256,7 @@ class QuaccSettings(BaseSettings):
 
     @validator("CONFIG_FILE", "RESULTS_DIR", "SCRATCH_DIR")
     def validate_paths(cls, v):
-        return Path(v).expanduser()
+        return Path(v).expanduser().resolve()
 
     class Config:
         """Pydantic config settings."""
@@ -282,9 +282,11 @@ class QuaccSettings(BaseSettings):
 
         from monty.serialization import loadfn
 
-        config_file_path = Path(
-            values.get("CONFIG_FILE", _DEFAULT_CONFIG_FILE_PATH)
-        ).expanduser()
+        config_file_path = (
+            Path(values.get("CONFIG_FILE", _DEFAULT_CONFIG_FILE_PATH))
+            .expanduser()
+            .resolve()
+        )
 
         new_values = {}  # type: dict
         if config_file_path.exists() and config_file_path.stat().st_size > 0:

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from shutil import which
 from typing import List, Optional, Union
 
-from pydantic import BaseSettings, Field, root_validator
+from pydantic import BaseSettings, Field, root_validator, validator
 
 from quacc.presets import vasp as vasp_defaults
 
@@ -253,6 +253,10 @@ class QuaccSettings(BaseSettings):
     )
 
     # --8<-- [end:settings]
+
+    @validator("CONFIG_FILE", "RESULTS_DIR", "SCRATCH_DIR")
+    def validate_paths(cls, v):
+        return Path(v).expanduser()
 
     class Config:
         """Pydantic config settings."""

--- a/src/quacc/utils/calc.py
+++ b/src/quacc/utils/calc.py
@@ -268,7 +268,7 @@ def _calc_setup(
     tmpdir = Path(mkdtemp(prefix="quacc-tmp-", dir=SETTINGS.SCRATCH_DIR)).resolve()
 
     # Create a symlink to the tmpdir in the results_dir
-    if SETTINGS.SCRATCH_DIR != SETTINGS.RESULTS_DIR:
+    if os.name != "nt" and SETTINGS.SCRATCH_DIR != SETTINGS.RESULTS_DIR:
         symlink = Path(job_results_dir, f"{tmpdir.name}-symlink")
         symlink.unlink(missing_ok=True)
         symlink.symlink_to(tmpdir, target_is_directory=True)

--- a/src/quacc/utils/calc.py
+++ b/src/quacc/utils/calc.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from ase.filters import ExpCellFilter
-from ase.io import read
+from ase.io import Trajectory, read
 from ase.optimize import FIRE
 from ase.vibrations import Vibrations
 from monty.dev import requires
@@ -157,14 +157,16 @@ def run_ase_opt(
     optimizer_kwargs.pop("use_TRICs", None)
 
     # Define the Trajectory object
-    traj_filename = str(Path(tmpdir, "opt.traj"))
+    traj_filename = Path(tmpdir, "opt.traj")
+    traj = Trajectory(traj_filename, "w", atoms=atoms)
+    optimizer_kwargs["trajectory"] = traj
 
     # Set volume relaxation constraints, if relevant
     if relax_cell and atoms.pbc.any():
         atoms = ExpCellFilter(atoms)
 
     # Run calculation
-    with optimizer(atoms, trajectory=traj_filename, **optimizer_kwargs) as dyn:
+    with traj, optimizer(atoms, **optimizer_kwargs) as dyn:
         dyn.run(fmax=fmax, steps=max_steps, **run_kwargs)
 
     # Store the trajectory atoms

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 from ase.build import bulk
@@ -65,7 +66,7 @@ def test_results_dir(tmpdir):
 
 def test_env_var(monkeypatch):
     monkeypatch.setenv("QUACC_SCRATCH_DIR", "/my/scratch/dir")
-    assert QuaccSettings().SCRATCH_DIR == "/my/scratch/dir"
+    assert QuaccSettings().SCRATCH_DIR == Path("/my/scratch/dir")
 
 
 def test_yaml(tmpdir, monkeypatch):
@@ -74,4 +75,4 @@ def test_yaml(tmpdir, monkeypatch):
     with open("quacc_test.yaml", "w") as f:
         f.write('SCRATCH_DIR: "/my/new/scratch/dir"')
     monkeypatch.setenv("QUACC_CONFIG_FILE", "quacc_test.yaml")
-    assert QuaccSettings().SCRATCH_DIR == "/my/new/scratch/dir"
+    assert QuaccSettings().SCRATCH_DIR == Path("/my/new/scratch/dir")

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -66,7 +66,7 @@ def test_results_dir(tmpdir):
 
 def test_env_var(monkeypatch):
     monkeypatch.setenv("QUACC_SCRATCH_DIR", "/my/scratch/dir")
-    assert QuaccSettings().SCRATCH_DIR == Path("/my/scratch/dir")
+    assert QuaccSettings().SCRATCH_DIR == Path("/my/scratch/dir").resolve()
 
 
 def test_yaml(tmpdir, monkeypatch):
@@ -75,4 +75,4 @@ def test_yaml(tmpdir, monkeypatch):
     with open("quacc_test.yaml", "w") as f:
         f.write('SCRATCH_DIR: "/my/new/scratch/dir"')
     monkeypatch.setenv("QUACC_CONFIG_FILE", "quacc_test.yaml")
-    assert QuaccSettings().SCRATCH_DIR == Path("/my/new/scratch/dir")
+    assert QuaccSettings().SCRATCH_DIR == Path("/my/new/scratch/dir").resolve()


### PR DESCRIPTION
Fixes:
- Allows for proper setting of `~/`-based paths for `RESULTS_DIR` and `SCRATCH_DIR`
- Doesn't create a redundant symlink file when `RESULTS_DIR == SCRATCH_DIR`.