### PR TITLE
Espresso: autorestarting in trivial cases

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -112,7 +112,8 @@ class EspressoTemplate(EspressoTemplate_):
 
         if self.binary == "pw":
             if self.autorestart and self.nruns > 0:
-                parameters["input_data"]["control"]["restart_mode"] = "restart"
+                parameters["input_data"]["electrons"]["startingpot"] = "file"
+                parameters["input_data"]["electrons"]["startingwfc"] = "file"
             write(
                 directory / self.inputname,
                 atoms,

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -32,7 +32,9 @@ class EspressoTemplate(EspressoTemplate_):
     """This is a wrapper around the ASE Espresso template that allows for the use of
     other binaries such as pw.x, ph.x, cp.x, etc."""
 
-    def __init__(self, binary: str = "pw", test_run: bool = False) -> None:
+    def __init__(
+        self, binary: str = "pw", test_run: bool = False, autorestart: bool = False
+    ) -> None:
         """
         Initialize the Espresso template.
 
@@ -44,6 +46,9 @@ class EspressoTemplate(EspressoTemplate_):
         test_run
             If True, a test run is performed to check that the calculation
             input_data is correct or to generate some files/info if needed.
+        autorestart
+            If True, the calculation will automatically switch to 'restart'
+            if this calculator performs more than one run. (ASE-relax/MD/NEB)
 
         Returns
         -------
@@ -64,6 +69,9 @@ class EspressoTemplate(EspressoTemplate_):
         self.outfiles = {"fildos": "pwscf.dos"}
 
         self.test_run = test_run
+
+        self.nruns = 0
+        self.autorestart = autorestart
 
     def write_input(
         self,
@@ -103,6 +111,8 @@ class EspressoTemplate(EspressoTemplate_):
             self._test_run(parameters, directory)
 
         if self.binary == "pw":
+            if self.autorestart and self.nruns > 0:
+                parameters["input_data"]["control"]["restart_mode"] = "restart"
             write(
                 directory / self.inputname,
                 atoms,
@@ -119,6 +129,10 @@ class EspressoTemplate(EspressoTemplate_):
                 write_fortran_namelist(
                     fd, binary=self.binary, properties=properties, **parameters
                 )
+
+    def execute(self, *args: Any, **kwargs: Any) -> None:
+        super().execute(*args, **kwargs)
+        self.nruns += 1
 
     @staticmethod
     def _search_keyword(parameters: dict[str, Any], key_to_search: str) -> str | None:

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -157,6 +157,7 @@ def relax_job(
 def ase_relax_job(
     atoms: Atoms,
     preset: str | None = "sssp_1.3.0_pbe_efficiency",
+    autorestart: bool = True,
     relax_cell: bool = False,
     parallel_info: dict[str] | None = None,
     opt_params: dict[str, Any] | None = None,
@@ -175,6 +176,10 @@ def ase_relax_job(
         The name of a YAML file containing a list of parameters to use as
         a "preset" for the calculator. quacc will automatically look in the
         `ESPRESSO_PRESET_DIR` (default: quacc/calculators/espresso/presets).
+    autorestart
+        Whether to automatically turn on the restart flag after the first
+        calculation. This avoids recomputing everything from scratch at each
+        step of the optimization.
     relax_cell
         Whether to relax the cell or not.
     parallel_info
@@ -220,7 +225,7 @@ def ase_relax_job(
         atoms,
         preset=preset,
         relax_cell=relax_cell,
-        template=EspressoTemplate("pw"),
+        template=EspressoTemplate("pw", autorestart=autorestart),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,


### PR DESCRIPTION
## Summary of Changes

Currently ase_relax_job will ask QE to compute the wavefunctions/charge-density from scratch at each step, this is highly inefficient.

If a template called Profile.run more than once and the autorestart is activated (default False, but True when calling ase_relax_job) then we turn off QE restart keyword.

## Requirements

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
