### PR TITLE
Address breaking change with NewtonNet 1.1

### DIFF
--- a/tests/local/recipes/newtonnet_recipes/test_newtonnet_recipes.py
+++ b/tests/local/recipes/newtonnet_recipes/test_newtonnet_recipes.py
@@ -139,10 +139,10 @@ def test_ts_job_with_custom_hessian(tmpdir):
     # Perform assertions on the result
     assert isinstance(output, dict)
 
-    # assert output["results"]["energy"] == pytest.approx(-8.855604432470276)
-    # assert output["freq_job"]["vib"]["results"]["vib_energies"][0] == pytest.approx(
-    #     0.2256022513686731
-    # )
+    assert output["results"]["energy"] == pytest.approx(-8.855604432470276)
+    assert output["freq_job"]["vib"]["results"]["vib_energies"][0] == pytest.approx(
+        0.2256022513686731
+    )
     assert "thermo" in output["freq_job"]
 
 


### PR DESCRIPTION
NewtonNet 1.1 broke the energy and vibrational frequency for one of the unit tests. This PR uncomments that test to show precisely where the breaking change is, and before merging we need to fix it so the tests pass. Ideally, we should identify what changed in NewtonNet 1.1 that caused the energy/forces to change for this test.

This is a new PR to make things clearer, @kumaranu.

- [ ] I have read the [Developer Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have added relevant unit tests. Note: Your PR will likely not be merged without proper tests.
