### PR TITLE
Proposal/Attempt: supercharge external optimizers to allow running additional actions.

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -229,8 +229,6 @@ class EspressoTemplate(EspressoTemplate_):
                     path.mkdir(parents=True, exist_ok=True)
                     input_data[section][d_key] = path
 
-        self.outdirs = [path for path in self.outdirs.values() if path is not None]
-
         parameters["input_data"] = input_data
 
         return parameters

--- a/src/quacc/calculators/espresso/opt_patchs.py
+++ b/src/quacc/calculators/espresso/opt_patchs.py
@@ -20,9 +20,7 @@ class PostProcessingPatch:
         post_processing_job_params = self._calc_kwargs.get("post_processing_params", {})
         forced_params = {
             "input_data": {
-                "input_pp": {
-                    "fileout": f"pseudo_charge_density_{self.nsteps}.cube"
-                }
+                "plot": {"fileout": f"pseudo_charge_density_{self.nsteps}.cube"}
             }
         }
         self._calc_kwargs["post_processing_params"] = recursive_dict_merge(

--- a/src/quacc/calculators/espresso/opt_patchs.py
+++ b/src/quacc/calculators/espresso/opt_patchs.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from quacc.recipes.espresso.core import post_processing_job
+
+
+class PostProcessingPatch:
+    job_names = ["post_processing"]
+
+    def __init__(self, **calc_kwargs):
+        self._results = {job_name: {} for job_name in self.job_names}
+        self._calc_kwargs = calc_kwargs
+
+    def step(self, *args, **kwargs):
+        super().step(*args, **kwargs)
+        # Would this cause issues because everything is ran asynchrously?
+        # If the opt is fast compared to the post-processing, file could be
+        # overwritten while being copied or something like that?
+        # How to redecorate here?
+        self._results["post_processing"][self.nsteps] = post_processing_job(
+            prev_dir=Path().cwd(), **self._calc_kwargs.get("post_processing_params", {})
+        )
+
+
+class SchemaPatch:
+
+    """Base class to patch an ASE optimizer. By modifying methods below,
+    you can 'patch' an optimizer to perform custom actions at specific moment of
+    the simulation"""
+
+    job_names = []
+
+    def __init__(self, **calc_kwargs):
+        self._results = {job_name: {} for job_name in self.job_names}
+        self._calc_kwargs = calc_kwargs
+
+    def step(self, *args, **kwargs):
+        super().step(*args, **kwargs)
+
+    def run(self, *args, **kwargs):
+        super().run(*args, **kwargs)
+
+    def converged(self, *args, **kwargs):
+        super().converged(*args, **kwargs)

--- a/src/quacc/calculators/espresso/opt_patchs.py
+++ b/src/quacc/calculators/espresso/opt_patchs.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from quacc.recipes.espresso.core import post_processing_job
+from quacc.utils.dicts import recursive_dict_merge
 
 
 class PostProcessingPatch:
@@ -16,6 +17,17 @@ class PostProcessingPatch:
         # If the opt is fast compared to the post-processing, file could be
         # overwritten while being copied or something like that?
         # How to redecorate here?
+        post_processing_job_params = self._calc_kwargs.get("post_processing_params", {})
+        forced_params = {
+            "input_data": {
+                "input_pp": {
+                    "fileout": f"pseudo_charge_density_{self.nsteps}.cube"
+                }
+            }
+        }
+        self._calc_kwargs["post_processing_params"] = recursive_dict_merge(
+            post_processing_job_params, forced_params
+        )
         self._results["post_processing"][self.nsteps] = post_processing_job(
             prev_dir=Path().cwd(), **self._calc_kwargs.get("post_processing_params", {})
         )

--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -14,7 +14,6 @@ from quacc.calculators.espresso.espresso import (
 from quacc.runners.ase import run_calc, run_opt
 from quacc.schemas.ase import summarize_opt_run, summarize_run
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.calculators.espresso.opt_patchs import SchemaPatch
 
 if TYPE_CHECKING:
     from typing import Any
@@ -104,7 +103,7 @@ def base_opt_fn(
     calc_swaps: dict[str, Any] | None = None,
     opt_defaults: dict[str, Any] | None = None,
     opt_params: dict[str, Any] | None = None,
-    opt_patch:  SchemaPatch | None = None,
+    opt_patch: Any | None = None,
     parallel_info: dict[str, Any] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: list[str] | None = None,

--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -11,9 +11,10 @@ from quacc.calculators.espresso.espresso import (
     EspressoProfile,
     EspressoTemplate,
 )
-from quacc.runners.ase import run_calc
-from quacc.schemas.ase import summarize_run
+from quacc.runners.ase import run_calc, run_opt
+from quacc.schemas.ase import summarize_opt_run, summarize_run
 from quacc.utils.dicts import recursive_dict_merge
+from quacc.calculators.espresso.opt_patchs import SchemaPatch
 
 if TYPE_CHECKING:
     from typing import Any
@@ -92,3 +93,76 @@ def base_fn(
     return summarize_run(
         final_atoms, input_atoms=atoms, additional_fields=additional_fields
     )
+
+
+def base_opt_fn(
+    atoms: Atoms = None,
+    preset: str | None = None,
+    template: EspressoTemplate | None = None,
+    profile: EspressoProfile | None = None,
+    calc_defaults: dict[str, Any] | None = None,
+    calc_swaps: dict[str, Any] | None = None,
+    opt_defaults: dict[str, Any] | None = None,
+    opt_params: dict[str, Any] | None = None,
+    opt_patch:  SchemaPatch | None = None,
+    parallel_info: dict[str, Any] | None = None,
+    additional_fields: dict[str, Any] | None = None,
+    copy_files: list[str] | None = None,
+) -> RunSchema:
+    """
+    Base function to carry out espresso recipes.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    preset
+        Name of the preset to use
+    template
+        EspressoTemplate to use
+    profile
+        EspressoProfile to use
+    calc_defaults
+        The default calculator parameters.
+    calc_swaps
+        Custom kwargs for the espresso calculator. Set a value to
+        `quacc.Remove` to remove a pre-existing key entirely. For a list of available
+        keys, refer to the `ase.calculators.espresso.Espresso` calculator.
+    parallel_info
+        Dictionary of parallelization information.
+    additional_fields
+        Any additional fields to supply to the summarizer.
+    copy_files
+        Files to copy to the runtime directory.
+
+    Returns
+    -------
+    RunSchema
+        Dictionary of results from [quacc.schemas.ase.summarize_run][]
+    """
+
+    atoms = Atoms() if atoms is None else atoms
+
+    calc_defaults["input_data"] = Namelist(calc_defaults.get("input_data"))
+    calc_swaps["input_data"] = Namelist(calc_swaps.get("input_data"))
+
+    binary = template.binary if template else "pw"
+
+    calc_defaults["input_data"].to_nested(binary=binary, **calc_defaults)
+    calc_swaps["input_data"].to_nested(binary=binary, **calc_swaps)
+
+    calc_flags = recursive_dict_merge(calc_defaults, calc_swaps)
+    opt_flags = recursive_dict_merge(opt_defaults, opt_params)
+
+    atoms.calc = Espresso(
+        input_atoms=atoms,
+        preset=preset,
+        parallel_info=parallel_info,
+        template=template,
+        profile=profile,
+        **calc_flags,
+    )
+
+    dyn = run_opt(atoms, optimizer_patch=opt_patch, copy_files=copy_files, **opt_flags)
+
+    return summarize_opt_run(dyn, additional_fields=additional_fields)

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -9,7 +9,6 @@ from ase.optimize import LBFGS
 from quacc import job
 from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso._base import base_fn, base_opt_fn
-from quacc.calculators.espresso.opt_patchs import SchemaPatch
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -160,7 +159,7 @@ def external_relax_job(
     parallel_info: dict[str] | None = None,
     test_run: bool = False,
     opt_params: dict[str, Any] | None = None,
-    opt_patch: SchemaPatch | None = None,
+    opt_patch: Any | None = None,
     copy_files: str | Path | list[str | Path] | None = None,
     **calc_kwargs,
 ) -> RunSchema:

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ase.filters import UnitCellFilter
+from ase.optimize import LBFGS
+
 from quacc import job
 from quacc.calculators.espresso.espresso import EspressoTemplate
-from quacc.recipes.espresso._base import base_fn
+from quacc.recipes.espresso._base import base_fn, base_opt_fn
+from quacc.calculators.espresso.opt_patchs import SchemaPatch
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
 
     from ase.atoms import Atoms
 
@@ -144,6 +149,91 @@ def relax_job(
         calc_swaps=calc_kwargs,
         parallel_info=parallel_info,
         additional_fields={"name": "pw.x Relax"},
+        copy_files=copy_files,
+    )
+
+
+@job
+def external_relax_job(
+    atoms: Atoms | UnitCellFilter,
+    preset: str | None = "sssp_1.3.0_pbe_efficiency",
+    parallel_info: dict[str] | None = None,
+    test_run: bool = False,
+    opt_params: dict[str, Any] | None = None,
+    opt_patch: SchemaPatch | None = None,
+    copy_files: str | Path | list[str | Path] | None = None,
+    **calc_kwargs,
+) -> RunSchema:
+    """
+    Function to carry out a structure relaxation with pw.x.
+
+    Parameters
+    ----------
+    atoms
+        The Atoms object or the result of a UnitCellFilter for cell-relaxation.
+    preset
+        The name of a YAML file containing a list of parameters to use as
+        a "preset" for the calculator. quacc will automatically look in the
+        `ESPRESSO_PRESET_DIR` (default: quacc/calculators/espresso/presets).
+    relax_cell
+        Whether to relax the cell or not.
+    parallel_info
+        Dictionary containing information about the parallelization of the
+        calculation. See the ASE documentation for more information.
+    test_run
+        If True, a test run is performed to check that the calculation input_data is correct or
+        to generate some files/info if needed.
+    copy_files
+        List of files to copy to the calculation directory. Useful for copying
+        files from a previous calculation. This parameter can either be a string
+        or a list of strings.
+
+        If a string is provided, it is assumed to be a path to a directory,
+        all of the child tree structure of that directory is going to be copied to the
+        scratch of this calculation. For phonon_job this is what most users will want to do.
+
+        If a list of strings is provided, each string point to a specific file. In this case
+        it is important to note that no directory structure is going to be copied, everything
+        is copied at the root of the temporary directory.
+    **calc_kwargs
+        Additional keyword arguments to pass to the Espresso calculator. See the
+        docstring of [quacc.calculators.espresso.espresso.Espresso][] for more information.
+
+    Returns
+    -------
+    RunSchema
+        Dictionary of results from [quacc.schemas.ase.summarize_run][].
+        See the type-hint for the data structure.
+    """
+
+    calc_defaults = {
+        "input_data": {
+            "control": {
+                "calculation": "scf",
+                "tstress": True if isinstance(atoms, UnitCellFilter) else False,
+                "tprnfor": True,
+            }
+        }
+    }
+
+    opt_defaults = {
+        "fmax": 0.01,
+        "max_steps": 500,
+        # LBFGS is very often the "best" optimizer for the general case.
+        "optimizer": LBFGS
+    }
+
+    return base_opt_fn(
+        atoms,
+        preset=preset,
+        template=EspressoTemplate("pw", test_run=test_run),
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        opt_defaults=opt_defaults,
+        opt_params=opt_params,
+        opt_patch=opt_patch,
+        parallel_info=parallel_info,
+        additional_fields={"name": "pw.x ExternalRelax"},
         copy_files=copy_files,
     )
 

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -16,7 +16,6 @@ from quacc import SETTINGS
 from quacc.atoms.core import copy_atoms
 from quacc.runners.prep import calc_cleanup, calc_setup
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.calculators.espresso.opt_patchs import SchemaPatch
 
 try:
     from sella import Internals, Sella
@@ -117,7 +116,7 @@ def run_opt(
     fmax: float = 0.01,
     max_steps: int = 500,
     optimizer: Optimizer = FIRE,
-    optimizer_patch : SchemaPatch | None = None,
+    optimizer_patch: Any | None = None,
     optimizer_kwargs: OptimizerKwargs | None = None,
     run_kwargs: dict[str, Any] | None = None,
     copy_files: str | Path | list[str | Path] | None = None,
@@ -196,8 +195,8 @@ def run_opt(
 
     # Run calculation
     with traj, optimizer(atoms, **optimizer_kwargs) as dyn:
-
         if optimizer_patch is not None:
+
             class PatchedOptimizer(optimizer_patch, dyn.__class__):
                 pass
 

--- a/src/quacc/utils/opt.py
+++ b/src/quacc/utils/opt.py
@@ -1,0 +1,16 @@
+class ASEOptimizerSuperCharged:
+    def __init__(self):
+        self.tasks = {}
+        self.every = {}
+        self.results = {}
+
+    def step(self):
+        super().step()
+        for task in self.tasks:
+            if self.nstep % self.every[task] != 0:
+                continue
+            self.results[task] = self.tasks[task]()
+
+    def attach_task(self, task, every = 1):
+        self.task[task.__name__] = task
+        self.every[task.__name__] = every

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from quacc import SETTINGS
 from quacc.calculators.espresso.espresso import EspressoTemplate
+from quacc.calculators.espresso.opt_patchs import PostProcessingPatch
 from quacc.recipes.espresso.core import (
     post_processing_job,
     relax_job,
@@ -259,7 +260,11 @@ def test_patched_external_relax_job(tmp_path, monkeypatch):
     input_data = {"control": {"pseudo_dir": tmp_path}}
 
     results = external_relax_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        opt_patch=PostProcessingPatch,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
     )
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Requirements

### Checklist

- [x] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [x] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).

## Summary of Changes

This is far from working, it is just to show the global idea. Being able to perform custom actions during dynamics would allow to:

- Generate all kind of additional information when running NEB/MD which is very often necessary.
- With some small additional tuning that user can do in quacc.utils.opt: Perform (hyper)active learning when doing MD/MC and more generally stop/restart the dynamics based on different criteria.

This is the least-intrusive way I found to allow that, I am still very naive on the workflow side so It might not even be possible?