### PR TITLE
Add an `additional_fields` kwarg to all jobs

### DIFF
--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -28,6 +28,7 @@ def static_job(
     method: Literal["GFN1-xTB", "GFN2-xTB", "DFTB"] = "GFN2-xTB",
     kpts: tuple | list[tuple] | dict | None = None,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -56,6 +57,8 @@ def static_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Any additional fields to store in the resulting task document.
     copy_files
         Files to copy to the runtime directory.
 
@@ -64,7 +67,7 @@ def static_job(
     RunSchema
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
@@ -75,7 +78,7 @@ def static_job(
         atoms,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "DFTB+ Static"},
+        additional_fields={"name": "DFTB+ Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -93,6 +96,7 @@ def relax_job(
     kpts: tuple | list[tuple] | dict | None = None,
     relax_cell: bool = False,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -128,6 +132,8 @@ def relax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Any additional fields to store in the resulting task document.
     copy_files
         Files to copy to the runtime directory.
 
@@ -137,6 +143,7 @@ def relax_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
 
+    additional_fields = additional_fields or {}
     defaults = {
         "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
         "Hamiltonian_Method": method if "xtb" in method.lower() else None,
@@ -151,7 +158,7 @@ def relax_job(
         atoms,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "DFTB+ Relax"},
+        additional_fields={"name": "DFTB+ Relax"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -44,6 +45,8 @@ def static_job(
         Atoms object
     calc_swaps
         Dictionary of custom kwargs for the EMT calculator.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -53,6 +56,7 @@ def static_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
     calc_swaps = calc_swaps or {}
+    additional_fields = additional_fields or {}
 
     atoms.calc = EMT(**calc_swaps)
     final_atoms = run_calc(atoms, copy_files=copy_files)
@@ -60,7 +64,7 @@ def static_job(
     return summarize_run(
         final_atoms,
         input_atoms=atoms,
-        additional_fields={"name": "EMT Static"},
+        additional_fields={"name": "EMT Static"} | additional_fields,
     )
 
 
@@ -70,6 +74,7 @@ def relax_job(
     relax_cell: bool = False,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -100,6 +105,8 @@ def relax_job(
         following defaults: `{}`
     opt_swaps
         Dictionary of swaps for [quacc.runners.calc.run_ase_opt][].
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -109,6 +116,7 @@ def relax_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_opt_run][]
     """
     calc_swaps = calc_swaps or {}
+    additional_fields = additional_fields or {}
 
     opt_defaults = {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
     opt_flags = merge_dicts(opt_defaults, opt_swaps)
@@ -117,4 +125,6 @@ def relax_job(
 
     dyn = run_ase_opt(atoms, relax_cell=relax_cell, copy_files=copy_files, **opt_flags)
 
-    return summarize_opt_run(dyn, additional_fields={"name": "EMT Relax"})
+    return summarize_opt_run(
+        dyn, additional_fields={"name": "EMT Relax"} | additional_fields
+    )

--- a/src/quacc/recipes/emt/defects.py
+++ b/src/quacc/recipes/emt/defects.py
@@ -38,6 +38,7 @@ def bulk_to_defects_flow(
     run_static: bool = True,
     defect_relax_kwargs: dict | None = None,
     defect_static_kwargs: dict | None = None,
+    additional_fields: dict | None = None,
 ) -> list[RunSchema | OptSchema]:
     """
     Workflow consisting of:
@@ -64,6 +65,9 @@ def bulk_to_defects_flow(
         Additional keyword arguments to pass to the relaxation calculation.
     defect_static_kwargs
         Additional keyword arguments to pass to the static calculation.
+    additional_fields
+        Additional fields to add to the result dictionary. Adds to all jobs in the
+        flow.
 
     Returns
     -------

--- a/src/quacc/recipes/emt/defects.py
+++ b/src/quacc/recipes/emt/defects.py
@@ -38,7 +38,6 @@ def bulk_to_defects_flow(
     run_static: bool = True,
     defect_relax_kwargs: dict | None = None,
     defect_static_kwargs: dict | None = None,
-    additional_fields: dict | None = None,
 ) -> list[RunSchema | OptSchema]:
     """
     Workflow consisting of:
@@ -65,9 +64,6 @@ def bulk_to_defects_flow(
         Additional keyword arguments to pass to the relaxation calculation.
     defect_static_kwargs
         Additional keyword arguments to pass to the static calculation.
-    additional_fields
-        Additional fields to add to the result dictionary. Adds to all jobs in the
-        flow.
 
     Returns
     -------

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -29,6 +29,7 @@ def static_job(
     xc: str = "wb97x-d",
     basis: str = "def2-tzvp",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> cclibSchema:
     """
@@ -72,6 +73,8 @@ def static_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -80,7 +83,7 @@ def static_job(
     cclibSchema
         Dictionary of results, as specified in [quacc.schemas.cclib.cclib_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
@@ -101,7 +104,7 @@ def static_job(
         atoms,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "Gaussian Static"},
+        additional_fields={"name": "Gaussian Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -115,6 +118,7 @@ def relax_job(
     basis: str = "def2-tzvp",
     freq: bool = False,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> cclibSchema:
     """
@@ -160,6 +164,8 @@ def relax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -168,7 +174,7 @@ def relax_job(
     cclibSchema
         Dictionary of results, as specified in [quacc.schemas.cclib.cclib_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "mem": "16GB",
         "chk": "Gaussian.chk",
@@ -189,7 +195,7 @@ def relax_job(
         atoms,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "Gaussian Relax"},
+        additional_fields={"name": "Gaussian Relax"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/gulp/core.py
+++ b/src/quacc/recipes/gulp/core.py
@@ -31,6 +31,7 @@ def static_job(
     library: str | None = None,
     keyword_swaps: dict | None = None,
     option_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -77,7 +78,7 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     keyword_defaults = {
         "gfnff": True if use_gfnff else None,
         "gwolf": True if use_gfnff else None,
@@ -91,7 +92,7 @@ def static_job(
         option_defaults=option_defaults,
         keyword_swaps=keyword_swaps,
         option_swaps=option_swaps,
-        additional_fields={"name": "GULP Static"},
+        additional_fields={"name": "GULP Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -104,6 +105,7 @@ def relax_job(
     relax_cell: bool = False,
     keyword_swaps: dict | None = None,
     option_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -147,6 +149,8 @@ def relax_job(
         Dictionary of custom keyword swap kwargs for the calculator.
     option_swaps
         Dictionary of custom option swap kwargs for the calculator.
+    additional_fields
+        Additional field to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -155,7 +159,7 @@ def relax_job(
     dict
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     keyword_defaults = {
         "opti": True,
         "gfnff": True if use_gfnff else None,
@@ -172,7 +176,7 @@ def relax_job(
         option_defaults=option_defaults,
         keyword_swaps=keyword_swaps,
         option_swaps=option_swaps,
-        additional_fields={"name": "GULP Relax"},
+        additional_fields={"name": "GULP Relax"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -45,6 +46,8 @@ def static_job(
         Atoms object
     calc_swaps
         Dictionary of custom kwargs for the LJ calculator.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -54,12 +57,15 @@ def static_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
     calc_swaps = calc_swaps or {}
+    additional_fields = additional_fields or {}
 
     atoms.calc = LennardJones(**calc_swaps)
     final_atoms = run_calc(atoms, copy_files=copy_files)
 
     return summarize_run(
-        final_atoms, input_atoms=atoms, additional_fields={"name": "LJ Static"}
+        final_atoms,
+        input_atoms=atoms,
+        additional_fields={"name": "LJ Static"} | additional_fields,
     )
 
 
@@ -68,6 +74,7 @@ def relax_job(
     atoms: Atoms,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -95,6 +102,8 @@ def relax_job(
         Dictionary of custom kwargs for the LJ calculator.
     opt_swaps
         Dictionary of swaps for [quacc.runners.calc.run_ase_opt][].
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -104,6 +113,7 @@ def relax_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
     calc_swaps = calc_swaps or {}
+    additional_fields = additional_fields or {}
 
     opt_defaults = {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
     opt_flags = merge_dicts(opt_defaults, opt_swaps)
@@ -111,7 +121,9 @@ def relax_job(
     atoms.calc = LennardJones(**calc_swaps)
     dyn = run_ase_opt(atoms, copy_files=copy_files, **opt_flags)
 
-    return summarize_opt_run(dyn, additional_fields={"name": "LJ Relax"})
+    return summarize_opt_run(
+        dyn, additional_fields={"name": "LJ Relax"} | additional_fields
+    )
 
 
 @job
@@ -122,6 +134,7 @@ def freq_job(
     pressure: float = 1.0,
     calc_swaps: dict | None = None,
     vib_kwargs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VibThermoSchema:
     """
@@ -155,6 +168,8 @@ def freq_job(
         dictionary of custom kwargs for the LJ calculator.
     vib_kwargs
         dictionary of custom kwargs for the Vibrations object.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -165,6 +180,7 @@ def freq_job(
     """
     calc_swaps = calc_swaps or {}
     vib_kwargs = vib_kwargs or {}
+    additional_fields = additional_fields or {}
 
     atoms.calc = LennardJones(**calc_swaps)
     vibrations = run_ase_vib(atoms, vib_kwargs=vib_kwargs, copy_files=copy_files)
@@ -175,5 +191,5 @@ def freq_job(
         igt,
         temperature=temperature,
         pressure=pressure,
-        additional_fields={"name": "LJ Frequency and Thermo"},
+        additional_fields={"name": "LJ Frequency and Thermo"} | additional_fields,
     )

--- a/src/quacc/recipes/newtonnet/core.py
+++ b/src/quacc/recipes/newtonnet/core.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -67,6 +68,8 @@ def static_job(
         Atoms object
     calc_swaps
         Dictionary of custom kwargs for the newtonnet calculator.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -76,6 +79,7 @@ def static_job(
         Dictionary of results, specified in [quacc.schemas.ase.summarize_run][]
     """
 
+    additional_fields = additional_fields or {}
     defaults = {
         "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
         "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
@@ -88,7 +92,7 @@ def static_job(
     return summarize_run(
         final_atoms,
         input_atoms=atoms,
-        additional_fields={"name": "NewtonNet Static"},
+        additional_fields={"name": "NewtonNet Static"} | additional_fields,
     )
 
 
@@ -98,6 +102,7 @@ def relax_job(
     atoms: Atoms,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -128,6 +133,8 @@ def relax_job(
         Dictionary of custom kwargs for the newtonnet calculator.
     opt_swaps
         Optional swaps for the optimization parameters.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -136,7 +143,7 @@ def relax_job(
     OptSchema
         Dictionary of results, specified in [quacc.schemas.ase.summarize_opt_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
         "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
@@ -150,7 +157,9 @@ def relax_job(
     dyn = run_ase_opt(atoms, copy_files=copy_files, **opt_flags)
 
     return _add_stdev_and_hess(
-        summarize_opt_run(dyn, additional_fields={"name": "NewtonNet Relax"})
+        summarize_opt_run(
+            dyn, additional_fields={"name": "NewtonNet Relax"} | additional_fields
+        )
     )
 
 
@@ -161,6 +170,7 @@ def freq_job(
     temperature: float = 298.15,
     pressure: float = 1.0,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> FreqSchema:
     """
@@ -187,6 +197,8 @@ def freq_job(
         The pressure for the thermodynamic analysis.
     calc_swaps
         Optional swaps for the calculator.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -195,7 +207,7 @@ def freq_job(
     FreqSchema
         Dictionary of results
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
         "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
@@ -227,7 +239,7 @@ def freq_job(
         additional_fields={"name": "ASE Thermo Analysis"},
     )
 
-    return summary
+    return summary | additional_fields
 
 
 def _add_stdev_and_hess(summary: dict) -> dict:

--- a/src/quacc/recipes/newtonnet/ts.py
+++ b/src/quacc/recipes/newtonnet/ts.py
@@ -53,6 +53,7 @@ def ts_job(
     freq_job_kwargs: dict | None = None,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> TSSchema:
     """
@@ -96,6 +97,8 @@ def ts_job(
         Optional swaps for the NewtonNet calculator.
     opt_swaps
         Optional swaps for the optimization parameters.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -105,6 +108,7 @@ def ts_job(
         Dictionary of results
     """
     freq_job_kwargs = freq_job_kwargs or {}
+    additional_fields = additional_fields or {}
 
     defaults = {
         "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
@@ -144,7 +148,7 @@ def ts_job(
     )
     opt_ts_summary["freq_job"] = freq_summary
 
-    return opt_ts_summary
+    return opt_ts_summary | additional_fields
 
 
 @job
@@ -157,6 +161,7 @@ def irc_job(
     freq_job_kwargs: dict | None = None,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> IRCSchema:
     """
@@ -213,6 +218,8 @@ def irc_job(
         Optional swaps for the calculator.
     opt_swaps
         Optional swaps for the optimization parameters.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -222,6 +229,7 @@ def irc_job(
         A dictionary containing the IRC summary and thermodynamic summary.
     """
     freq_job_kwargs = freq_job_kwargs or {}
+    additional_fields = additional_fields or {}
     default_settings = SETTINGS.copy()
 
     defaults = {
@@ -254,7 +262,8 @@ def irc_job(
     dyn = run_ase_opt(atoms, copy_files=copy_files, **opt_flags)
     opt_irc_summary = _add_stdev_and_hess(
         summarize_opt_run(
-            dyn, additional_fields={"name": f"NewtonNet IRC: {direction}"}
+            dyn,
+            additional_fields={"name": f"NewtonNet IRC: {direction}"},
         )
     )
     SETTINGS.CHECK_CONVERGENCE = default_settings.CHECK_CONVERGENCE
@@ -267,7 +276,7 @@ def irc_job(
     )
     opt_irc_summary["freq_job"] = freq_summary
 
-    return opt_irc_summary
+    return opt_irc_summary | additional_fields
 
 
 @job
@@ -280,6 +289,7 @@ def quasi_irc_job(
     irc_job_kwargs: dict | None = None,
     relax_job_kwargs: dict | None = None,
     freq_job_kwargs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> QuasiIRCSchema:
     """
@@ -313,6 +323,8 @@ def quasi_irc_job(
         Keyword arguments for `relax_job`
     freq_job_kwargs
         Keyword arguments for `freq_job`.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -324,6 +336,7 @@ def quasi_irc_job(
     """
     relax_job_kwargs = relax_job_kwargs or {}
     freq_job_kwargs = freq_job_kwargs or {}
+    additional_fields = additional_fields or {}
 
     irc_job_defaults = {"calc_swaps": {"max_steps": 5}}
     irc_job_kwargs = merge_dicts(irc_job_defaults, irc_job_kwargs)
@@ -349,7 +362,7 @@ def quasi_irc_job(
     relax_summary["freq_job"] = freq_summary
     relax_summary["irc_job"] = irc_summary
 
-    return relax_summary
+    return relax_summary | additional_fields
 
 
 def _get_hessian(atoms: Atoms) -> NDArray:

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -31,6 +31,7 @@ def static_job(
     basis: str = "def2-tzvp",
     input_swaps: dict | None = None,
     block_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> cclibSchema:
     """
@@ -81,6 +82,8 @@ def static_job(
         Dictionary of orcablock swaps for the calculator. To enable new entries,
         set the value as True. To remove entries from the defaults, set the
         value as None.
+    additional_fields
+        Any additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -89,7 +92,7 @@ def static_job(
     cclibSchema
         Dictionary of results from [quacc.schemas.cclib.cclib_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     default_inputs = {
         xc: True,
         basis: True,
@@ -112,7 +115,7 @@ def static_job(
         default_blocks=default_blocks,
         input_swaps=input_swaps,
         block_swaps=block_swaps,
-        additional_fields={"name": "ORCA Static"},
+        additional_fields={"name": "ORCA Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -127,6 +130,7 @@ def relax_job(
     run_freq: bool = False,
     input_swaps: dict | None = None,
     block_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> cclibSchema:
     """
@@ -180,6 +184,8 @@ def relax_job(
         Dictionary of orcablock swaps for the calculator. To enable new entries,
         set the value as True. To remove entries from the defaults, set the
         value as None.
+    additional_fields
+        Any additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -212,7 +218,7 @@ def relax_job(
         default_blocks=default_blocks,
         input_swaps=input_swaps,
         block_swaps=block_swaps,
-        additional_fields={"name": "ORCA Relax"},
+        additional_fields={"name": "ORCA Relax"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -194,7 +194,7 @@ def relax_job(
     cclibSchema
         Dictionary of results from [quacc.schemas.cclib.cclib_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     default_inputs = {
         xc: True,
         basis: True,

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -31,6 +31,7 @@ def static_job(
     method: str = "wb97x-v",
     basis: str = "def2-tzvp",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -67,6 +68,8 @@ def static_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Any additional fields to store in the resulting task document.
     copy_files
         Files to copy to the runtime directory.
 
@@ -75,7 +78,7 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "mem": "16GB",
         "num_threads": "max",
@@ -91,7 +94,7 @@ def static_job(
         spin_multiplicity,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "Psi4 Static"},
+        additional_fields={"name": "Psi4 Static"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -37,6 +37,7 @@ def static_job(
     smd_solvent: str | None = None,
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -96,6 +97,8 @@ def static_job(
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
         See QChemDictSet documentation for more details.
+    additional_fields
+        Any additional fields to set in the summary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -104,6 +107,7 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
+    additional_fields = additional_fields or {}
     defaults = {
         "basis_set": basis,
         "scf_algorithm": scf_algorithm,
@@ -125,7 +129,7 @@ def static_job(
         charge,
         spin_multiplicity,
         defaults=defaults,
-        additional_fields={"name": "Q-Chem Static"},
+        additional_fields={"name": "Q-Chem Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -142,6 +146,7 @@ def internal_relax_job(
     smd_solvent: str | None = None,
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -201,6 +206,8 @@ def internal_relax_job(
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
         See QChemDictSet documentation for more details.
+    additional_fields
+        Any additional fields to set in the summary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -230,7 +237,8 @@ def internal_relax_job(
         charge,
         spin_multiplicity,
         defaults=defaults,
-        additional_fields={"name": "Q-Chem Optimization (Internal)"},
+        additional_fields={"name": "Q-Chem Optimization (Internal)"}
+        | additional_fields,
         copy_files=copy_files,
     )
 
@@ -247,6 +255,7 @@ def freq_job(
     smd_solvent: str | None = None,
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -314,7 +323,7 @@ def freq_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "job_type": "freq",
         "basis_set": basis,
@@ -336,7 +345,7 @@ def freq_job(
         spin_multiplicity,
         defaults=defaults,
         copy_files=copy_files,
-        additional_fields={"name": "Q-Chem Frequency"},
+        additional_fields={"name": "Q-Chem Frequency"} | additional_fields,
     )
 
 
@@ -353,6 +362,7 @@ def relax_job(
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -419,6 +429,8 @@ def relax_job(
         See QChemDictSet documentation for more details.
     opt_swaps
         Dictionary of custom kwargs for [quacc.runners.calc.run_ase_opt][]
+    additional_fields
+        Any additional fields to set in the summary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -427,7 +439,7 @@ def relax_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.summarize_opt_run][]
     """
-
+    additional_fields = additional_fields or {}
     qchem_defaults = {
         "basis_set": basis,
         "scf_algorithm": scf_algorithm,
@@ -456,7 +468,7 @@ def relax_job(
         qchem_defaults=qchem_defaults,
         opt_defaults=opt_defaults,
         opt_swaps=opt_swaps,
-        additional_fields={"name": "Q-Chem Optimization"},
+        additional_fields={"name": "Q-Chem Optimization"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -216,7 +216,7 @@ def internal_relax_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "job_type": "opt",
         "basis_set": basis,

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -42,6 +42,7 @@ def ts_job(
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -108,6 +109,8 @@ def ts_job(
         See QChemDictSet documentation for more details.
     opt_swaps
         Dictionary of custom kwargs for [quacc.runners.calc.run_ase_opt][]
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -116,7 +119,7 @@ def ts_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.summarize_opt_run][]
     """
-
+    additional_fields = additional_fields or {}
     qchem_defaults = {
         "basis_set": basis,
         "scf_algorithm": scf_algorithm,
@@ -148,7 +151,7 @@ def ts_job(
         qchem_defaults=qchem_defaults,
         opt_defaults=opt_defaults,
         opt_swaps=opt_swaps,
-        additional_fields={"name": "Q-Chem TS"},
+        additional_fields={"name": "Q-Chem TS"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -171,6 +174,7 @@ def irc_job(
     n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -239,6 +243,8 @@ def irc_job(
         See QChemDictSet documentation for more details.
     opt_swaps
         Dictionary of custom kwargs for [quacc.runners.calc.run_ase_opt][]
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -247,7 +253,7 @@ def irc_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.summarize_opt_run][]
     """
-
+    additional_fields = additional_fields or {}
     qchem_defaults = {
         "basis_set": basis,
         "scf_algorithm": scf_algorithm,
@@ -279,7 +285,7 @@ def irc_job(
         qchem_defaults=qchem_defaults,
         opt_defaults=opt_defaults,
         opt_swaps=opt_swaps,
-        additional_fields={"name": "Q-Chem IRC"},
+        additional_fields={"name": "Q-Chem IRC"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -303,6 +309,7 @@ def quasi_irc_job(
     overwrite_inputs: dict | None = None,
     irc_opt_swaps: dict | None = None,
     relax_opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -347,7 +354,7 @@ def quasi_irc_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.summarize_opt_run][]
     """
-
+    additional_fields = additional_fields or {}
     default_settings = SETTINGS.copy()
 
     irc_opt_swaps_defaults = {"fmax": 100, "max_steps": 10}
@@ -387,4 +394,4 @@ def quasi_irc_job(
 
     relax_summary["initial_irc"] = irc_summary
 
-    return relax_summary
+    return relax_summary | additional_fields

--- a/src/quacc/recipes/tblite/core.py
+++ b/src/quacc/recipes/tblite/core.py
@@ -31,6 +31,7 @@ def static_job(
     atoms: Atoms,
     method: Literal["GFN1-xTB", "GFN2-xTB", "IPEA1-xTB"] = "GFN2-xTB",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
     """
@@ -52,6 +53,8 @@ def static_job(
         GFN1-xTB, GFN2-xTB, and IPEA1-xTB.
     calc_swaps
         Dictionary of custom kwargs for the tblite calculator.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -60,6 +63,7 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
+    additional_fields = additional_fields or {}
 
     defaults = {"method": method}
     flags = merge_dicts(defaults, calc_swaps)
@@ -69,7 +73,7 @@ def static_job(
     return summarize_run(
         final_atoms,
         input_atoms=atoms,
-        additional_fields={"name": "TBLite Static"},
+        additional_fields={"name": "TBLite Static"} | additional_fields,
     )
 
 
@@ -81,6 +85,7 @@ def relax_job(
     relax_cell: bool = False,
     calc_swaps: dict | None = None,
     opt_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> OptSchema:
     """
@@ -112,6 +117,8 @@ def relax_job(
         Dictionary of custom kwargs for the tblite calculator.
     opt_swaps
         Dictionary of custom kwargs for [quacc.runners.calc.run_ase_opt][].
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -120,6 +127,7 @@ def relax_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.summarize_opt_run][]
     """
+    additional_fields = additional_fields or {}
 
     defaults = {"method": method}
     flags = merge_dicts(defaults, calc_swaps)
@@ -130,7 +138,9 @@ def relax_job(
 
     dyn = run_ase_opt(atoms, relax_cell=relax_cell, copy_files=copy_files, **opt_flags)
 
-    return summarize_opt_run(dyn, additional_fields={"name": "TBLite Relax"})
+    return summarize_opt_run(
+        dyn, additional_fields={"name": "TBLite Relax"} | additional_fields
+    )
 
 
 @job
@@ -143,6 +153,7 @@ def freq_job(
     pressure: float = 1.0,
     calc_swaps: dict | None = None,
     vib_kwargs: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VibThermoSchema:
     """
@@ -178,6 +189,8 @@ def freq_job(
         dictionary of custom kwargs for the tblite calculator.
     vib_kwargs
         dictionary of custom kwargs for the Vibrations object.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -187,6 +200,7 @@ def freq_job(
         Dictionary of results from [quacc.schemas.ase.summarize_vib_and_thermo][]
     """
     vib_kwargs = vib_kwargs or {}
+    additional_fields = additional_fields or {}
 
     defaults = {"method": method}
     flags = merge_dicts(defaults, calc_swaps)
@@ -200,5 +214,5 @@ def freq_job(
         igt,
         temperature=temperature,
         pressure=pressure,
-        additional_fields={"name": "TBLite Frequency and Thermo"},
+        additional_fields={"name": "TBLite Frequency and Thermo"} | additional_fields,
     )

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -23,6 +23,7 @@ def static_job(
     atoms: Atoms,
     preset: str | None = "BulkSet",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """
@@ -53,6 +54,8 @@ def static_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely.
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -61,7 +64,7 @@ def static_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "ismear": -5,
         "laechg": True,
@@ -76,7 +79,7 @@ def static_job(
         preset=preset,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "VASP Static"},
+        additional_fields={"name": "VASP Static"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -87,6 +90,7 @@ def relax_job(
     preset: str | None = "BulkSet",
     relax_cell: bool = True,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """
@@ -121,6 +125,8 @@ def relax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely.
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the runtime directory.
 
@@ -129,7 +135,7 @@ def relax_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "ediffg": -0.02,
         "isif": 3 if relax_cell else 2,
@@ -157,6 +163,7 @@ def double_relax_job(
     relax_cell: bool = True,
     calc_swaps1: dict | None = None,
     calc_swaps2: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> DoubleRelaxSchema:
     """
@@ -183,6 +190,8 @@ def double_relax_job(
         Dictionary of custom kwargs for the first relaxation.
     calc_swaps2
         Dictionary of custom kwargs for the second relaxation.
+    additional_fields
+        Additional fields to supply to the summarizer.
     copy_files
         Files to copy to the (first) runtime directory.
 
@@ -191,6 +200,7 @@ def double_relax_job(
     DoubleRelaxSchema
         Dictionary of results
     """
+    additional_fields = additional_fields or {}
 
     # Run first relaxation
     summary1 = relax_job.__wrapped__(
@@ -211,7 +221,7 @@ def double_relax_job(
     )
     summary2["relax1"] = summary1
 
-    return summary2
+    return summary2 | additional_fields
 
 
 def _base_job(

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -74,6 +74,7 @@ def mp_prerelax_job(
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
     additional_fields = additional_fields or {}
+
     defaults = {
         "ediffg": -0.05,
         "xc": "pbesol",
@@ -97,6 +98,7 @@ def mp_relax_job(
     preset: str | None = "MPScanSet",
     bandgap: float | None = None,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -37,6 +37,7 @@ def mp_prerelax_job(
     preset: str | None = "MPScanSet",
     bandgap: float | None = None,
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """
@@ -62,6 +63,8 @@ def mp_prerelax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -70,7 +73,7 @@ def mp_prerelax_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
-
+    additional_fields = additional_fields or {}
     defaults = {
         "ediffg": -0.05,
         "xc": "pbesol",
@@ -83,7 +86,7 @@ def mp_prerelax_job(
         preset=preset,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "MP Pre-Relax"},
+        additional_fields={"name": "MP Pre-Relax"} | additional_fields,
         copy_files=copy_files,
     )
 
@@ -119,6 +122,8 @@ def mp_relax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to add to the result dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -127,6 +132,7 @@ def mp_relax_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
+    additional_fields = additional_fields or {}
 
     defaults = {"lcharg": True, "lwave": True} | _get_bandgap_swaps(bandgap)
     return _base_job(
@@ -134,7 +140,7 @@ def mp_relax_job(
         preset=preset,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "MP Relax"},
+        additional_fields={"name": "MP Relax"} | additional_fields,
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -36,6 +36,7 @@ def qmof_relax_job(
     preset: str | None = "QMOFSet",
     relax_cell: bool = True,
     run_prerelax: bool = True,
+    additional_fields: dict | None = None,
     calc_swaps: dict | None = None,
 ) -> QMOFRelaxSchema:
     """
@@ -66,6 +67,8 @@ def qmof_relax_job(
         If True, a pre-relax will be carried out with BFGSLineSearch.
         Recommended if starting from hypothetical structures or materials with
         very high starting forces.
+    additional_fields
+        Additional fields to add to the result dictionary.
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely. Applies for all jobs.
@@ -75,6 +78,7 @@ def qmof_relax_job(
     QMOFRelaxSchema
         Dictionary of results
     """
+    additional_fields = additional_fields or {}
 
     # 1. Pre-relaxation
     if run_prerelax:
@@ -103,7 +107,7 @@ def qmof_relax_job(
     summary5["volume_relax_lowacc"] = summary3 if relax_cell else None
     summary5["double_relax"] = summary4
 
-    return summary5
+    return summary5 | additional_fields
 
 
 def _prerelax(

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -18,6 +18,7 @@ def slab_static_job(
     atoms: Atoms,
     preset: str | None = "SlabSet",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """
@@ -50,6 +51,8 @@ def slab_static_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to add to the results dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -58,6 +61,7 @@ def slab_static_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
+    additional_fields = additional_fields or {}
 
     defaults = {
         "auto_dipole": True,
@@ -85,6 +89,7 @@ def slab_relax_job(
     atoms: Atoms,
     preset: str | None = "SlabSet",
     calc_swaps: dict | None = None,
+    additional_fields: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> VaspSchema:
     """
@@ -117,6 +122,8 @@ def slab_relax_job(
     calc_swaps
         Dictionary of custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely. Set a value to `None` to remove a pre-existing key entirely.
+    additional_fields
+        Additional fields to add to the results dictionary.
     copy_files
         Files to copy to the runtime directory.
 
@@ -125,6 +132,7 @@ def slab_relax_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][]
     """
+    additional_fields = additional_fields or {}
 
     defaults = {
         "auto_dipole": True,
@@ -142,7 +150,7 @@ def slab_relax_job(
         preset=preset,
         defaults=defaults,
         calc_swaps=calc_swaps,
-        additional_fields={"name": "VASP Slab Relax"},
+        additional_fields={"name": "VASP Slab Relax"} | additional_fields,
         copy_files=copy_files,
     )
 


### PR DESCRIPTION
- [X] I have read the [Developer Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant unit tests. Note: Your PR will likely not be merged without proper tests.

The purpose of this PR is to add an `additional_fields` kwarg to all jobs. This is primarily meant to assist with provenance tracking. For instance, if you are running a workflow on a material "MP-10", you could set `additional_fields={"tag": "MP-10"}` for the relevant jobs. Several workflow engines support tagging, but we want to provide an option for this independent of the workflow engine in case the user doesn't run with one or the workflow engine doesn't support it.