### PR TITLE
Remove calculator params from docstrings

### DIFF
--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -46,17 +46,6 @@ def static_job(
         entirely. For a list of available keys, refer to the
         `ase.calculators.dftb.Dftb` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
-                "Hamiltonian_MaxSccIterations": 200,
-                "Hamiltonian_Method": method if "xtb" in method.lower() else None,
-                "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
-            }
-            ```
-
     Returns
     -------
     RunSchema
@@ -105,20 +94,6 @@ def relax_job(
         calculator defaults. Set a value to `None` to remove a pre-existing key
         entirely. For a list of available keys, refer to the
         `ase.calculators.dftb.Dftb` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
-                "Hamiltonian_MaxSccIterations": 200,
-                "Hamiltonian_Method": method if "xtb" in method.lower() else None,
-                "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
-                "Driver_": "GeometryOptimization",
-                "Driver_LatticeOpt": "Yes" if relax_cell else "No",
-                "Driver_AppendGeometries": "Yes", "Driver_MaxSteps": 2000,
-            }
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -37,12 +37,6 @@ def static_job(atoms: Atoms, **calc_kwargs) -> RunSchema:
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.emt.EMT` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {}
-            ```
-
     Returns
     -------
     RunSchema
@@ -78,22 +72,10 @@ def relax_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
-            ```
     **calc_kwargs
         Custom kwargs for the EMT calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.emt.EMT` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {}
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -55,27 +55,6 @@ def static_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.gaussian.Gaussian` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "mem": "16GB",
-                "chk": "Gaussian.chk",
-                "nprocshared": multiprocessing.cpu_count(),
-                "xc": xc,
-                "basis": basis,
-                "charge": charge,
-                "mult": spin_multiplicity,
-                "sp": "",
-                "scf": ["maxcycle=250", "xqc"],
-                "integral": "ultrafine",
-                "nosymmetry": "",
-                "pop": "CM5",
-                "gfinput": "",
-                "ioplist": ["6/7=3", "2/9=2000"],
-            }
-            ```
-
     Returns
     -------
     cclibSchema
@@ -142,27 +121,6 @@ def relax_job(
         Custom kwargs for the Gaussian calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.gaussian.Gaussian` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "mem": "16GB",
