### PR TITLE
Avoid surprises deleting dense k-spacing from basic_pw preset

### DIFF
--- a/src/quacc/calculators/espresso/presets/basic_pw.yaml
+++ b/src/quacc/calculators/espresso/presets/basic_pw.yaml
@@ -1,10 +1,10 @@
-# Last modified: 12-27-2023
+# Last modified: 04-01-2024
 
 input_data:
   system:
     occupations: smearing
-    degauss: 0.001
+    degauss: 0.005
 
-kspacing: 0.03
+kspacing: gamma
 
 parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml

--- a/src/quacc/calculators/espresso/presets/basic_pw.yaml
+++ b/src/quacc/calculators/espresso/presets/basic_pw.yaml
@@ -5,6 +5,6 @@ input_data:
     occupations: smearing
     degauss: 0.005
 
-kspacing: gamma
+kpts: gamma
 
 parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml


### PR DESCRIPTION
Situation: A user is used to the ASE espresso calculator and wants to run a very large isolated system in a big box. The user doesn't set any kpts because they are used to Gamma being the default. Instead, quacc set a very high kspacing, which in this case will ruin the calculation.

This patch aims to avoid that.

## Summary of Changes

\>> Provide a description of your changes here, linking to any associated issue reports. <<

## Requirements

### Checklist

- [ ] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
