### PR TITLE
Update `phonon_job` in Espresso to be more intuitive

### DIFF
--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -8,6 +8,8 @@ from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso._base import base_fn
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ase.atoms import Atoms
 
     from quacc.schemas._aliases.ase import RunSchema
@@ -17,8 +19,8 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     preset: str | None = None,
-    copy_files: list[str] | None = None,
     parallel_info: dict[str] | None = None,
+    copy_files: str | Path | list[str | Path] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -32,6 +34,9 @@ def static_job(
         The name of a YAML file containing a list of parameters to use as
         a "preset" for the calculator. quacc will automatically look in the
         `ESPRESSO_PRESET_DIR` (default: quacc/calculators/espresso/presets).
+    parallel_info
+        Dictionary containing information about the parallelization of the
+        calculation. See the ASE documentation for more information.
     copy_files
         List of files to copy to the calculation directory. Useful for copying
         files from a previous calculation. This parameter can either be a string
@@ -44,9 +49,6 @@ def static_job(
         If a list of strings is provided, each string point to a specific file. In this case
         it is important to note that no directory structure is going to be copied, everything
         is copied at the root of the temporary directory.
-    parallel_info
-        Dictionary containing information about the parallelization of the
-        calculation. See the ASE documentation for more information.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. See the
         docstring of [quacc.calculators.espresso.espresso.Espresso][] for more information.
@@ -79,8 +81,8 @@ def static_job(
 
 @job
 def phonon_job(
+    prev_dir: str | Path,
     preset: str | None = None,
-    copy_files: str | list[str] | None = None,
     parallel_info: dict[str] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
@@ -89,22 +91,13 @@ def phonon_job(
 
     Parameters
     ----------
+    prev_dir
+        Previous directory where pw.x was run. This is used to copy the entire tree structure
+        of that directory to the working directory of this calculation.
     preset
         The name of a YAML file containing a list of parameters to use as
         a "preset" for the calculator. quacc will automatically look in the
         `ESPRESSO_PRESET_DIR` (default: quacc/calculators/espresso/presets).
-    copy_files
-        List of files to copy to the calculation directory. Almost always needed
-        for ph.x calculations. This parameter can either be a string or a list of
-        strings.
-
-        If a string is provided, it is assumed to be a path to a directory,
-        all of the child tree structure of that directory is going to be copied to the
-        scratch of this calculation. For phonon_job this is what most users will want to do.
-
-        If a list of strings is provided, each string point to a specific file. In this case
-        it is important to note that no directory structure is going to be copied, everything
-        is copied at the root of the temporary directory.
     parallel_info
         Dictionary containing information about the parallelization of the
         calculation. See the ASE documentation for more information.
@@ -142,5 +135,5 @@ def phonon_job(
         calc_swaps=calc_kwargs,
         parallel_info=parallel_info,
         additional_fields={"name": "ph.x Phonon"},
-        copy_files=copy_files,
+        copy_files=prev_dir,
     )

--- a/tests/core/recipes/espresso_recipes/test_espresso.py
+++ b/tests/core/recipes/espresso_recipes/test_espresso.py
@@ -198,7 +198,7 @@ def test_phonon_job(tmp_path, monkeypatch):
         atoms, input_data=input_data, pseudopotentials=pseudopotentials, kspacing=0.25
     )
 
-    ph_results = phonon_job(input_data=ph_loose, copy_files=pw_results["dir_name"])
+    ph_results = phonon_job(pw_results["dir_name"], input_data=ph_loose)
 
     assert (0, 0, 0) in ph_results["results"]
     assert np.allclose(
@@ -253,8 +253,8 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch):
     nat_todo = [1]
 
     ph_results = phonon_job(
+        pw_results["dir_name"]
         input_data=ph_loose,
-        copy_files=pw_results["dir_name"],
         qpts=qpts,
         nat_todo=nat_todo,
     )

--- a/tests/core/recipes/espresso_recipes/test_espresso.py
+++ b/tests/core/recipes/espresso_recipes/test_espresso.py
@@ -253,7 +253,7 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch):
     nat_todo = [1]
 
     ph_results = phonon_job(
-        pw_results["dir_name"]
+        pw_results["dir_name"],
         input_data=ph_loose,
         qpts=qpts,
         nat_todo=nat_todo,

--- a/tests/core/recipes/espresso_recipes/test_espresso.py
+++ b/tests/core/recipes/espresso_recipes/test_espresso.py
@@ -253,10 +253,7 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch):
     nat_todo = [1]
 
     ph_results = phonon_job(
-        pw_results["dir_name"],
-        input_data=ph_loose,
-        qpts=qpts,
-        nat_todo=nat_todo,
+        pw_results["dir_name"], input_data=ph_loose, qpts=qpts, nat_todo=nat_todo
     )
 
     assert (0, 0, 0) in ph_results["results"]


### PR DESCRIPTION
1. Require the use of a prior path (i.e. make it an arg, not a kwarg)
2. Rename the argument to `prev_dir`
3. Make it be a full folder to unpack, i.e. don't bother allowing individual files

To be merged alongside #1404.