### PR TITLE
Upload coverage reports to codecov at the end, with retries

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,8 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        python-version: ["3.10"]
 
     defaults:
       run:
@@ -71,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -102,7 +100,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11"]
         wflow_engine: [dask, parsl, redun, jobflow]
 
     defaults:
@@ -116,7 +113,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -139,8 +136,6 @@ jobs:
   tests-psi4:
     strategy:
       fail-fast: true
-      matrix:
-        python-version: ["3.11"]
     runs-on: ubuntu-latest
 
     defaults:
@@ -154,7 +149,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -187,8 +182,6 @@ jobs:
   tests-defects-phonons:
     strategy:
       fail-fast: true
-      matrix:
-        python-version: ["3.11"]
     runs-on: ubuntu-latest
 
     defaults:
@@ -202,7 +195,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -231,8 +224,6 @@ jobs:
   tests-tblite-dftbplus:
     strategy:
       fail-fast: true
-      matrix:
-        python-version: ["3.11"]
     runs-on: ubuntu-latest
 
     defaults:
@@ -246,7 +237,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -278,8 +269,6 @@ jobs:
   tests-qchem-sella-newtonnet:
     strategy:
       fail-fast: true
-      matrix:
-        python-version: ["3.11"]
     runs-on: ubuntu-latest
 
     defaults:
@@ -293,7 +282,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ matrix.os }} ${{ matrix.python-version }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -93,7 +93,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -132,7 +132,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ matrix.wflow_engine }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -180,7 +180,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -224,7 +224,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -271,7 +271,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -318,7 +318,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }} coverage report
+          name: ${{ GITHUB_JOB }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,9 +46,12 @@ jobs:
       - name: Run tests with pytest
         run: pytest --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-covalent:
     runs-on: ubuntu-latest
@@ -87,9 +90,12 @@ jobs:
       - name: Stop Covalent server
         run: covalent stop
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-engines:
     runs-on: ubuntu-latest
@@ -123,9 +129,12 @@ jobs:
       - name: Run tests with pytest
         run: pytest tests/${{ matrix.wflow_engine }} --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-psi4:
     strategy:
@@ -168,9 +177,12 @@ jobs:
       - name: Run tests with pytest
         run: pytest -k 'psi4' --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-defects-phonons:
     strategy:
@@ -209,9 +221,12 @@ jobs:
       - name: Run tests with pytest
         run: pytest -k 'defects or phonon' --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-tblite-dftbplus:
     strategy:
@@ -253,9 +268,12 @@ jobs:
       - name: Run tests with pytest
         run: pytest -k 'dftb or tblite' --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
 
   tests-qchem-sella-newtonnet:
     strategy:
@@ -297,6 +315,28 @@ jobs:
       - name: Run tests with pytest
         run: pytest -k 'qchem or sella or newtonnet' --cov=quacc --cov-report=xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: github.repository == 'Quantum-Accelerators/quacc'
+      - name: Upload code coverage report to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }} coverage report
+          path: 'coverage.xml'
+          retention-days: 1
+
+  codecov:
+    needs: [tests-core,tests-covalent,tests-engines,tests-psi4,tests-defects-phonons,tests-qchem-sella-newtonnet]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage to Codecov.io
+        uses: Wandalen/wretry.action@v1.3.0
+        with:
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+          attempt_limit: 5
+          attempt_delay: 30000

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -93,7 +93,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -132,7 +132,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -180,7 +180,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -224,7 +224,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -271,7 +271,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -318,7 +318,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github,job }} ${{ RANDOM }} coverage report
+          name: ${{ github.job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ matrix.os }} ${{ matrix.python-version }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -93,7 +93,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -132,7 +132,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ matrix.wflow_engine }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -180,7 +180,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -224,7 +224,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -271,7 +271,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -318,7 +318,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} coverage report
+          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -93,7 +93,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -132,7 +132,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -180,7 +180,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -224,7 +224,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -271,7 +271,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 
@@ -318,7 +318,7 @@ jobs:
       - name: Upload code coverage report to Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ GITHUB_JOB }} ${{ RANDOM }} coverage report
+          name: ${{ github,job }} ${{ RANDOM }} coverage report
           path: 'coverage.xml'
           retention-days: 1
 


### PR DESCRIPTION
This fixes a super annoying Codecov bug where the uploader just fails randomly, causing erratic code coverage. To avoid that, we do one big codecov upload at the end, with retries enabled.