### PR TITLE
Implement a minimal preset for Espresso

### DIFF
--- a/src/quacc/calculators/espresso/presets/basic.yaml
+++ b/src/quacc/calculators/espresso/presets/basic.yaml
@@ -1,0 +1,10 @@
+# Last modified: 12-27-2023
+
+input_data:
+  system:
+    occupations: smearing
+    degauss: 0.001
+
+kspacing: 0.03
+
+parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @job
 def static_job(
     atoms: Atoms,
-    preset: str | None = None,
+    preset: str | None = "basic",
     parallel_info: dict[str] | None = None,
     copy_files: str | Path | list[str | Path] | None = None,
     **calc_kwargs,
@@ -59,13 +59,7 @@ def static_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
 
-    calc_defaults = {
-        "input_data": {
-            "control": {"calculation": "scf", "restart_mode": "from_scratch"},
-            "system": {"ecutwfc": 60, "ecutrho": 240},
-            "electrons": {"conv_thr": 1e-8, "mixing_mode": "plain", "mixing_beta": 0.7},
-        }
-    }
+    calc_defaults = {"input_data": {"control": {"calculation": "scf"}}}
 
     return base_fn(
         atoms,

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @job
 def phonon_job(
     prev_dir: str | Path,
-    preset: str | None = None,
+    preset: str | None = "basic",
     parallel_info: dict[str] | None = None,
     **calc_kwargs,
 ) -> RunSchema:

--- a/tests/core/recipes/espresso_recipes/test_espresso.py
+++ b/tests/core/recipes/espresso_recipes/test_espresso.py
@@ -16,8 +16,36 @@ pytestmark = pytest.mark.skipif(which("pw.x") is None, reason="QE not installed"
 DEFAULT_SETTINGS = SETTINGS.model_copy()
 
 
-
 def test_static_job(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    pp_dir = Path(__file__).parent
+
+    copy_decompress_files([pp_dir / "Si.upf.gz"], tmp_path)
+
+    atoms = bulk("Si")
+
+    pseudopotentials = {"Si": "Si.upf"}
+    input_data = {"control": {"pseudo_dir": tmp_path}}
+
+    results = static_job(
+        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kspacing=0.5
+    )
+
+    assert np.allclose(results["atoms"].positions, atoms.positions, atol=1.0e-4)
+
+    assert np.allclose(results["atoms"].cell, atoms.cell, atol=1.0e-3)
+    assert (results["atoms"].symbols == atoms.symbols).all()
+
+    new_input_data = results["parameters"]["input_data"]
+
+    assert new_input_data["system"]["degauss"] == 0.001
+    assert new_input_data["system"]["occupations"] == "smearing"
+    assert new_input_data["system"]["ecutwfc"] == 30.0
+    assert new_input_data["system"]["ecutrho"] == 240.0
+
+
+def test_static_job_v2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     pp_dir = Path(__file__).parent

--- a/tests/core/recipes/espresso_recipes/test_espresso.py
+++ b/tests/core/recipes/espresso_recipes/test_espresso.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.skipif(which("pw.x") is None, reason="QE not installed"
 DEFAULT_SETTINGS = SETTINGS.model_copy()
 
 
+
 def test_static_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
Closes #1412. Also, I removed default parameters like `ecutwfc` and `ecutrho`, which should not be in the recipe defaults since they would be the same defaults for every recipe. The recipe defaults should have the minimal info needed to run a reliable calculation for that calculation type; we can put a default preset ("minimal.yaml") that will automatically set `ecutwfc` and `ecutrho` to the max value based on the pseudopotential YAML instead.
