### PR TITLE
Changing Path object to str for ONETEP_CMD in base functions

### DIFF
--- a/src/quacc/recipes/onetep/_base.py
+++ b/src/quacc/recipes/onetep/_base.py
@@ -55,7 +55,7 @@ def base_fn(
         pseudo_path=str(SETTINGS.ONETEP_PP_PATH) if SETTINGS.ONETEP_PP_PATH else ".",
         parallel_info=SETTINGS.ONETEP_PARALLEL_CMD,
         profile=OnetepProfile(
-            SETTINGS.ONETEP_CMD
+            str(SETTINGS.ONETEP_CMD)
         ),  # TODO: If the ASE merge is successful, we need to change ONETEP_PARALLEL_CMD to a list[str] and remove parallel info.
         # If we also have access to post_args we can point not to the binary but to the launcher which takes -t nthreads as a post_args
         **calc_flags,
@@ -113,7 +113,7 @@ def base_opt_fn(
         pseudo_path=str(SETTINGS.ONETEP_PP_PATH) if SETTINGS.ONETEP_PP_PATH else ".",
         parallel_info=SETTINGS.ONETEP_PARALLEL_CMD,
         profile=OnetepProfile(
-            SETTINGS.ONETEP_CMD
+            str(SETTINGS.ONETEP_CMD)
         ),  # TODO: If the ASE merge is successful, we need to change ONETEP_PARALLEL_CMD to a list[str] and remove parallel info.
         # If we also have access to post_args we can point not to the binary but to the launcher which takes -t nthreads as a post_args
         **calc_flags,


### PR DESCRIPTION
## Summary of Changes

Similarly, parallel_info needs to be sent in OnetepProfile, also for now the ONETEP_PARALLEL_CMD will not work

We need parallel_info, do you want to change it here, or should I do it in a separate branch?

## Requirements

### Checklist

- [ ] I have read the [Contributing Guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html). Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
