### PR TITLE
Better support for various Maggma stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- The `PRIMARY_STORE` setting has changed to `STORE` and is now formatted more intuitively.
+- The `PRIMARY_STORE` setting has changed to `STORE` and is now formatted more intuitively
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - PDOS jobs and flows for Espresso
 
+### Changed
+
+- The `PRIMARY_STORE` setting has changed to `STORE` and is now formatted more intuitively.
+
+### Fixed
+
+- Fixed usage of `MontyStore` as the data store option
+
 ### Removed
 
 - Removed the deprecated "q-chem legacy" recipes

--- a/docs/user/db/basics.md
+++ b/docs/user/db/basics.md
@@ -47,7 +47,7 @@ Here, we describe how to set up quacc with a database of your choosing.
         # Define your database details
         store = MongoStore(
             database="my_db_name",
-            collection="my_collection_name",
+            collection_name="my_collection_name",
             username="my_username",
             password="my_password",
             host="localhost",

--- a/docs/user/db/basics.md
+++ b/docs/user/db/basics.md
@@ -4,26 +4,34 @@ Here, we describe how to set up quacc with a database of your choosing.
 
 === "General Purpose"
 
-    For a given recipe, you can have quacc automatically store the final output summaries in your desired database by defining a [Maggma data store](https://materialsproject.github.io/maggma/reference/stores/) in the `PRIMARY_STORE` [quacc setting](../settings/settings.md).
+    For a given recipe, you can have quacc automatically store the final output summaries in your desired database by defining a [Maggma data store](https://materialsproject.github.io/maggma/reference/stores/) in the `STORE` [quacc setting](../settings/settings.md).
 
-    For instance, let's pretend you have decided to make a [`MongoStore`](https://materialsproject.github.io/maggma/reference/stores/#maggma.stores.mongolike.MongoStore) be your database of choice. After defining or loading your Maggma store, you would call `.to_json()` to get a dictionary representation. You can then store this JSON, formatted as a string, in the `PRIMARY_STORE` global quacc setting.
+    For instance, let's pretend you have decided to make a [`MongoStore`](https://materialsproject.github.io/maggma/reference/stores/#maggma.stores.mongolike.MongoStore) be your database of choice. In your Python code, it might look like the following
 
     ```python
     from maggma.stores import MongoStore
 
     store = MongoStore(
-        "my_db_name",
-        "my_collection_name",
+        database="my_db_name",
+        collection_name="my_collection_name",
         username="my_username",
         password="my_password",
         host="localhost",
         port=27017,
     )
-    print(store.to_json())  # This is the JSON string you would store in PRIMARY_STORE
     ```
 
+    To replicate the same behavior, simply specify the `STORE` setting in your `~/.quacc.yaml` file using `type` as the name of the `Store` and all arguments provided as key-value pairs.
+
     ```yaml title="~/.quacc.yaml"
-    PRIMARY_STORE: '{"@module": "maggma.stores.mongolike", "@class": "MongoStore", "@version": "0.51.19", "database": "my_db_name", "collection_name": "my_collection_name", "host": "localhost", "port": 27017, "username": "my_username", "password": "my_password", "ssh_tunnel": null, "safe_update": false, "auth_source": "my_db_name", "mongoclient_kwargs": {}, "default_sort": null}'
+    STORE:
+      type: MongoStore
+      database: my_db_name
+      collection_name: my_collection_name
+      username: my_username
+      password: my_password
+      host: localhost
+      port: 27017
     ```
 
     ??? "How to Manually Upload to a Data Store"
@@ -38,8 +46,8 @@ Here, we describe how to set up quacc with a database of your choosing.
 
         # Define your database details
         store = MongoStore(
-            "my_db_name",
-            "my_collection_name",
+            database="my_db_name",
+            collection="my_collection_name",
             username="my_username",
             password="my_password",
             host="localhost",

--- a/docs/user/db/basics.md
+++ b/docs/user/db/basics.md
@@ -25,13 +25,13 @@ Here, we describe how to set up quacc with a database of your choosing.
 
     ```yaml title="~/.quacc.yaml"
     STORE:
-      type: MongoStore
-      database: my_db_name
-      collection_name: my_collection_name
-      username: my_username
-      password: my_password
-      host: localhost
-      port: 27017
+      MongoStore:
+        database: my_db_name
+        collection_name: my_collection_name
+        username: my_username
+        password: my_password
+        host: localhost
+        port: 27017
     ```
 
     ??? "How to Manually Upload to a Data Store"

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -1,4 +1,5 @@
 """Schemas for storing ASE-based data."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -63,7 +64,7 @@ def summarize_run(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -72,7 +73,7 @@ def summarize_run(
     """
 
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     if not final_atoms.calc:
         msg = "ASE Atoms object has no attached calculator."
@@ -157,7 +158,7 @@ def summarize_opt_run(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -169,7 +170,7 @@ def summarize_opt_run(
         SETTINGS.CHECK_CONVERGENCE if check_convergence is None else check_convergence
     )
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     # Get trajectory
     if not trajectory:
@@ -245,7 +246,7 @@ def summarize_vib_run(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -253,7 +254,7 @@ def summarize_vib_run(
         Dictionary representation of the task document
     """
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     vib_freqs_raw = vib.get_frequencies().tolist()
     vib_energies_raw = vib.get_energies().tolist()
@@ -365,7 +366,7 @@ def summarize_ideal_gas_thermo(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -374,7 +375,7 @@ def summarize_ideal_gas_thermo(
     """
 
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     spin_multiplicity = round(2 * igt.spin + 1)
 
@@ -455,7 +456,7 @@ def summarize_vib_and_thermo(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -463,7 +464,7 @@ def summarize_vib_and_thermo(
         A dictionary that merges the `VibSchema` and `ThermoSchema`.
     """
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     vib_task_doc = summarize_vib_run(
         vib, charge_and_multiplicity=charge_and_multiplicity, store=False

--- a/src/quacc/schemas/cclib.py
+++ b/src/quacc/schemas/cclib.py
@@ -1,4 +1,5 @@
 """Schemas for molecular DFT codes parsed by cclib."""
+
 from __future__ import annotations
 
 import logging
@@ -36,20 +37,22 @@ def cclib_summarize_run(
     final_atoms: Atoms,
     logfile_extensions: str | list[str],
     dir_path: Path | str | None = None,
-    pop_analyses: list[
-        Literal[
-            "cpsa",
-            "mpa",
-            "lpa",
-            "bickelhaupt",
-            "density",
-            "mbo",
-            "bader",
-            "ddec6",
-            "hirshfeld",
+    pop_analyses: (
+        list[
+            Literal[
+                "cpsa",
+                "mpa",
+                "lpa",
+                "bickelhaupt",
+                "density",
+                "mbo",
+                "bader",
+                "ddec6",
+                "hirshfeld",
+            ]
         ]
-    ]
-    | None = None,
+        | None
+    ) = None,
     check_convergence: bool | None = None,
     additional_fields: dict[str, Any] | None = None,
     store: Store | None = None,
@@ -83,7 +86,7 @@ def cclib_summarize_run(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -96,7 +99,7 @@ def cclib_summarize_run(
         SETTINGS.CHECK_CONVERGENCE if check_convergence is None else check_convergence
     )
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     # Get the cclib base task document
     cclib_task_doc = _make_cclib_schema(

--- a/src/quacc/schemas/phonons.py
+++ b/src/quacc/schemas/phonons.py
@@ -60,7 +60,7 @@ def summarize_phonopy(
         The PhononSchema.
     """
     additional_fields = additional_fields or {}
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     uri = get_uri(Path.cwd())
     directory = ":".join(uri.split(":")[1:])

--- a/src/quacc/schemas/vasp.py
+++ b/src/quacc/schemas/vasp.py
@@ -1,4 +1,5 @@
 """Schemas for VASP."""
+
 from __future__ import annotations
 
 import logging
@@ -65,7 +66,7 @@ def vasp_summarize_run(
         Additional fields to add to the task document.
     store
         Maggma Store object to store the results in. If None,
-        `SETTINGS.PRIMARY_STORE` will be used.
+        `SETTINGS.STORE` will be used.
 
     Returns
     -------
@@ -80,7 +81,7 @@ def vasp_summarize_run(
         SETTINGS.CHECK_CONVERGENCE if check_convergence is None else check_convergence
     )
     dir_path = Path(dir_path or final_atoms.calc.directory)
-    store = SETTINGS.PRIMARY_STORE if store is None else store
+    store = SETTINGS.STORE if store is None else store
 
     # Fetch all tabulated results from VASP outputs files. Fortunately, emmet
     # already has a handy function for this

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -111,19 +111,19 @@ class QuaccSettings(BaseSettings):
         description=(
             """
             The desired Maggma data store where calculation results will be stored. All data stores listed in 
-            `maggma.stores.__init__.py` are supported. If a dictionary is provided, the `type` key must be set 
-            to the desired store type. The remaining parameters are the keyword arguments accepted by the Store.
+            `maggma.stores.__init__.py` are supported. If a dictionary is provided, the first key must be set 
+            to the desired store type. The sub-parameters are the keyword arguments accepted by the Store.
             An example is shown below: 
 
             ```yaml
             STORE:
-              type: MongoStore
-              database: my_db
-              collection_name: my_collection
-              username: my_username
-              password: my_password
-              host: localhost
-              port: 27017
+              MongoStore:
+                database: my_db
+                collection_name: my_collection
+                username: my_username
+                password: my_password
+                host: localhost
+                port: 27017
             ```
             """
         ),
@@ -438,14 +438,15 @@ class QuaccSettings(BaseSettings):
         return v.expanduser() if v is not None else v
 
     @field_validator("STORE")
-    def generate_store(cls, v: Union[dict[str, Any], Store]) -> Store:
+    def generate_store(cls, v: Union[dict[str, dict[str, Any]], Store]) -> Store:
         """Generate the Maggma store."""
         from maggma import stores
 
         if isinstance(v, dict):
-            store = getattr(stores, v.pop("type"))
+            store_name = list(v.keys())[0]
+            store = getattr(stores, store_name)
 
-            return store(**v)
+            return store(**v[store_name])
         else:
             return v
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -1,4 +1,5 @@
 """Settings for quacc."""
+
 from __future__ import annotations
 
 import os
@@ -42,8 +43,10 @@ class QuaccSettings(BaseSettings):
     CONFIG_FILE: Path = Field(
         _DEFAULT_CONFIG_FILE_PATH,
         description=(
-            "Path to the YAML file to load alternative quacc configuration "
-            "defaults from."
+            """
+            Path to the YAML file to load alternative quacc configuration 
+            defaults from.
+            """
         ),
     )
 
@@ -64,26 +67,32 @@ class QuaccSettings(BaseSettings):
     RESULTS_DIR: Path = Field(
         Path.cwd(),
         description=(
-            "Directory to permanently store I/O-based calculation results in."
-            "Note that this behavior may be modified by the chosen workflow engine."
+            """
+            Directory to permanently store I/O-based calculation results in. 
+            Note that this behavior may be modified by the chosen workflow engine.
+            """
         ),
     )
     SCRATCH_DIR: Optional[Path] = Field(
         None,
         description=(
-            "The base directory where calculations are run. If set to None, calculations will be run in a "
-            "temporary directory within `RESULTS_DIR`. If a `Path` is supplied, calculations will "
-            "be run in a temporary directory within `SCRATCH_DIR`. Files are always moved back "
-            "to `RESULTS_DIR` after the calculation is complete, and the temporary directory "
-            "in `SCRATCH_DIR` is removed."
+            """
+            The base directory where calculations are run. If set to None, calculations will be run in a 
+            temporary directory within `RESULTS_DIR`. If a `Path` is supplied, calculations will 
+            be run in a temporary directory within `SCRATCH_DIR`. Files are always moved back 
+            to `RESULTS_DIR` after the calculation is complete, and the temporary directory 
+            in `SCRATCH_DIR` is removed.
+            """
         ),
     )
     CREATE_UNIQUE_DIR: bool = Field(
         True,
         description=(
-            "Whether to have a unique directory in RESULTS_DIR for each job."
-            "Some workflow engines have an option to do this for you already,"
-            "in which case you should set this to False."
+            """
+            Whether to have a unique directory in RESULTS_DIR for each job. 
+            Some workflow engines have an option to do this for you already, 
+            in which case you should set this to False.
+            """
         ),
     )
     GZIP_FILES: bool = Field(
@@ -97,12 +106,26 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
     # Data Store Settings
     # ---------------------------
-    PRIMARY_STORE: Optional[Union[str, Store]] = Field(
+    STORE: Optional[Union[dict, Store]] = Field(
         None,
         description=(
-            "String-based JSON representation of the primary Maggma data store "
-            "where calculation results will be stored."
-            "Taken from the `.to_json()` method of the corresponding Store object."
+            """
+            The desired Maggma data store where calculation results will be stored. All data stores listed in 
+            `maggma.stores.__init__.py` are supported. If a dictionary is provided, the `type` key must be set 
+            to the desired store type. The remaining parameters are the keyword arguments accepted by the Store.
+            An example is shown below: 
+
+            ```yaml
+            STORE:
+              type: MongoStore
+              database: my_db
+              collection_name: my_collection
+              username: my_username
+              password: my_password
+              host: localhost
+              port: 27017
+            ```
+            """
         ),
     )
 
@@ -119,8 +142,10 @@ class QuaccSettings(BaseSettings):
     ORCA_CMD: Path = Field(
         Path(which("orca") or "orca"),
         description=(
-            "Path to the ORCA executable. This must be the full, absolute path "
-            "for parallel calculations to work."
+            """
+            Path to the ORCA executable. This must be the full, absolute path 
+            for parallel calculations to work.
+            """
         ),
     )
 
@@ -196,9 +221,11 @@ class QuaccSettings(BaseSettings):
     VASP_PARALLEL_CMD: str = Field(
         "",
         description=(
-            "Parallel command to run VASP with Custodian."
-            "For example: srun -N 2 --ntasks-per-node 48"
-            "Note that this does not include the executable name."
+            """
+            Parallel command to run VASP with Custodian.
+            For example: `"srun -N 2 --ntasks-per-node 48"`.
+            Note that this does not include the executable name.
+            """
         ),
     )
     VASP_CMD: str = Field(
@@ -219,45 +246,57 @@ class QuaccSettings(BaseSettings):
     VASP_INCAR_COPILOT: Literal["off", "on", "aggressive"] = Field(
         "on",
         description=(
-            "Controls VASP co-pilot mode for automated INCAR parameter handling."
-            "off: Do not use co-pilot mode. INCAR parameters will be unmodified."
-            "on: Use co-pilot mode. This will only modify INCAR flags not already set by the user."
-            "aggressive: Use co-pilot mode in aggressive mode. This will modify INCAR flags even if they are already set by the user."
+            """
+            Controls VASP co-pilot mode for automated INCAR parameter handling.
+            off: Do not use co-pilot mode. INCAR parameters will be unmodified.
+            on: Use co-pilot mode. This will only modify INCAR flags not already set by the user.
+            aggressive: Use co-pilot mode in aggressive mode. This will modify INCAR flags even if they are already set by the user.
+            """
         ),
     )
     VASP_BADER: bool = Field(
         bool(which("bader")),
         description=(
-            "Whether to run a Bader analysis when summarizing VASP results."
-            "Requires bader to be in PATH."
+            """"
+            Whether to run a Bader analysis when summarizing VASP results.
+            Requires bader to be in PATH.
+            """
         ),
     )
     VASP_CHARGEMOL: bool = Field(
         bool(os.environ.get("DDEC6_ATOMIC_DENSITIES_DIR")),
         description=(
-            "Whether to run a Chargemol (i.e. DDEC6, CM5) analysis when summarizing VASP results."
-            "Requires the Chargemol executable to be in PATH and the DDEC6_ATOMIC_DENSITIES_DIR environment variable."
+            """
+            Whether to run a Chargemol (i.e. DDEC6, CM5) analysis when summarizing VASP results.
+            Requires the Chargemol executable to be in PATH and the DDEC6_ATOMIC_DENSITIES_DIR environment variable.
+            """
         ),
     )
     VASP_PRESET_MAG_DEFAULT: float = Field(
         1.0,
         description=(
-            "Default initial magmom to use for a given element if a preset "
-            "with magmoms is provided but an element is missing from the list"
+            """
+            Default initial magmom to use for a given element if a preset 
+            with magmoms is provided but an element is missing from the list.
+            """
         ),
     )
     VASP_MAG_CUTOFF: float = Field(
         0.05,
         description=(
-            "If the absolute value of all magnetic moments are below this value, "
-            "they will be set to 0 such that a spin-unpolarized calculation will be performed"
+            """
+            If the absolute value of all magnetic moments are below this value, 
+            they will be set to 0 such that a spin-unpolarized calculation will be performed.
+            """
         ),
     )
     VASP_COPY_MAGMOMS: bool = Field(
         True,
         description=(
-            "If True, any pre-existing atoms.get_magnetic_moments() will be set"
-            "in atoms.set_initial_magnetic_moments()."
+            """
+            If True, any pre-existing atoms.get_magnetic_moments() will be set 
+            in atoms.set_initial_magnetic_moments().
+            """
         ),
     )
     VASP_PRESET_DIR: Path = Field(
@@ -272,8 +311,10 @@ class QuaccSettings(BaseSettings):
     VASP_CUSTODIAN_VTST: bool = Field(
         False,
         description=(
-            "If VTST-related input swaps should be used when running Custodian."
-            "Requires VASP to be compiled with VTST"
+            """
+            If VTST-related input swaps should be used when running Custodian. 
+            Requires VASP to be compiled with VTST
+            """
         ),
     )
     VASP_CUSTODIAN_MAX_ERRORS: int = Field(
@@ -301,8 +342,10 @@ class QuaccSettings(BaseSettings):
     VASP_CUSTODIAN_WALL_TIME: Optional[int] = Field(
         None,
         description=(
-            "After this many seconds, Custodian will stop running "
-            "and ensure that VASP writes a STOPCAR"
+            """
+            After this many seconds, Custodian will stop running 
+            and ensure that VASP writes a STOPCAR
+            """
         ),
     )
 
@@ -355,8 +398,10 @@ class QuaccSettings(BaseSettings):
     DEBUG: bool = Field(
         False,
         description=(
-            "Whether to run in debug mode. This will set the logging level to DEBUG, "
-            "ASE logs (e.g. optimizations, vibrations, thermo) are printed to stdout."
+            """
+            Whether to run in debug mode. This will set the logging level to DEBUG, 
+            ASE logs (e.g. optimizations, vibrations, thermo) are printed to stdout.
+            """
         ),
     )
 
@@ -392,12 +437,17 @@ class QuaccSettings(BaseSettings):
         """Expand ~/ in paths."""
         return v.expanduser() if v is not None else v
 
-    @field_validator("PRIMARY_STORE")
-    def generate_store(cls, v: Union[str, Store]) -> Store:
+    @field_validator("STORE")
+    def generate_store(cls, v: Union[dict[str, Any], Store]) -> Store:
         """Generate the Maggma store."""
-        from monty.json import MontyDecoder
+        from maggma import stores
 
-        return MontyDecoder().decode(v) if isinstance(v, str) else v
+        if isinstance(v, dict):
+            store = getattr(stores, v.pop("type"))
+
+            return store(**v)
+        else:
+            return v
 
     model_config = SettingsConfigDict(env_prefix="quacc_")
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -106,7 +106,7 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
     # Data Store Settings
     # ---------------------------
-    STORE: Optional[Union[dict, Store]] = Field(
+    STORE: Optional[Union[dict[str, dict], Store]] = Field(
         None,
         description=(
             """

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,5 +1,2 @@
 DEBUG: true
 WORKFLOW_ENGINE: null
-STORE:
-  type: MemoryStore
-  collection_name: test_store

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,2 +1,5 @@
 DEBUG: true
 WORKFLOW_ENGINE: null
+STORE:
+  type: MemoryStore
+  collection_name: test_store

--- a/tests/core/recipes/lj_recipes/test_lj_recipes.py
+++ b/tests/core/recipes/lj_recipes/test_lj_recipes.py
@@ -10,11 +10,11 @@ DEFAULT_SETTINGS = SETTINGS.model_copy()
 
 
 def setup_module():
-    SETTINGS.PRIMARY_STORE = MemoryStore()
+    SETTINGS.STORE = MemoryStore()
 
 
 def teardown_module():
-    SETTINGS.PRIMARY_STORE = DEFAULT_SETTINGS.PRIMARY_STORE
+    SETTINGS.STORE = DEFAULT_SETTINGS.STORE
 
 
 def test_static_job(tmp_path, monkeypatch):

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -15,13 +15,13 @@ FILE_DIR = Path(__file__).parent
 
 
 def setup_function():
-    SETTINGS.PRIMARY_STORE = None
+    SETTINGS.STORE = None
     SETTINGS.GZIP_FILES = True
     SETTINGS.CREATE_UNIQUE_DIR = False
 
 
 def teardown_function():
-    SETTINGS.PRIMARY_STORE = DEFAULT_SETTINGS.PRIMARY_STORE
+    SETTINGS.STORE = DEFAULT_SETTINGS.STORE
     SETTINGS.GZIP_FILES = DEFAULT_SETTINGS.GZIP_FILES
     SETTINGS.CREATE_UNIQUE_DIR = DEFAULT_SETTINGS.CREATE_UNIQUE_DIR
 
@@ -43,7 +43,7 @@ def test_file_v1(tmp_path, monkeypatch):
 
 def test_store(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    SETTINGS.PRIMARY_STORE = MemoryStore()
+    SETTINGS.STORE = MemoryStore()
     atoms = bulk("Cu")
     static_job(atoms)
 


### PR DESCRIPTION
## Summary of Changes

This PR does two things:

1. FIX: It fixes support for `MontyStore`
2. CHANGE: It modifies how Maggma `Store`s are specified in the quacc settings. Now, instead of using `PRIMARY_STORE` with an unwieldy JSON string, a dictionary is provided: `STORE`. It specifies the maggma `Store` type and all arguments to pass to it.

Example:

```yaml title="~/.quacc.yaml"
STORE:
  MongoStore: # any store in `maggma.stores.__init__.py` is valid
    database: my_db_name
    collection_name: my_collection_name
    username: my_username
    password: my_password
    host: localhost
    port: 27017
```
   

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
