### PR TITLE
Support intelligent default k-point handling in Espresso calculator and default preset

### DIFF
--- a/src/quacc/calculators/espresso/__init__.py
+++ b/src/quacc/calculators/espresso/__init__.py
@@ -1,1 +1,5 @@
 """Enhanced version of the ASE Espresso calculator."""
+
+from quacc.calculators.espresso.espresso import Espresso
+
+__all__ = ["Espresso"]

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -64,7 +64,7 @@ class EspressoTemplate(EspressoTemplate_):
         properties: Any,
     ) -> None:
         """
-        The function that should be used instead of the one in ASE EspressoTemplate
+        The function that should be used instead of the one in ASE's `EspressoTemplate`
         to write the input file. It calls a customly defined write function.
 
         Parameters
@@ -108,7 +108,7 @@ class EspressoTemplate(EspressoTemplate_):
 
     def read_results(self, directory: Path | str) -> dict[str, Any]:
         """
-        The function that should be used instead of the one in ASE EspressoTemplate
+        The function that should be used instead of the one in ASE's `EspressoTemplate`
         to read the output file. It calls a customly defined read function. It also
         adds the "energy" key to the results dictionnary if it is not present. This
         is needed if the calculation is not made with pw.x.
@@ -183,7 +183,7 @@ class EspressoTemplate(EspressoTemplate_):
 
 class Espresso(Espresso_):
     """
-    This is a wrapper around the ASE Espresso calculator that adjusts input_data
+    This is a wrapper around the ASE `Espresso` calculator that adjusts input_data
     parameters and allows for the use of presets. Templates are used to set
     the binary and input/output file names.
     """

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -325,6 +325,8 @@ class Espresso(Espresso_):
             kpts, _ = convert_pmg_kpts(
                 self._user_calc_params["pmg_kpts"], self.input_atoms
             )
+            if kpts == [1, 1, 1]:
+                kpts = None
             self._user_calc_params["kpts"] = kpts
             self._user_calc_params.pop("pmg_kpts")
 

--- a/src/quacc/calculators/espresso/presets/basic_pw.yaml
+++ b/src/quacc/calculators/espresso/presets/basic_pw.yaml
@@ -5,6 +5,7 @@ input_data:
     occupations: smearing
     degauss: 0.001
 
-kspacing: 0.03
+pmg_kpts:
+  kppvol: 100
 
 parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml

--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -189,6 +189,10 @@ def test_pmg_kpts():
     calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
     assert calc.parameters["kpts"] == [12, 12, 12]
 
+    atoms = bulk("Cu") * (10, 10, 10)
+    calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
+    assert calc.parameters["kpts"] is None
+
     atoms = bulk("Cu")
     calc = Espresso(input_atoms=atoms, preset="basic_pw")
     assert calc.parameters["kpts"] == [12, 12, 12]

--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from ase import Atoms
+from ase.build import bulk
 
 from quacc.calculators.espresso.espresso import Espresso, EspressoTemplate
 
@@ -181,3 +182,17 @@ def test_bad_calculator_params():
 
     with pytest.raises(ValueError):
         Espresso(input_atoms=atoms, kpts=(1, 1, 1), directory="bad")
+
+
+def test_pmg_kpts():
+    atoms = bulk("Cu")
+    calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
+    assert calc.parameters["kpts"] == [12, 12, 12]
+
+    atoms = bulk("Cu")
+    calc = Espresso(input_atoms=atoms, preset="basic_pw")
+    assert calc.parameters["kpts"] == [12, 12, 12]
+
+    atoms = bulk("Cu")
+    calc = Espresso(input_atoms=atoms, kpts=[1, 1, 1], preset="basic_pw")
+    assert calc.parameters["kpts"] == [1, 1, 1]


### PR DESCRIPTION
## Summary of Changes

In this PR, I propose the addition of a keyword argument in the `Espresso` calculator that permits "intelligent" on-the-fly decision making for the `kpts` setting, meant for automated workflows. This new parameter supports all the Pymatgen automated k-point generation schemes, including those based on normalization by lattice parameters (`kppvol`) or number of atoms (`kppa`) among others that are commonly used on the Materials Project.

An example:

```python
from ase.build import bulk
from quacc.calculators.espresso import Espresso

atoms = bulk("Cu")
calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
print(calc.parameters["kpts"]) # [12, 12, 12] since it's a very small cell

atoms = bulk("Cu") * (4, 4, 4)
calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
print(calc.parameters["kpts"]) # [3, 3, 3] since it's a larger cell

atoms = bulk("Cu") * (10, 10, 10)
calc = Espresso(input_atoms=atoms, pmg_kpts={"kppvol": 100})
print(calc.parameters["kpts"]) # `None` since it's a huge cell; uses `None` over `[1, 1, 1]`
```

With this in place, I also propose adding

```yaml
pmg_kpts:
  kppvol: 100
```

to the default preset to improve the user experience and provide a sensible default. Personally, I would strongly encourage all presets to have some k-point information (ideally based on one of the provided, automated mechanisms like `kppvol` or otherwise) so users have a practical default for calculations.

## Requirements

### Checklist

- [X] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
