### PR TITLE
More Espresso cleanup

### DIFF
--- a/src/quacc/calculators/espresso/__init__.py
+++ b/src/quacc/calculators/espresso/__init__.py
@@ -1,1 +1,5 @@
 """Enhanced version of the ASE Espresso calculator."""
+
+from quacc.calculators.espresso.espresso import Espresso
+
+__all__ = ["Espresso"]

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -304,9 +304,6 @@ class Espresso(Espresso_):
         else:
             self._user_calc_params = self.kwargs
 
-        if self._user_calc_params.get("kpts") == "gamma":
-            self._user_calc_params["kpts"] = None
-
         if self._user_calc_params.get("kpts") and self._user_calc_params.get(
             "kspacing"
         ):

--- a/src/quacc/calculators/espresso/presets/molecule_efficiency.yaml
+++ b/src/quacc/calculators/espresso/presets/molecule_efficiency.yaml
@@ -9,6 +9,6 @@ input_data:
     mixing_mode: local-TF
     mixing_beta: 0.35
 
-kpts: gamma
+kpts: null
 
 parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml

--- a/src/quacc/calculators/espresso/presets/tough_metal_clusters_efficiency.yaml
+++ b/src/quacc/calculators/espresso/presets/tough_metal_clusters_efficiency.yaml
@@ -24,6 +24,6 @@ input_data:
     bfgs_ndim: 6
     upscale: 1000
 
-kpts: gamma
+kpts: null
 
 parent_pseudopotentials: sssp_1.3.0_pbe_efficiency.yaml


### PR DESCRIPTION
## Summary of Changes

1. Allow `Espresso` to be imported as `from quacc.calculators.espresso import Espresso`
2. Remove support for `kpts="gamma"` since the user can just be using the ASE-supported `kpts=None`. In a YAML, `None` is represented as `null` so it's fine there too. There used to be some awkwardness in quacc about dict merging and `None`s, but that's a thing of the past.

## Requirements

### Checklist

- [X] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