-                "chk": "Gaussian.chk",
-                "nprocshared": multiprocessing.cpu_count(),
-                "xc": xc,
-                "basis": basis,
-                "charge": charge,
-                "mult": spin_multiplicity,
-                "opt": "",
-                "pop": "CM5",
-                "scf": ["maxcycle=250", "xqc"],
-                "integral": "ultrafine",
-                "nosymmetry": "",
-                "freq": "" if freq else None,
-                "ioplist": ["2/9=2000"],
-            }
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/gulp/core.py
+++ b/src/quacc/recipes/gulp/core.py
@@ -47,25 +47,10 @@ def static_job(
         Dictionary of custom `keyword` kwargs for the GULP calculator. Set a
         value to `None` to remove a pre-existing key entirely. For a list of
         available keys, refer to the `ase.calculators.gulp.GULP` calculator.
-
-        !!! Info "Keyword defaults"
-
-            ```python
-            {
-                "gfnff": True if use_gfnff else None,
-                "gwolf": True if use_gfnff and atoms.pbc.any() else None,
-            }
-            ```
     options
         Dictionary of custom `options` kwargs for the GULP calculator. Set a
         value to `None` to remove a pre-existing key entirely. For a list of
         available keys, refer to the `ase.calculators.gulp.GULP` calculator.
-
-        !!! Info "Option defaults"
-
-            ```python
-            {"dump every gulp.res": True}
-            ```
     library
         Filename of the potential library file, if required.
 
@@ -116,28 +101,10 @@ def relax_job(
         Dictionary of custom `keyword` kwargs for the GULP calculator. Set a
         value to `None` to remove a pre-existing key entirely. For a list of
         available keys, refer to the `ase.calculators.gulp.GULP` calculator.
-
-        !!! Info "Keyword defaults"
-
-            ```python
-            {
-                "opti": True,
-                "gfnff": True if use_gfnff else None,
-                "gwolf": True if use_gfnff and atoms.pbc.any() else None,
-                "conp": True if relax_cell and atoms.pbc.any() else None,
-                "conv": None if relax_cell and atoms.pbc.any() else True,
-            }
-            ```
     options
         Dictionary of custom `options` kwargs for the GULP calculator. Set a
         value to `None` to remove a pre-existing key entirely. For a list of
         available keys, refer to the `ase.calculators.gulp.GULP` calculator.
-
-        !!! Info "Option defaults"
-
-            ```python
-            {"dump every gulp.res": True}
-            ```
     library
         Filename of the potential library file, if required.
 

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -39,12 +39,6 @@ def static_job(atoms: Atoms, **calc_kwargs) -> RunSchema:
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.lj.LJ` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {}
-            ```
-
     Returns
     -------
     RunSchema
@@ -74,22 +68,10 @@ def relax_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
-            ```
     **calc_kwargs
         Custom kwargs for the LJ calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.lj.LJ` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {}
-            ```
 
     Returns
     -------
@@ -133,12 +115,6 @@ def freq_job(
         Dictionary of custom kwargs for the LJ calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.lj.LJ` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {}
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/newtonnet/core.py
+++ b/src/quacc/recipes/newtonnet/core.py
@@ -59,15 +59,6 @@ def static_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `newtonnet.utils.ase_interface.MLAseCalculator` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
-                "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
-            }
-            ```
-
     Returns
     -------
     RunSchema
@@ -109,27 +100,12 @@ def relax_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {"fmax": 0.01, "max_steps": 1000, "optimizer": Sella or FIRE}
-            ```
     copy_files
         Files to copy to the runtime directory.
     **calc_kwargs
         Dictionary of custom kwargs for the NewtonNet calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `newtonnet.utils.ase_interface.MLAseCalculator` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
-                "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
-            }
-            ```
 
     Returns
     -------
@@ -180,16 +156,6 @@ def freq_job(
         Custom kwargs for the NewtonNet calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `newtonnet.utils.ase_interface.MLAseCalculator` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
-                "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
-                "hess_method": "autograd",
-            }
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/newtonnet/ts.py
+++ b/src/quacc/recipes/newtonnet/ts.py
@@ -69,33 +69,10 @@ def ts_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {
-                "fmax": 0.01,
-                "max_steps": 1000,
-                "optimizer": Sella,
-                "optimizer_kwargs": {"diag_every_n": 0, "order": 1}
-                if use_custom_hessian
-                else {"order": 1},
-            }
-            ```
     **calc_kwargs
         Dictionary of custom kwargs for the NewtonNet calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `newtonnet.utils.ase_interface.MLAseCalculator` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
-                "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
-                "hess_method": "autograd",
-            }
-            ```
 
     Returns
     -------
@@ -174,38 +151,10 @@ def irc_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {
-                "fmax": 0.01,
-                "max_steps": 1000,
-                "optimizer": IRC,
-                "optimizer_kwargs": {
-                    "dx": 0.1,
-                    "eta": 1e-4,
-                    "gamma": 0.4,
-                    "keep_going": True,
-                },
-                "run_kwargs": {
-                    "direction": direction,
-                },
-            }
-            ```
     **calc_kwargs
         Custom kwargs for the NewtonNet calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `newtonnet.utils.ase_interface.MLAseCalculator` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "model_path": SETTINGS.NEWTONNET_MODEL_PATH,
