### PR TITLE
Remove `.compute()` in Dask subflow

### DIFF
--- a/docs/user/basics/wflow_decorators.md
+++ b/docs/user/basics/wflow_decorators.md
@@ -58,7 +58,7 @@ A `#!Python @subflow` in quacc is any workflow that returns a list of job output
     | ------------------- | --------------------------------- |
     | `#!Python @job`     | `#!Python @delayed`               |
     | `#!Python @flow`    | No effect                         |
-    | `#!Python @subflow` | `#!Python delayed(...).compute()` |
+    | `#!Python @subflow` | `#!Python @delayed`               |
 
     </center>
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -376,7 +376,7 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
         def workflow(a, b, c):
             result1 = add(a, b)
             result2 = make_more(result1)
-            return add_distributed(result2, c).compute()
+            return add_distributed(result2, c)
 
         workflow(1, 2, 3)
         ```
@@ -428,40 +428,6 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
     """
     from quacc import SETTINGS
 
-    @wraps(_func)
-    def _inner(
-        *f_args, decorator_kwargs: dict[str, Any] | None = None, **f_kwargs
-    ) -> Any:
-        """
-        This function is used for handling workflow engines that require some action
-        beyond just decoration. It also patches the parent function `_func` to take an
-        additional keyword argument, `deocrator_kwargs`, that is a dictionary of keyword
-        arguments to pass during the decorator construction.
-
-        Parameters
-        ----------
-        *f_args
-            Positional arguments to the function, if any.
-        decorator_kwargs
-            Keyword arguments to pass to the workflow engine decorator.
-        **f_kwargs
-            Keyword arguments to the function, if any.
-
-        Returns
-        -------
-        Any
-            The output of the @job-decorated function.
-        """
-        decorator_kwargs = decorator_kwargs if decorator_kwargs is not None else kwargs
-
-        if SETTINGS.WORKFLOW_ENGINE == "dask":
-            from dask import delayed
-
-            decorated = delayed(_func, **decorator_kwargs)
-            return decorated(*f_args, **f_kwargs).compute()
-        else:
-            raise NotImplementedError("Only Dask is supported for this inner function.")
-
     if _func is None:
         return partial(subflow, **kwargs)
 
@@ -478,6 +444,8 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
 
         return redun_task(_func, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "dask":
-        return _inner
+        from dask import delayed
+
+        return delayed(_func, **kwargs)
     else:
         return _func

--- a/tests/dask/test_dask_syntax.py
+++ b/tests/dask/test_dask_syntax.py
@@ -44,7 +44,7 @@ def test_dask_decorators(tmp_path, monkeypatch):
     assert client.compute(add(1, 2)).result() == 3
     assert client.compute(mult(1, 2)).result() == 2
     assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert dask.compute(*client.gather(dynamic_workflow(1, 2, 3))) == (6, 6, 6)
+    assert client.gather(client.compute(dynamic_workflow(1, 2, 3))) == [6, 6, 6]
 
 
 def test_strip_decorators():

--- a/tests/dask/test_dask_syntax.py
+++ b/tests/dask/test_dask_syntax.py
@@ -28,23 +28,23 @@ def test_dask_decorators(tmp_path, monkeypatch):
         return [val] * 3
 
     @subflow
-    def add_distributed(vals, c):
-        return [add(val, c) for val in vals]
+    def add_distributed(vals, c, op):
+        return [op(val, c) for val in vals]
 
     @flow
     def workflow(a, b, c):
         return mult(add(a, b), c)
 
     @flow
-    def dynamic_workflow(a, b, c):
+    def dynamic_workflow(a, b, c, op):
         result1 = add(a, b)
         result2 = make_more(result1)
-        return add_distributed(result2, c)
+        return add_distributed(result2, c, op)
 
     assert client.compute(add(1, 2)).result() == 3
     assert client.compute(mult(1, 2)).result() == 2
     assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert client.gather(client.compute(dynamic_workflow(1, 2, 3))) == [6, 6, 6]
+    assert client.gather(client.compute(dynamic_workflow(1, 2, 3, add))) == [6, 6, 6]
 
 
 def test_strip_decorators():

--- a/tests/dask/test_dask_syntax.py
+++ b/tests/dask/test_dask_syntax.py
@@ -47,41 +47,6 @@ def test_dask_decorators(tmp_path, monkeypatch):
     assert dask.compute(*client.gather(dynamic_workflow(1, 2, 3))) == (6, 6, 6)
 
 
-def test_dask_decorators_args(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-
-    @job()
-    def add(a, b):
-        return a + b
-
-    @job()
-    def mult(a, b):
-        return a * b
-
-    @job()
-    def make_more(val):
-        return [val] * 3
-
-    @subflow()
-    def add_distributed(vals, c, op):
-        return [op(val, c) for val in vals]
-
-    @flow()
-    def workflow(a, b, c):
-        return mult(add(a, b), c)
-
-    @flow()
-    def dynamic_workflow(a, b, c, op):
-        result1 = add(a, b)
-        result2 = make_more(result1)
-        return add_distributed(result2, c, op)
-
-    assert client.compute(add(1, 2)).result() == 3
-    assert client.compute(mult(1, 2)).result() == 2
-    assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert client.gather(client.compute(dynamic_workflow(1, 2, 3, add))) == [6, 6, 6]
-
-
 def test_strip_decorators():
     @job
     def add(a, b):

--- a/tests/dask/test_dask_syntax.py
+++ b/tests/dask/test_dask_syntax.py
@@ -63,23 +63,23 @@ def test_dask_decorators_args(tmp_path, monkeypatch):
         return [val] * 3
 
     @subflow()
-    def add_distributed(vals, c):
-        return [add(val, c) for val in vals]
+    def add_distributed(vals, c, op):
+        return [op(val, c) for val in vals]
 
     @flow()
     def workflow(a, b, c):
         return mult(add(a, b), c)
 
     @flow()
-    def dynamic_workflow(a, b, c):
+    def dynamic_workflow(a, b, c, op):
         result1 = add(a, b)
         result2 = make_more(result1)
-        return add_distributed(result2, c)
+        return add_distributed(result2, c, op)
 
     assert client.compute(add(1, 2)).result() == 3
     assert client.compute(mult(1, 2)).result() == 2
     assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert dask.compute(*client.gather(dynamic_workflow(1, 2, 3))) == (6, 6, 6)
+    assert client.gather(client.compute(dynamic_workflow(1, 2, 3, add))) == [6, 6, 6]
 
 
 def test_strip_decorators():


### PR DESCRIPTION
## Summary of Changes

Closes #1470.

## Requirements

### Checklist

- [X] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
