### PR TITLE
Do a `zpath` check on copying files

### DIFF
--- a/src/quacc/utils/files.py
+++ b/src/quacc/utils/files.py
@@ -63,7 +63,7 @@ def copy_decompress_files(
     None
     """
     for f in source_files:
-        f_path = Path(f).expanduser()
+        f_path = Path(zpath(f)).expanduser()
         if f_path.is_symlink():
             continue
         if f_path.is_file():


### PR DESCRIPTION
When checking to see if a file exists to be copied, use monty's `zpath()` utility to return the zipped extension if present.