### PR TITLE
Add a test for a MACE-MP-0 relaxation job with `dispersion=True`

### DIFF
--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -86,6 +86,20 @@ def test_relax_job(tmp_path, monkeypatch, method):
     assert output["atoms"].get_volume() == pytest.approx(atoms.get_volume())
 
 
+def test_relax_job_dispersion(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    _set_dtype(64)
+
+    atoms = bulk("Cu") * (2, 2, 2)
+    atoms[0].position += 0.1
+    output = relax_job(atoms, method="mace", dispersion=True)
+    assert output["results"]["energy"] == pytest.approx(-32.670471191406259)
+    assert np.shape(output["results"]["forces"]) == (8, 3)
+    assert output["atoms"] != atoms
+    assert output["atoms"].get_volume() == pytest.approx(atoms.get_volume())
+
+
 @pytest.mark.parametrize("method", methods)
 def test_relax_cell_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -94,7 +94,7 @@ def test_relax_job_dispersion(tmp_path, monkeypatch):
     atoms = bulk("Cu") * (2, 2, 2)
     atoms[0].position += 0.1
     output = relax_job(atoms, method="mace", dispersion=True)
-    assert output["results"]["energy"] == pytest.approx(-32.670471191406259)
+    assert output["results"]["energy"] == pytest.approx(-37.33948477096204)
     assert np.shape(output["results"]["forces"]) == (8, 3)
     assert output["atoms"] != atoms
     assert output["atoms"].get_volume() == pytest.approx(atoms.get_volume())

--- a/tests/requirements-mlp.txt
+++ b/tests/requirements-mlp.txt
@@ -1,3 +1,4 @@
 matgl==0.9.2
 chgnet==0.3.3
 mace-torch==0.3.4
+torch-dftd==0.4.0


### PR DESCRIPTION
Sanity check inspired by #1652.