### PR TITLE
Add support for `supercell_matrix` in phonon recipes

### DIFF
--- a/src/quacc/atoms/phonons.py
+++ b/src/quacc/atoms/phonons.py
@@ -1,4 +1,5 @@
 """Atoms handling with Phonopy."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
 def get_phonopy(
     atoms: Atoms,
     min_length: float | None = None,
+    supercell_matrix: (
+        tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]] | None
+    ) = None,
     symprec: float = 1e-5,
     displacement: float = 0.01,
     phonopy_kwargs: dict | None = None,
@@ -39,6 +43,9 @@ def get_phonopy(
         ASE atoms object.
     min_length
         Minimum length of each lattice dimension (A).
+    supercell_matrix
+        The supercell matrix to use. If specified, it will override any
+        value specified by `min_lengths`.
     symprec
         Precision for symmetry detection.
     displacement
@@ -58,11 +65,9 @@ def get_phonopy(
         structure, symprec=symprec
     ).get_symmetrized_structure()
 
-    if min_length:
+    if supercell_matrix is None and min_lengths is not None:
         n_supercells = np.round(np.ceil(min_length / atoms.cell.lengths()))
         supercell_matrix = np.diag([n_supercells, n_supercells, n_supercells])
-    else:
-        supercell_matrix = None
 
     phonopy_atoms = get_phonopy_structure(structure)
     phonon = phonopy.Phonopy(

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -1,4 +1,5 @@
 """Common workflows for phonons."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -31,6 +32,9 @@ def phonon_flow(
     relax_job: Job | None = None,
     symprec: float = 1e-4,
     min_length: float | None = 15.0,
+    supercell_matrix: (
+        tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]] | None
+    ) = None,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -55,6 +59,9 @@ def phonon_flow(
         Precision for symmetry detection.
     min_length
         Minimum length of each lattice dimension (A).
+    supercell_matrix
+        The supercell matrix to use. If specified, it will override any
+        value specified by `min_lengths`.
     displacement
         Atomic displacement (A).
     t_step
@@ -79,6 +86,7 @@ def phonon_flow(
         phonon = get_phonopy(
             atoms,
             min_length=min_length,
+            supercell_matrix=supercell_matrix,
             symprec=symprec,
             displacement=displacement,
             phonopy_kwargs=phonopy_kwargs,

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for EMT."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -22,6 +23,9 @@ def phonon_flow(
     atoms: Atoms,
     symprec: float = 1e-4,
     min_length: float | None = 15.0,
+    supercell_matrix: (
+        tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]] | None
+    ) = None,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -53,6 +57,9 @@ def phonon_flow(
         Precision for symmetry detection.
     min_length
         Minimum length of each lattice dimension (A).
+    supercell_matrix
+        The supercell matrix to use. If specified, it will override any
+        value specified by `min_lengths`.
     displacement
         Atomic displacement (A).
     t_step
@@ -92,6 +99,7 @@ def phonon_flow(
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_length=min_length,
+        supercell_matrix=supercell_matrix,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for MLPs."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -23,6 +24,9 @@ def phonon_flow(
     method: Literal["mace", "m3gnet", "chgnet"],
     symprec: float = 1e-4,
     min_length: float | None = 15.0,
+    supercell_matrix: (
+        tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]] | None
+    ) = None,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -56,6 +60,9 @@ def phonon_flow(
         Precision for symmetry detection.
     min_length
         Minimum length of each lattice dimension (A).
+    supercell_matrix
+        The supercell matrix to use. If specified, it will override any
+        value specified by `min_lengths`.
     displacement
         Atomic displacement (A).
     t_step
@@ -96,6 +103,7 @@ def phonon_flow(
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_length=min_length,
+        supercell_matrix=supercell_matrix,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/src/quacc/recipes/tblite/phonons.py
+++ b/src/quacc/recipes/tblite/phonons.py
@@ -1,4 +1,5 @@
 """Phonon recipes for TBLite."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -22,6 +23,9 @@ def phonon_flow(
     atoms: Atoms,
     symprec: float = 1e-4,
     min_length: float | None = 15.0,
+    supercell_matrix: (
+        tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]] | None
+    ) = None,
     displacement: float = 0.01,
     t_step: float = 10,
     t_min: float = 0,
@@ -53,6 +57,9 @@ def phonon_flow(
         Precision for symmetry detection.
     min_length
         Minimum length of each lattice dimension (A).
+    supercell_matrix
+        The supercell matrix to use. If specified, it will override any
+        value specified by `min_lengths`.
     displacement
         Atomic displacement (A).
     t_step
@@ -90,6 +97,7 @@ def phonon_flow(
         relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_length=min_length,
+        supercell_matrix=supercell_matrix,
         displacement=displacement,
         t_step=t_step,
         t_min=t_min,

--- a/tests/core/recipes/emt_recipes/test_emt_phonons.py
+++ b/tests/core/recipes/emt_recipes/test_emt_phonons.py
@@ -16,6 +16,14 @@ def test_phonon_flow(tmp_path, monkeypatch):
     assert output["results"]["force_constants"].shape == (8, 8, 3, 3)
     assert "mesh_properties" in output["results"]
 
+    atoms = bulk("Cu")
+    output = phonon_flow(atoms, supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)))
+    assert output["results"]["thermal_properties"]["temperatures"].shape == (101,)
+    assert output["results"]["thermal_properties"]["temperatures"][0] == 0
+    assert output["results"]["thermal_properties"]["temperatures"][-1] == 1000
+    assert output["results"]["force_constants"].shape == (8, 8, 3, 3)
+    assert "mesh_properties" in output["results"]
+
 
 def test_phonon_flow_v2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary of Changes

Adds the `supercell_matrix` keyword argument for phonon recipes. Partially addresses #1652.

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
