### PR TITLE
Espresso: the nested come back

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -9,7 +9,12 @@ from ase.calculators.espresso import Espresso as Espresso_
 from ase.calculators.espresso import EspressoProfile
 from ase.calculators.espresso import EspressoTemplate as EspressoTemplate_
 from ase.io import read, write
-from ase.io.espresso import read_espresso_ph, write_espresso_ph, write_fortran_namelist
+from ase.io.espresso import (
+    Namelist,
+    read_espresso_ph,
+    write_espresso_ph,
+    write_fortran_namelist,
+)
 
 from quacc import SETTINGS
 from quacc.calculators.espresso.utils import get_pseudopotential_info
@@ -276,10 +281,15 @@ class Espresso(Espresso_):
         if self.kwargs.get("directory"):
             raise ValueError("quacc does not support the directory argument.")
 
+        self.kwargs["input_data"] = Namelist(self.kwargs.get("input_data"))
+        self.kwargs["input_data"].to_nested(binary=self._binary, **self.kwargs)
+
         if self.preset:
             calc_preset = load_yaml_calc(
                 SETTINGS.ESPRESSO_PRESET_DIR / f"{self.preset}"
             )
+            calc_preset["input_data"] = Namelist(calc_preset.get("input_data"))
+            calc_preset["input_data"].to_nested(binary=self._binary, **calc_preset)
             if "pseudopotentials" in calc_preset:
                 ecutwfc, ecutrho, pseudopotentials = get_pseudopotential_info(
                     calc_preset["pseudopotentials"], self.input_atoms

--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -13,6 +13,7 @@ from quacc.calculators.espresso.espresso import (
 from quacc.runners.ase import run_calc
 from quacc.schemas.ase import summarize_run
 from quacc.utils.dicts import recursive_dict_merge
+from ase.io.espresso import Namelist
 
 if TYPE_CHECKING:
     from typing import Any
@@ -64,6 +65,15 @@ def base_fn(
     """
 
     atoms = Atoms() if atoms is None else atoms
+
+    calc_defaults = Namelist(calc_defaults)
+    calc_swaps = Namelist(calc_swaps)
+
+    binary = template.binary if template else "pw"
+
+    calc_defaults.to_nested(binary = binary)
+    calc_swaps.to_nested(binary = binary)
+
     calc_flags = recursive_dict_merge(calc_defaults, calc_swaps, allowed_nones=["kpts"])
 
     atoms.calc = Espresso(

--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ase import Atoms
+from ase.io.espresso import Namelist
 
 from quacc.calculators.espresso.espresso import (
     Espresso,
@@ -13,7 +14,6 @@ from quacc.calculators.espresso.espresso import (
 from quacc.runners.ase import run_calc
 from quacc.schemas.ase import summarize_run
 from quacc.utils.dicts import recursive_dict_merge
-from ase.io.espresso import Namelist
 
 if TYPE_CHECKING:
     from typing import Any
@@ -66,13 +66,13 @@ def base_fn(
 
     atoms = Atoms() if atoms is None else atoms
 
-    calc_defaults = Namelist(calc_defaults)
-    calc_swaps = Namelist(calc_swaps)
+    calc_defaults["input_data"] = Namelist(calc_defaults.get("input_data"))
+    calc_swaps["input_data"] = Namelist(calc_swaps.get("input_data"))
 
     binary = template.binary if template else "pw"
 
-    calc_defaults.to_nested(binary = binary)
-    calc_swaps.to_nested(binary = binary)
+    calc_defaults["input_data"].to_nested(binary=binary, **calc_defaults)
+    calc_swaps["input_data"].to_nested(binary=binary, **calc_swaps)
 
     calc_flags = recursive_dict_merge(calc_defaults, calc_swaps, allowed_nones=["kpts"])
 

--- a/src/quacc/utils/dicts.py
+++ b/src/quacc/utils/dicts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from typing import TYPE_CHECKING
+from collections.abc import MutableMapping
 
 if TYPE_CHECKING:
     from typing import Any
@@ -41,8 +42,8 @@ def recursive_dict_merge(
 
 
 def _recursive_dict_pair_merge(
-    dict1: dict[str, Any] | None, dict2: dict[str, Any] | None
-) -> dict[str, Any]:
+    dict1: MutableMapping[str, Any] | None, dict2: MutableMapping[str, Any] | None
+) -> MutableMapping[str, Any]:
     """
     Recursively merges two dictionaries. If one of the inputs is `None`, then it is
     treated as `{}`.
@@ -63,13 +64,16 @@ def _recursive_dict_pair_merge(
     dict
         Merged dictionary
     """
-    dict1 = dict1 or {}
-    dict2 = dict2 or {}
+
+    dict1 = dict1 or (dict1.__class__() if dict1 is not None else {})
+    dict2 = dict2 or (dict2.__class__() if dict2 is not None else {})
     merged = safe_dict_copy(dict1)
 
     for key, value in dict2.items():
         if key in merged:
-            if isinstance(merged[key], dict) and isinstance(value, dict):
+            if isinstance(merged[key], MutableMapping) and isinstance(
+                value, MutableMapping
+            ):
                 merged[key] = _recursive_dict_pair_merge(merged[key], value)
             else:
                 merged[key] = value


### PR DESCRIPTION
## Requirements

### Checklist

- [ ] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).

## Summary of Changes

Ok, this is getting a little bit silly... The flat/nested form not being the problem, the most annoying is the possibility for any kwargs to be a keyword...

Without thinking about that (I never use the ASE calculator this way) I named one of the parameters in ase.io.espresso.write_espresso_ph, to the name of one of the ph.x parameters, which is conflicting now (you will see the test fail). I will need to open a small patch on the ASE main to change the name...

This also try to extend the recursive_dict_merge to any dict-like (UserDict, defaultdict, OrderedDict, Namelist) object and allow to conserve the class even if they are nested.
