### PR TITLE
Use `min_lengths` for phonons

### DIFF
--- a/src/quacc/atoms/phonons.py
+++ b/src/quacc/atoms/phonons.py
@@ -1,4 +1,5 @@
 """Atoms handling with Phonopy."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 @requires(phonopy, "Phonopy is not installed.")
 def get_phonopy(
     atoms: Atoms,
-    min_length: float | None = None,
+    min_lengths: float | tuple[float, float, float] | None = None,
     symprec: float = 1e-5,
     displacement: float = 0.01,
     phonopy_kwargs: dict | None = None,
@@ -37,7 +38,7 @@ def get_phonopy(
     ----------
     atoms
         ASE atoms object.
-    min_length
+    min_lengths
         Minimum length of each lattice dimension (A).
     symprec
         Precision for symmetry detection.
@@ -58,8 +59,8 @@ def get_phonopy(
         structure, symprec=symprec
     ).get_symmetrized_structure()
 
-    if min_length:
-        n_supercells = np.round(np.ceil(min_length / atoms.cell.lengths()))
+    if min_lengths:
+        n_supercells = np.round(np.ceil(min_lengths / atoms.cell.lengths()))
         supercell_matrix = np.diag([n_supercells, n_supercells, n_supercells])
     else:
         supercell_matrix = None

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -1,4 +1,5 @@
 """Common workflows for phonons."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -30,7 +31,7 @@ def phonon_flow(
     force_job: Job,
     relax_job: Job | None = None,
     symprec: float = 1e-4,