-                "settings_path": SETTINGS.NEWTONNET_CONFIG_PATH,
-            }
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -55,34 +55,11 @@ def static_job(
         entries, set the value as True. To remove entries from the defaults, set
         the value as None. For a list of available keys, refer to the
         `ase.calculators.orca.ORCA` calculator.
-
-        !!! Info "Calculator `orcasimpleinput` defaults`"
-
-            ```python
-            {
-                xc: True,
-                basis: True,
-                "sp": True,
-                "slowconv": True,
-                "normalprint": True,
-                "xyzfile": True,
-            }
-            ```
     orcablocks
         Dictionary of `orcablocks` swaps for the calculator. To enable new entries,
         set the value as True. To remove entries from the defaults, set the
         value as None. For a list of available keys, refer to the
         `ase.calculators.orca.ORCA` calculator.
-
-        !!! Info "Calculator `orcablocks` defaults"
-
-            ```python
-            (
-                {f"%pal nprocs {multiprocessing.cpu_count()} end": True}
-                if which("mpirun")
-                else {}
-            )
-            ```
     copy_files
         Files to copy to the runtime directory.
 
@@ -153,35 +130,11 @@ def relax_job(
         entries, set the value as True. To remove entries from the defaults, set
         the value as None. For a list of available keys, refer to the
         `ase.calculators.orca.ORCA` calculator.
-
-        !!! Info "Calculator `orcasimpleinput` defaults"
-
-            ```python
-            {
-                xc: True,
-                basis: True,
-                "opt": True,
-                "slowconv": True,
-                "normalprint": True,
-                "freq": True if run_freq else None,
-                "xyzfile": True,
-            }
-            ```
     orcablocks
         Dictionary of `orcablocks` swaps for the calculator. To enable new entries,
         set the value as True. To remove entries from the defaults, set the
         value as None. For a list of available keys, refer to the
         `ase.calculators.orca.ORCA` calculator.
-
-        !!! Info "Calculator `orcablocks` defaults"
-
-            ```python
-            (
-                {f"%pal nprocs {multiprocessing.cpu_count()} end": True}
-                if which("mpirun")
-                else {}
-            )
-            ```
     copy_files
         Files to copy to the runtime directory.
 

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -57,20 +57,6 @@ def static_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `ase.calculators.psi4.Psi4` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "mem": "16GB",
-                "num_threads": "max",
-                "method": method,
-                "basis": basis,
-                "charge": charge,
-                "multiplicity": spin_multiplicity,
-                "reference": "uks" if spin_multiplicity > 1 else "rks",
-            }
-            ```
-
     Returns
     -------
     RunSchema

--- a/src/quacc/recipes/tblite/core.py
+++ b/src/quacc/recipes/tblite/core.py
@@ -46,12 +46,6 @@ def static_job(
         Custom kwargs for the TBLite calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `tblite.ase.TBLite` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {"method": method}
-            ```
     Returns
     -------
     RunSchema
@@ -94,22 +88,11 @@ def relax_job(
         Dictionary of custom kwargs for the optimization process. Set a value
         to `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to [quacc.runners.ase.run_opt][].
-
-        !!! Info "Optimizer defaults"
-
-            ```python
-            {"fmax": 0.01, "max_steps": 1000, "optimizer": FIRE}
-            ```
     **calc_kwargs
         Custom kwargs for the tblite calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `tblite.ase.TBLite` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {"method": method}
-            ```
     Returns
     -------
     OptSchema

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -44,20 +44,6 @@ def static_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "ismear": -5,
-                "laechg": True,
-                "lcharg": True,
-                "lreal": False,
-                "lwave": True,
-                "nedos": 5001,
-                "nsw": 0,
-            }
-            ```
-
     Returns
     -------
     VaspSchema
@@ -109,21 +95,6 @@ def relax_job(
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
-
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "ediffg": -0.02,
-                "isif": 3 if relax_cell else 2,
-                "ibrion": 2,
-                "isym": 0,
-                "lcharg": False,
-                "lwave": False,
-                "nsw": 200,
-                "symprec": 1e-8,
-            }
-            ```
 
     Returns
     -------

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -61,11 +61,6 @@ def mp_prerelax_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {"ediffg": -0.05, "xc": "pbesol", "lwave": True, "lcharg": True} | _get_bandgap_swaps(bandgap)
-            ```
     Returns
     -------
     VaspSchema
@@ -116,11 +111,6 @@ def mp_relax_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {"lcharg": True, "lwave": True} | _get_bandgap_swaps(bandgap)
-            ```
     Returns
     -------
     VaspSchema

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -40,21 +40,6 @@ def slab_static_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "auto_dipole": True,
-                "ismear": -5,
-                "laechg": True,
-                "lcharg": True,
-                "lreal": False,
-                "lvhar": True,
-                "lwave": True,
-                "nedos": 5001,
-                "nsw": 0,
-            }
-            ```
     Returns
     -------
     VaspSchema
@@ -105,21 +90,6 @@ def slab_relax_job(
         `None` to remove a pre-existing key entirely. For a list of available
         keys, refer to the `quacc.calculators.vasp.vasp.Vasp` calculator.
 
-        !!! Info "Calculator defaults"
-
-            ```python
-            {
-                "auto_dipole": True,
-                "ediffg": -0.02,
-                "isif": 2,
-                "ibrion": 2,
-                "isym": 0,
-                "lcharg": False,
-                "lwave": False,
-                "nsw": 200,
-                "symprec": 1e-8,
-            }
-            ```
     Returns
     -------
     VaspSchema


### PR DESCRIPTION
In principle, the idea was nice in that it would enable editors to show the default params by default. In practice, it's messy because things can accidentally become out of sync between the docstring and the code, and sometimes it's not practical to list all parameters in the docstring itself.