### PR TITLE
Clean up Dask documentation

### DIFF
--- a/docs/user/wflow_engine/wflow_engines1.md
+++ b/docs/user/wflow_engine/wflow_engines1.md
@@ -249,16 +249,12 @@ graph LR
     atoms = bulk("Cu")
 
     # Define the workflow
-    delayed = bulk_to_slabs_flow(atoms)  # (1)!
+    delayed = bulk_to_slabs_flow(atoms)
 
     # Print the results
-    result = client.gather(client.compute(delayed))  # (2)!
+    result = client.compute(delayed).result()
     print(result)
     ```
-
-    1. This has type `List[Delayed]`.
-
-    2. Running `#!Python client.compute(List[Delayed])` yields a `#!Python List[Future]` object. Calling `#!Python client.gather(List[Future])` will resolve the outputs from multiple `Future` objects. As an alternative, you could also do `#!Python result = dask.compute(delayed)[0]`, where the `[0]` indexing is needed because `#!Python dask.compute` always returns a tuple even when there is only one result.
 
 === "Redun"
 

--- a/docs/user/wflow_engine/wflow_engines2.md
+++ b/docs/user/wflow_engine/wflow_engines2.md
@@ -558,7 +558,7 @@ graph LR
     delayed = workflow(atoms)
 
     # Fetch the results
-    result = client.gather(client.compute(delayed))
+    result = client.compute(delayed).result()
     print(result)
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ exclude_also = [
   "if TYPE_CHECKING:",
   "if __name__ == .__main__.:",
   "except ImportError:",
-  "with worker_client() as client:",
 ]
 
 [tool.ruff]

--- a/tests/dask/test_dask_recipes.py
+++ b/tests/dask/test_dask_recipes.py
@@ -23,7 +23,7 @@ def test_dask_functools(tmp_path, monkeypatch):
     delayed = bulk_to_slabs_flow(
         atoms, job_params={"relax_job": {"opt_params": {"fmax": 0.1}}}, run_static=False
     )
-    result = client.gather(client.compute(delayed))
+    result = client.compute(delayed).result()
     assert len(result) == 4
     assert "atoms" in result[-1]
     assert result[-1]["fmax"] == 0.1

--- a/tests/dask/test_dask_syntax.py
+++ b/tests/dask/test_dask_syntax.py
@@ -55,8 +55,8 @@ def test_dask_decorators(tmp_path, monkeypatch):
     assert client.compute(add(1, 2)).result() == 3
     assert client.compute(mult(1, 2)).result() == 2
     assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert client.gather(client.compute(dynamic_workflow(1, 2, 3))) == [6, 6, 6]
-    assert client.gather(client.compute(dynamic_workflow2(1, 2, 3))) == [6, 6, 6]
+    assert client.compute(dynamic_workflow(1, 2, 3)).result() == [6, 6, 6]
+    assert client.compute(dynamic_workflow2(1, 2, 3)).result() == [6, 6, 6]
 
 
 def test_dask_decorators_args(tmp_path, monkeypatch):
@@ -101,8 +101,8 @@ def test_dask_decorators_args(tmp_path, monkeypatch):
     assert client.compute(add(1, 2)).result() == 3
     assert client.compute(mult(1, 2)).result() == 2
     assert client.compute(workflow(1, 2, 3)).result() == 9
-    assert client.gather(client.compute(dynamic_workflow(1, 2, 3))) == [6, 6, 6]
-    assert client.gather(client.compute(dynamic_workflow2(1, 2, 3))) == [6, 6, 6]
+    assert client.compute(dynamic_workflow(1, 2, 3)).result() == [6, 6, 6]
+    assert client.compute(dynamic_workflow2(1, 2, 3)).result() == [6, 6, 6]
 
 
 def test_strip_decorators():
@@ -160,5 +160,5 @@ def test_customize_funcs(monkeypatch, tmp_path):
     add_ = update_parameters(add, {"b": 3}, decorator="job")
     dynamic_workflow_ = update_parameters(dynamic_workflow, {"c": 4}, decorator="flow")
     assert client.compute(add_(1)).result() == 4
-    assert client.gather(client.compute(dynamic_workflow_(1, 2))) == [7, 7, 7]
-    assert client.gather(client.compute(test_dynamic_workflow(1, 2))) == [7, 7, 7]
+    assert client.compute(dynamic_workflow_(1, 2)).result() == [7, 7, 7]
+    assert client.compute(test_dynamic_workflow(1, 2)).result() == [7, 7, 7]

--- a/tests/dask/test_dask_tutorials.py
+++ b/tests/dask/test_dask_tutorials.py
@@ -27,7 +27,6 @@ def test_tutorial1a(tmp_path, monkeypatch):
 
     # Print result
     assert "atoms" in client.compute(delayed).result()  # (2)!
-    assert "atoms" in delayed.compute()
     assert "atoms" in dask.compute(delayed)[0]
 
 
@@ -50,8 +49,7 @@ def test_tutorial1b(tmp_path, monkeypatch):
     delayed = bulk_to_slabs_flow(atoms)  # (1)!
 
     # Print the results
-    assert "atoms" in client.gather(client.compute(delayed))[0]
-    assert "atoms" in dask.compute(delayed)[0][0]
+    assert "atoms" in client.compute(delayed).result()[0]
 
 
 def test_tutorial2a(tmp_path, monkeypatch):
@@ -118,7 +116,7 @@ def test_tutorial2c(tmp_path, monkeypatch):
     delayed = workflow(atoms)
 
     # Fetch the results
-    result = client.gather(client.compute(delayed))
+    result = client.compute(delayed).result()
 
     # Print the results
     assert len(result) == 4


### PR DESCRIPTION
## Summary of Changes

Dask documentation cleanup as a result of the new `@subflow` method.

## Requirements

### Checklist

- [x] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [x] My PR is on a custom branch and is _not_ named `main`.
- [x] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [x] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
