### PR TITLE
[WIP] Q-Chem calculator refactor

### DIFF
--- a/src/quacc/calculators/qchem/io.py
+++ b/src/quacc/calculators/qchem/io.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import struct
+from copy import deepcopy
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from ase import Atoms, units
+from emmet.core.tasks import _parse_custodian
+from monty.io import zopen
+from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.io.qchem.inputs import QCInput
+from pymatgen.io.qchem.outputs import QCOutput
+from pymatgen.io.qchem.sets import QChemDictSet
+
+if TYPE_CHECKING:
+    from typing import Any, TypedDict, Literal
+
+    from ase import Atoms
+    from numpy.typing import NDArray
+
+    class Results(TypedDict):
+        energy: float  # eV
+        forces: NDArray  # Nx3, eV/Å
+        hessian: NDArray  # Nx3x3, native Q-Chem units. TODO: convert to ASE units
+        enthalpy: float  # eV
+        entropy: float  # eV/K
+        qc_output: dict[
+            str, Any
+        ]  # output from `pymatgen.io.qchem.outputs.QCOutput.data`
+        qc_input: dict[
+            str, Any
+        ]  # input from `pymatgen.io.qchem.inputs.QCInput.as_dict()`
+        custodian: dict[str, Any]  # custodian.json file metadata
+
+
+def write_qchem(
+    atoms: Atoms,
+    directory: Path | str,
+    input_filepath: Path | str,
+    parameters: dict[str, Any],
+) -> None:
+    """
+    Write the Q-Chem input files.
+
+    Parameters
+    ----------
+    atoms
+        The ASE atoms object.
+    directory
+        The directory to write the Q-Chem files to.
+    input_filepath
+        The path to the input file to write.
+    paramters
+        The Q-Chem parameters to use, formatted as a dictionary.
+
+    Returns
+    -------
+    None
+    """
+
+    charge = parameters.get("charge", 0)
+    spin_multiplicity = parameters.get("spin_multiplicity", 1)
+    method = parameters.get("method")
+    basis_set = parameters.get("basis_set", "def2-tzvpd")
+    job_type = parameters.get("job_type", "force")
+    scf_algorithm = parameters.get("scf_algorithm", "diis")
+    qchem_input_params = parameters.get("qchem_input_params", {})
+
+    atoms = deepcopy(atoms)
+    atoms.charge = charge
+    atoms.spin_multiplicity = spin_multiplicity
+    mol = AseAtomsAdaptor.get_molecule(atoms)
+
+    if self.prev_orbital_coeffs is not None:
+        with Path(directory, "53.0").open(mode="wb") as file:
+            for val in self.prev_orbital_coeffs:
+                data = struct.pack("d", val)
+                file.write(data)
+        if "overwrite_inputs" not in qchem_input_params:
+            qchem_input_params["overwrite_inputs"] = {}
+        if "rem" not in qchem_input_params["overwrite_inputs"]:
+            qchem_input_params["overwrite_inputs"]["rem"] = {}
+        if "scf_guess" not in qchem_input_params["overwrite_inputs"]["rem"]:
+            qchem_input_params["overwrite_inputs"]["rem"]["scf_guess"] = "read"
+
+    qcin = QChemDictSet(
+        mol,
+        job_type,
+        basis_set,
+        scf_algorithm,
+        qchem_version=6,
+        **qchem_input_params,
+    )
+    qcin.write(input_filepath)
+
+
+def read_qchem(
+    directory: Path | str,
+    input_filepath: Path | str,
+    ouptut_filepath: Path | str,
+    job_type: Literal["opt", "sp", "freq", "force"],
+) -> Results:
+    """
+    Read the Q-Chem output files.
+
+    Parameters
+    ----------
+    directory
+        The path to the directory to read the Q-Chem results from.
+    input_filepath
+        The path to the input file to read.
+    output_filepath
+        The path to the output file to read.
+    job_type
+        The type of Q-Chem job that was run.
+
+    Returns
+    -------
+    Results
+        The Q-Chem results, formatted as a dictionary.
+    """
+    qc_input = QCInput.from_file(str(input_filepath)).as_dict()
+    qc_output = QCOutput(str(ouptut_filepath)).data
+
+    results = {}
+    results["qc_output"] = qc_output
+    results["qc_input"] = qc_input
+    results["custodian"] = _parse_custodian(directory)
+    results["energy"] = qc_output["final_energy"] * units.Hartree
+
+    if job_type in ["force", "opt"]:
+        tmp_grad_data = []
+
+        # Read the gradient scratch file in 8 byte chunks
+        with zopen(directory / "131.0", mode="rb") as file:
+            binary = file.read()
+        tmp_grad_data.extend(
+            struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
+            for ii in range(len(binary) // 8)
+        )
+        grad = [
+            [
+                float(tmp_grad_data[ii * 3]),
+                float(tmp_grad_data[ii * 3 + 1]),
+                float(tmp_grad_data[ii * 3 + 2]),
+            ]
+            for ii in range(len(tmp_grad_data) // 3)
+        ]
+
+        # Ensure that the scratch values match the correct values from the
+        # output file but with higher precision
+        if qc_output["pcm_gradients"] is not None:
+            gradient = qc_output["pcm_gradients"][0]
+        else:
+            gradient = qc_output["gradients"][0]
+        for ii, subgrad in enumerate(grad):
+            for jj, val in enumerate(subgrad):
+                if abs(gradient[ii, jj] - val) > 1e-6:
+                    raise ValueError(
+                        "Difference between gradient value in scratch file vs. output file should not be this large."
+                    )
+                gradient[ii, jj] = val
+
+        # Convert gradient to force + deal with units
+        results["forces"] = gradient * (-units.Hartree / units.Bohr)
+
+    # Read orbital coefficients scratch file in 8 byte chunks
+    self.prev_orbital_coeffs = []
+    with zopen(directory / "53.0", mode="rb") as file:
+        binary = file.read()
+    self.prev_orbital_coeffs.extend(
+        struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
+        for ii in range(len(binary) // 8)
+    )
+
+    if job_type == "freq":
+        # Read Hessian scratch file in 8 byte chunks
+        tmp_hess_data = []
+        with zopen(directory / "132.0", mode="rb") as file:
+            binary = file.read()
+        tmp_hess_data.extend(
+            struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
+            for ii in range(len(binary) // 8)
+        )
+
+        results["hessian"] = np.reshape(
+            np.array(tmp_hess_data),
+            (len(qc_output["species"]) * 3, len(qc_output["species"]) * 3),
+        )
+        results["enthalpy"] = qc_output["total_enthalpy"] * (units.kcal / units.mol)
+        results["entropy"] = qc_output["total_entropy"] * (
+            0.001 * units.kcal / units.mol
+        )

--- a/src/quacc/calculators/qchem/io.py
+++ b/src/quacc/calculators/qchem/io.py
@@ -15,7 +15,7 @@ from pymatgen.io.qchem.outputs import QCOutput
 from pymatgen.io.qchem.sets import QChemDictSet
 
 if TYPE_CHECKING:
-    from typing import Any, TypedDict, Literal
+    from typing import Any, Literal, TypedDict
 
     from ase import Atoms
     from numpy.typing import NDArray

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 # TODO: 
 # 1. How to get the `job_type` to pass to `read_qchem`?
 # 2. How to deal with updating self.prev_orbital_coeffs in `read_qchem`/`write_qchem`? 
-# 3. Update the units for the Hessian to be ASE units.
+# 3. Use `TypedDict` type hints for `dict[str,Any]` hints in Results
+# 4. Update the units for the Hessian to be ASE units.
 class QChemProfile:
     """
     Q-Chem profile

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -1,276 +1,237 @@
-"""A Q-Chem calculator built on Pymatgen and Custodian functionality"""
+"""
+ASE calculator for Q-Chem
+"""
 from __future__ import annotations
 
 import inspect
-import logging
-import struct
-from copy import deepcopy
+import multiprocessing
 from pathlib import Path
-from typing import ClassVar
+from subprocess import check_call
+from typing import TYPE_CHECKING
 
-import numpy as np
-from ase import Atoms, units
-from ase.calculators.calculator import FileIOCalculator
-from emmet.core.tasks import _parse_custodian
-from monty.io import zopen
-from pymatgen.io.ase import AseAtomsAdaptor
-from pymatgen.io.qchem.inputs import QCInput
-from pymatgen.io.qchem.outputs import QCOutput
-from pymatgen.io.qchem.sets import QChemDictSet
+from ase.calculators.genericfileio import CalculatorTemplate, GenericFileIOCalculator
 
 from quacc.calculators.qchem import custodian
+from quacc.calculators.qchem.io import read_qchem, write_qchem
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from typing import Any
 
+    from ase.atoms import Atoms
 
-# TODO: Would be more consistent to convert the Hessian to ASE units if it's being
-# stored in the first-class results.
-class QChem(FileIOCalculator):
+    from quacc.calculators.qchem.io import Results
+
+# TODO: 
+# 1. How to get the `job_type` to pass to `read_qchem`?
+# 2. How to deal with updating self.prev_orbital_coeffs in `read_qchem`/`write_qchem`? 
+# 3. Update the units for the Hessian to be ASE units.
+class QChemProfile:
+    """
+    Q-Chem profile
     """
 
-    Parameters
-    ----------
-    atoms
-        The Atoms object to be used for the calculation.
-    cores
-        Number of cores to use for the Q-Chem calculation.
-    charge
-        The total charge of the molecular system.
-    spin_multiplicity
-        The spin multiplicity of the molecular system.
-    qchem_input_params
-        Dictionary of Q-Chem input parameters to be passed to
-        `pymatgen.io.qchem.sets.DictSet`.
-    **fileiocalculator_kwargs
-        Additional arguments to be passed to
-        `ase.calculators.calculator.FileIOCalculator`.
-
-    Returns
-    -------
-    Atoms
-        The ASE Atoms object with attached Q-Chem calculator. In calc.results,
-        the following properties are set:
-
-        - energy: electronic energy in eV
-        - forces: forces in eV/A
-        - hessian: Hessian in native Q-Chem units
-        - entropy: total enthalpy in eV
-        - enthalpy: total entropy in eV/K
-        - qc_output: Output from `pymatgen.io.qchem.outputs.QCOutput.data`
-        - qc_input: Input from `pymatgen.io.qchem.inputs.QCInput.as_dict()`
-        - custodian: custodian.json file metadata
-    """
-
-    implemented_properties: ClassVar[list[str]] = [
-        "energy",
-        "forces",
-        "hessian",
-        "enthalpy",
-        "entropy",
-        "qc_output",
-        "qc_input",
-        "custodian",
-    ]
-
-    def __init__(
-        self,
-        atoms: Atoms,
-        charge: int = 0,
-        spin_multiplicity: int = 1,
-        method: str | None = None,
-        basis_set: str = "def2-tzvpd",
-        job_type: str = "force",
-        scf_algorithm: str = "diis",
-        cores: int = 1,
-        qchem_input_params: dict | None = None,
-        **fileiocalculator_kwargs,
-    ):
-        # Assign variables to self
-        self.atoms = atoms
-        self.cores = cores
-        self.charge = charge
-        self.spin_multiplicity = spin_multiplicity
-        self.job_type = job_type
-        self.basis_set = basis_set
-        self.scf_algorithm = scf_algorithm
-        self.qchem_input_params = qchem_input_params or {}
-        self.fileiocalculator_kwargs = fileiocalculator_kwargs
-
-        # Sanity checks
-        if "directory" in self.fileiocalculator_kwargs:
-            raise NotImplementedError("The directory kwarg is not supported.")
-
-        if "overwrite_inputs" not in self.qchem_input_params:
-            self.qchem_input_params["overwrite_inputs"] = {}
-
-        if self.qchem_input_params.get("smd_solvent") and self.qchem_input_params.get(
-            "pcm_dielectric"
-        ):
-            raise ValueError("PCM and SMD cannot be employed simultaneously.")
-
-        if "rem" not in self.qchem_input_params["overwrite_inputs"]:
-            self.qchem_input_params["overwrite_inputs"]["rem"] = {}
-        if (
-            method
-            and "method" not in self.qchem_input_params["overwrite_inputs"]["rem"]
-        ):
-            self.qchem_input_params["overwrite_inputs"]["rem"]["method"] = method
-
-        # We will save the parameters that have been passed to the Q-Chem
-        # calculator via FileIOCalculator's self.default_parameters
-        self.default_parameters = {
-            "cores": self.cores,
-            "charge": self.charge,
-            "spin_multiplicity": self.spin_multiplicity,
-            "scf_algorithm": self.scf_algorithm,
-            "basis_set": self.basis_set,
-        }
-
-        if method:
-            self.default_parameters["method"] = method
-
-        # We also want to save the contents of self.qchem_input_params. However,
-        # the overwrite_inputs key will have a corresponding value which is
-        # either an empty dictionary or a nested dict of dicts, requiring a bit
-        # of careful unwrapping.
-        for key in self.qchem_input_params:
-            if key == "overwrite_inputs":
-                for subkey in self.qchem_input_params[key]:
-                    for subsubkey in self.qchem_input_params[key][subkey]:
-                        self.default_parameters[
-                            f"overwrite_{subkey}_{subsubkey}"
-                        ] = self.qchem_input_params[key][subkey][subsubkey]
-            else:
-                self.default_parameters[key] = self.qchem_input_params[key]
-
-        # Get Q-Chem executable command
-        self.command = self._manage_environment()
-
-        # Instantiate previous orbital coefficients
-        self.prev_orbital_coeffs = None
-
-        # Instantiate the calculator
-        FileIOCalculator.__init__(
-            self,
-            restart=None,
-            ignore_bad_restart_file=FileIOCalculator._deprecated,
-            label=None,
-            atoms=self.atoms,
-            **self.fileiocalculator_kwargs,
-        )
-
-    def _manage_environment(self) -> str:
+    def __init__(self, cores: int | None = None) -> None:
         """
-        Manage the environment for the Q-Chem calculator.
+        Initialize the Q-Chem profile.
+
+        Parameters
+        ----------
+        cores
+            The number of cores to use for the Q-Chem calculation.
+            Defaults to the number of cores on the machine.
 
         Returns
         -------
-        str
-            The command flag to pass to the Q-Chem calculator.
+        None
+        """
+        self.cores = cores or multiprocessing.cpu_count()
+
+    def run(
+        self,
+        directory: Path | str,
+        output_filename: str,
+    ) -> None:
+        """
+        Run the xTB calculation.
+
+        Parameters
+        ----------
+        directory
+            The directory where the calculation will be run.
+        output_filename
+            The name of the log file to write to in the directory.
+
+        Returns
+        -------
+        None
+        """
+        run_qchem_custodian_file = Path(inspect.getfile(custodian)).resolve()
+        cmd = ["python", str(run_qchem_custodian_file), str(self.cores)]
+
+        with open(output_filename, "w") as fd:
+            check_call(cmd, stdout=fd, cwd=directory)
+
+
+class _QChemTemplate(CalculatorTemplate):
+    """
+    Q-Chem template
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the Q-Chem template.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        label = "mol"
+        super().__init__(
+            name=label,
+            implemented_properties=[
+                "energy",
+                "forces",
+                "hessian",
+                "enthalpy",
+                "entropy",
+                "qc_output",
+                "qc_input",
+                "custodian",
+            ],
+        )
+
+        self.input_file = f"{label}.qin"
+        self.output_file = f"{label}.qout"
+
+    def execute(self, directory: Path | str, profile: QChemProfile) -> None:
+        """
+        Run the Q-Chem executable.
+
+        Parameters
+        ----------
+        directory
+            The path to the directory to run the Q-Chem executable in.
+        profile
+            The Q-Chem profile to use.
+
+        Returns
+        -------
+        None
+        """
+        profile.run(directory, self.output_file)
+
+    def write_input(
+        self,
+        directory: Path | str,
+        atoms: Atoms,
+        parameters: dict[str, Any],
+        properties: Any,  # skipcq: PYL-W0613
+    ) -> None:
+        """
+        Write the xTB input files.
+
+        Parameters
+        ----------
+        directory
+            The path to the directory to write the Q-Chem input files in.
+        atoms
+            The ASE atoms object to write.
+        parameters
+            The Q-Chem parameters to use, formatted as a dictionary.
+        properties
+            This is needed the base class and should not be explicitly specified.
+
+        Returns
+        -------
+        None
         """
 
-        # Return the command flag
-        run_qchem_custodian_file = Path(inspect.getfile(custodian)).resolve()
-        return f"python {run_qchem_custodian_file} {self.cores}"
-
-    def write_input(self, atoms, properties=None, system_changes=None):
-        FileIOCalculator.write_input(self, atoms, properties, system_changes)
-        atoms = deepcopy(atoms)
-        atoms.charge = self.charge
-        atoms.spin_multiplicity = self.spin_multiplicity
-        mol = AseAtomsAdaptor.get_molecule(atoms)
-        if self.prev_orbital_coeffs is not None:
-            with Path("53.0").open(mode="wb") as file:
-                for val in self.prev_orbital_coeffs:
-                    data = struct.pack("d", val)
-                    file.write(data)
-            if "overwrite_inputs" not in self.qchem_input_params:
-                self.qchem_input_params["overwrite_inputs"] = {}
-            if "rem" not in self.qchem_input_params["overwrite_inputs"]:
-                self.qchem_input_params["overwrite_inputs"]["rem"] = {}
-            if "scf_guess" not in self.qchem_input_params["overwrite_inputs"]["rem"]:
-                self.qchem_input_params["overwrite_inputs"]["rem"]["scf_guess"] = "read"
-        qcin = QChemDictSet(
-            mol,
-            self.job_type,
-            self.basis_set,
-            self.scf_algorithm,
-            qchem_version=6,
-            **self.qchem_input_params,
-        )
-        qcin.write("mol.qin")
-
-    def read_results(self):
-        qc_input = QCInput.from_file("mol.qin").as_dict()
-        qc_output = QCOutput("mol.qout").data
-        self.results["qc_output"] = qc_output
-        self.results["qc_input"] = qc_input
-        self.results["custodian"] = _parse_custodian(Path.cwd())
-
-        self.results["energy"] = qc_output["final_energy"] * units.Hartree
-
-        if self.job_type in ["force", "opt"]:
-            tmp_grad_data = []
-            # Read the gradient scratch file in 8 byte chunks
-            with zopen("131.0", mode="rb") as file:
-                binary = file.read()
-            tmp_grad_data.extend(
-                struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
-                for ii in range(len(binary) // 8)
-            )
-            grad = [
-                [
-                    float(tmp_grad_data[ii * 3]),
-                    float(tmp_grad_data[ii * 3 + 1]),
-                    float(tmp_grad_data[ii * 3 + 2]),
-                ]
-                for ii in range(len(tmp_grad_data) // 3)
-            ]
-            # Ensure that the scratch values match the correct values from the
-            # output file but with higher precision
-            if qc_output["pcm_gradients"] is not None:
-                gradient = qc_output["pcm_gradients"][0]
-            else:
-                gradient = qc_output["gradients"][0]
-            for ii, subgrad in enumerate(grad):
-                for jj, val in enumerate(subgrad):
-                    if abs(gradient[ii, jj] - val) > 1e-6:
-                        raise ValueError(
-                            "Difference between gradient value in scratch file vs. output file should not be this large."
-                        )
-                    gradient[ii, jj] = val
-            # Convert gradient to force + deal with units
-            self.results["forces"] = gradient * (-units.Hartree / units.Bohr)
-        else:
-            self.results["forces"] = None
-
-        # Read orbital coefficients scratch file in 8 byte chunks
-        self.prev_orbital_coeffs = []
-        with zopen("53.0", mode="rb") as file:
-            binary = file.read()
-        self.prev_orbital_coeffs.extend(
-            struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
-            for ii in range(len(binary) // 8)
+        write_qchem(
+            atoms,
+            directory,
+            directory / self.input_file,
+            parameters,
         )
 
-        if self.job_type == "freq":
-            tmp_hess_data = []
-            # Read Hessian scratch file in 8 byte chunks
-            with zopen("132.0", mode="rb") as file:
-                binary = file.read()
-            tmp_hess_data.extend(
-                struct.unpack("d", binary[ii * 8 : (ii + 1) * 8])[0]
-                for ii in range(len(binary) // 8)
-            )
-            self.results["hessian"] = np.reshape(
-                np.array(tmp_hess_data),
-                (len(qc_output["species"]) * 3, len(qc_output["species"]) * 3),
-            )
-            self.results["enthalpy"] = qc_output["total_enthalpy"] * (
-                units.kcal / units.mol
-            )
-            self.results["entropy"] = qc_output["total_entropy"] * (
-                0.001 * units.kcal / units.mol
-            )
-        else:
-            self.results["hessian"] = None
+    def read_results(self, directory: Path) -> Results:
+        """
+        Use cclib to read the results from the Q-Chem calculation.
+
+        Parameters
+        ----------
+        directory
+            The path to the directory to read the Q-Chem results from.
+
+        Returns
+        -------
+        Results
+            The xTB results, formatted as a dictionary.
+        """
+
+        return read_qchem(
+            directory, directory / self.input_file, directory / self.output_file
+        )
+
+
+class QChem(GenericFileIOCalculator):
+    """
+    Q-Chem calculator
+    """
+
+    def __init__(
+        self,
+        *,
+        profile: QChemProfile | None = None,
+        directory: Path | str = ".",
+        **kwargs,
+    ) -> None:
+        """
+        Initialize the Q-Chem calculator.
+
+        Parameters
+        ----------
+        profile
+            The Q-Chem profile to use.
+        directory
+            The path to the directory to run the Q-Chem executable in.
+        **kwargs
+            The Q-Chem parameters to use:
+
+            atoms: Atoms
+                The Atoms object to be used for the calculation.
+            charge: int
+                The total charge of the molecular system.
+                Default: 0.
+            spin_multiplicity: int
+                The spin multiplicity of the molecular system.
+                Default: 1.
+            method: str
+                The Q-Chem method to use.
+            basis_set: str
+                The Q-Chem basis set to use.
+            job_type: Literal["opt", "sp", "freq", "force"])
+                The Q-Chem job type to use.
+            scf_algorithm: str
+                The Q-Chem SCF algorithm to use.
+            qchem_input_params: dict[str, Any]
+                Dictionary of Q-Chem input parameters to be passed to
+                `pymatgen.io.qchem.sets.DictSet`.
+
+        Returns
+        -------
+        None
+        """
+
+        profile = profile or QChemProfile()
+        directory = Path(directory).expanduser().resolve()
+
+        super().__init__(
+            template=_QChemTemplate(),
+            profile=profile,
+            directory=directory,
+            parameters=kwargs,
+        )

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from quacc.calculators.qchem.io import Results
 
+
 class QChemProfile:
     """
     Q-Chem profile

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from quacc.calculators.qchem.io import Results
 
 # TODO: 
+# 0. Undo removal of `n_cores` from Q-Chem recipes because users need to be able to change it.
 # 1. How to get the `job_type` to pass to `read_qchem`?
 # 2. How to deal with updating self.prev_orbital_coeffs in `read_qchem`/`write_qchem`? 
 # 3. Use `TypedDict` type hints for `dict[str,Any]` hints in Results

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -128,7 +128,7 @@ class _QChemTemplate(CalculatorTemplate):
         properties: Any,  # skipcq: PYL-W0613
     ) -> None:
         """
-        Write the xTB input files.
+        Write the Q-Chem input files.
 
         Parameters
         ----------
@@ -165,7 +165,7 @@ class _QChemTemplate(CalculatorTemplate):
         Returns
         -------
         Results
-            The xTB results, formatted as a dictionary.
+            The Q-Chem results, formatted as a dictionary.
         """
 
         return read_qchem(

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -21,12 +21,6 @@ if TYPE_CHECKING:
 
     from quacc.calculators.qchem.io import Results
 
-# TODO: 
-# 0. Undo removal of `n_cores` from Q-Chem recipes because users need to be able to change it.
-# 1. How to get the `job_type` to pass to `read_qchem`?
-# 2. How to deal with updating self.prev_orbital_coeffs in `read_qchem`/`write_qchem`? 
-# 3. Use `TypedDict` type hints for `dict[str,Any]` hints in Results
-# 4. Update the units for the Hessian to be ASE units.
 class QChemProfile:
     """
     Q-Chem profile

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -1,7 +1,6 @@
 """Core recipes for the Q-Chem"""
 from __future__ import annotations
 
-import multiprocessing
 from typing import TYPE_CHECKING
 
 from ase.optimize import FIRE
@@ -35,7 +34,6 @@ def static_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
@@ -53,7 +51,6 @@ def static_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -89,9 +86,6 @@ def static_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -110,7 +104,6 @@ def static_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -140,7 +133,6 @@ def internal_relax_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
@@ -159,7 +151,6 @@ def internal_relax_job(
             "method": method,
             "charge": charge,
             "spin_multiplicity": spin_multiplicity,
-            "cores": n_cores or multiprocessing.cpu_count(),
             "qchem_input_params": {
                 "pcm_dielectric": pcm_dielectric,
                 "smd_solvent": smd_solvent,
@@ -194,9 +185,6 @@ def internal_relax_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -217,7 +205,6 @@ def internal_relax_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -245,7 +232,6 @@ def freq_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     copy_files: list[str] | None = None,
 ) -> RunSchema:
@@ -264,7 +250,6 @@ def freq_job(
             "method": method,
             "charge": charge,
             "spin_multiplicity": spin_multiplicity,
-            "cores": n_cores or multiprocessing.cpu_count(),
             "qchem_input_params": {
                 "pcm_dielectric": pcm_dielectric,
                 "smd_solvent": smd_solvent,
@@ -299,9 +284,6 @@ def freq_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -322,7 +304,6 @@ def freq_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -350,7 +331,6 @@ def relax_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
     copy_files: list[str] | None = None,
@@ -369,7 +349,6 @@ def relax_job(
             "method": method,
             "charge": charge,
             "spin_multiplicity": spin_multiplicity,
-            "cores": n_cores or multiprocessing.cpu_count(),
             "qchem_input_params": {
                 "pcm_dielectric": pcm_dielectric,
                 "smd_solvent": smd_solvent,
@@ -410,9 +389,6 @@ def relax_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -434,7 +410,6 @@ def relax_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -1,7 +1,6 @@
 """Transition state recipes for the Q-Chem"""
 from __future__ import annotations
 
-import multiprocessing
 from typing import TYPE_CHECKING
 
 from monty.dev import requires
@@ -39,7 +38,6 @@ def ts_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
     copy_files: list[str] | None = None,
@@ -58,7 +56,6 @@ def ts_job(
             "method": method,
             "charge": charge,
             "spin_multiplicity": spin_multiplicity,
-            "cores": n_cores or multiprocessing.cpu_count(),
             "qchem_input_params": {
                 "pcm_dielectric": pcm_dielectric,
                 "smd_solvent": smd_solvent,
@@ -99,9 +96,6 @@ def ts_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -123,7 +117,6 @@ def ts_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -168,7 +161,6 @@ def irc_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     opt_swaps: dict | None = None,
     copy_files: list[str] | None = None,
@@ -187,7 +179,6 @@ def irc_job(
             "method": method,
             "charge": charge,
             "spin_multiplicity": spin_multiplicity,
-            "cores": n_cores or multiprocessing.cpu_count(),
             "qchem_input_params": {
                 "pcm_dielectric": pcm_dielectric,
                 "smd_solvent": smd_solvent,
@@ -230,9 +221,6 @@ def irc_job(
         "water", "ethanol", "methanol", and "acetonitrile". Refer to the Q-Chem
         manual for a complete list of solvents available. Defaults to None, in
         which case SMD will not be employed.
-    n_cores
-        Number of cores to use for the Q-Chem calculation. Defaults to use all
-        cores available on a given node.
     overwrite_inputs
         Dictionary passed to `pymatgen.io.qchem.QChemDictSet` which can modify
         default values set therein as well as set additional Q-Chem parameters.
@@ -254,7 +242,6 @@ def irc_job(
         "method": method,
         "charge": charge,
         "spin_multiplicity": spin_multiplicity,
-        "cores": n_cores or multiprocessing.cpu_count(),
         "qchem_input_params": {
             "pcm_dielectric": pcm_dielectric,
             "smd_solvent": smd_solvent,
@@ -299,7 +286,6 @@ def quasi_irc_job(
     scf_algorithm: str = "diis",
     pcm_dielectric: str | None = None,
     smd_solvent: str | None = None,
-    n_cores: int | None = None,
     overwrite_inputs: dict | None = None,
     irc_opt_swaps: dict | None = None,
     relax_opt_swaps: dict | None = None,
@@ -364,7 +350,6 @@ def quasi_irc_job(
         scf_algorithm=scf_algorithm,
         pcm_dielectric=pcm_dielectric,
         smd_solvent=smd_solvent,
-        n_cores=n_cores,
         overwrite_inputs=overwrite_inputs,
         opt_swaps=irc_opt_swaps,
         copy_files=copy_files,
@@ -380,7 +365,6 @@ def quasi_irc_job(
         scf_algorithm=scf_algorithm,
         pcm_dielectric=pcm_dielectric,
         smd_solvent=smd_solvent,
-        n_cores=n_cores,
         overwrite_inputs=overwrite_inputs,
         opt_swaps=relax_opt_swaps,
     )


### PR DESCRIPTION
Closes #1116. Should not involve any breaking changes.

TODO:
1. Undo removal of `n_cores` from Q-Chem recipes because users need to be able to change it.
2. How to get the `job_type` to pass to `read_qchem`?
3. How to deal with updating `self.prev_orbital_coeffs` in `read_qchem`/`write_qchem`? 
4. Use `TypedDict` type hints for `dict[str,Any]` hints in Results
5. Update the units for the Hessian to be ASE units. This would be breaking, so perhaps reserved for a future PR.