-    min_length: float | None = 15.0,
+    min_lengths: float | tuple[float, float, float] | None = 20.0,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -53,7 +54,7 @@ def phonon_flow(
         The job used to relax the structure before calculating the forces.
     symprec
         Precision for symmetry detection.
-    min_length
+    min_lengths
         Minimum length of each lattice dimension (A).
     displacement
         Atomic displacement (A).
@@ -78,7 +79,7 @@ def phonon_flow(
     def _get_forces_subflow(atoms: Atoms) -> list[dict]:
         phonon = get_phonopy(
             atoms,
-            min_length=min_length,
+            min_lengths=min_lengths,
             symprec=symprec,
             displacement=displacement,
             phonopy_kwargs=phonopy_kwargs,
@@ -94,7 +95,7 @@ def phonon_flow(
     def _thermo_job(atoms: Atoms, force_job_results: list[dict]) -> PhononSchema:
         phonon = get_phonopy(
             atoms,
-            min_length=min_length,
+            min_lengths=min_lengths,
             symprec=symprec,
             displacement=displacement,
             phonopy_kwargs=phonopy_kwargs,

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for EMT."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 def phonon_flow(
     atoms: Atoms,
     symprec: float = 1e-4,
-    min_length: float | None = 15.0,
+    min_lengths: float | tuple[float, float, float] | None = 20.0,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -51,7 +52,7 @@ def phonon_flow(
         Atoms object
     symprec
         Precision for symmetry detection.
-    min_length
+    min_lengths
         Minimum length of each lattice dimension (A).
     displacement
         Atomic displacement (A).
@@ -91,7 +92,7 @@ def phonon_flow(
         static_job_,
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
-        min_length=min_length,
+        min_lengths=min_lengths,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for MLPs."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -22,7 +23,7 @@ def phonon_flow(
     atoms: Atoms,
     method: Literal["mace", "m3gnet", "chgnet"],
     symprec: float = 1e-4,
-    min_length: float | None = 15.0,
+    min_lengths: float | tuple[float, float, float] | None = 20.0,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -95,7 +96,7 @@ def phonon_flow(
         static_job_,
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
-        min_length=min_length,
+        min_lengths=min_lengths,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -55,7 +55,7 @@ def phonon_flow(
         Universal ML interatomic potential method to use
     symprec
         Precision for symmetry detection.
-    min_length
+    min_lengths
         Minimum length of each lattice dimension (A).
     displacement
         Atomic displacement (A).

--- a/src/quacc/recipes/tblite/phonons.py
+++ b/src/quacc/recipes/tblite/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for TBLite."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 def phonon_flow(
     atoms: Atoms,
     symprec: float = 1e-4,
-    min_length: float | None = 15.0,
+    min_lengths: float | tuple[float, float, float] | None = 20.0,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -51,7 +52,7 @@ def phonon_flow(
         Atoms object
     symprec
         Precision for symmetry detection.
-    min_length
+    min_lengths
         Minimum length of each lattice dimension (A).
     displacement
         Atomic displacement (A).
@@ -89,7 +90,7 @@ def phonon_flow(
         static_job_,
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
-        min_length=min_length,
+        min_lengths=min_lengths,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/tests/core/atoms/test_phonons.py
+++ b/tests/core/atoms/test_phonons.py
@@ -14,8 +14,11 @@ def test_get_phonopy():
     phonopy = get_phonopy(atoms)
     assert_array_equal(phonopy.supercell_matrix, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-    phonopy = get_phonopy(atoms, min_length=5)
+    phonopy = get_phonopy(atoms, min_lengths=5)
     assert_array_equal(phonopy.supercell_matrix, [[2, 0, 0], [0, 2, 0], [0, 0, 2]])
+
+    phonopy = get_phonopy(atoms, min_lengths=[5, 10, 5])
+    assert_array_equal(phonopy.supercell_matrix, [[2, 0, 0], [0, 4, 0], [0, 0, 2]])
 
     phonopy = get_phonopy(atoms, displacement=1)
     assert_almost_equal(

--- a/tests/core/recipes/emt_recipes/test_emt_phonons.py
+++ b/tests/core/recipes/emt_recipes/test_emt_phonons.py
@@ -9,7 +9,7 @@ from quacc.recipes.emt.phonons import phonon_flow
 def test_phonon_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    output = phonon_flow(atoms, min_length=5.0)
+    output = phonon_flow(atoms, min_lengths=5.0)
     assert output["results"]["thermal_properties"]["temperatures"].shape == (101,)
     assert output["results"]["thermal_properties"]["temperatures"][0] == 0
     assert output["results"]["thermal_properties"]["temperatures"][-1] == 1000
@@ -20,7 +20,7 @@ def test_phonon_flow(tmp_path, monkeypatch):
 def test_phonon_flow_v2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    output = phonon_flow(atoms, min_length=None, t_min=10, t_max=20, t_step=5)
+    output = phonon_flow(atoms, min_lengths=None, t_min=10, t_max=20, t_step=5)
     assert output["results"]["thermal_properties"]["temperatures"].shape == (3,)
     assert output["results"]["thermal_properties"]["temperatures"][0] == 10
     assert output["results"]["thermal_properties"]["temperatures"][-1] == 20
@@ -32,7 +32,7 @@ def test_phonon_flow_v3(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu") * (2, 2, 2)
     atoms[0].position += 0.2
-    output = phonon_flow(atoms, run_relax=False, min_length=5.0)
+    output = phonon_flow(atoms, run_relax=False, min_lengths=5.0)
     assert output["results"]["thermal_properties"]["temperatures"].shape == (101,)
     assert output["results"]["thermal_properties"]["temperatures"][0] == 0
     assert output["results"]["thermal_properties"]["temperatures"][-1] == 1000
@@ -45,7 +45,7 @@ def test_phonon_flow_v4(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu") * (2, 2, 2)
     atoms[0].position += 0.2
-    output = phonon_flow(atoms, run_relax=True, min_length=5.0)
+    output = phonon_flow(atoms, run_relax=True, min_lengths=5.0)
     assert output["results"]["thermal_properties"]["temperatures"].shape == (101,)
     assert output["results"]["thermal_properties"]["temperatures"][0] == 0
     assert output["results"]["thermal_properties"]["temperatures"][-1] == 1000

--- a/tests/core/recipes/mlp_recipes/test_phonon_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_phonon_recipes.py
@@ -19,6 +19,6 @@ def test_phonon_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _set_dtype(64)
     atoms = bulk("Cu")
-    output = phonon_flow(atoms, method="mace", min_length=5.0)
+    output = phonon_flow(atoms, method="mace", min_lengths=5.0)
     assert output["results"]["force_constants"].shape == (8, 8, 3, 3)
     assert len(output["results"]["thermal_properties"]["temperatures"]) == 101

--- a/tests/core/recipes/tblite_recipes/test_tblite_phonons.py
+++ b/tests/core/recipes/tblite_recipes/test_tblite_phonons.py
@@ -11,7 +11,7 @@ def test_phonon_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     output = phonon_flow(
-        atoms, min_length=5.0, job_params={"static_job": {"method": "GFN1-xTB"}}
+        atoms, min_lengths=5.0, job_params={"static_job": {"method": "GFN1-xTB"}}
     )
     assert output["results"]["force_constants"].shape == (8, 8, 3, 3)
     assert len(output["results"]["thermal_properties"]["temperatures"]) == 101


### PR DESCRIPTION
## Summary of Changes

Partially addresses #1652. Still more to do.

1. Use `min_lengths: float | tuple[float, float, float] | None` instead of `min_length: float | None` for phonon keyword argument
2. Change default to 20.0 A

## Requirements

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).

