### PR TITLE
More robust handling of complex settings types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6]
+
+### Fixed
+
+- Using environment variables to set a setting to `None` now works as expected
+- Overall, more intuitive and robust handling of settings across the various input methods
+
 ## [0.6.5]
 
 ### Added

--- a/docs/user/settings/settings.md
+++ b/docs/user/settings/settings.md
@@ -32,7 +32,13 @@ WORKFLOW_ENGINE: # (3)!
 
 ## Using Environment Variables
 
-If you want to define quacc settings without writing them to a YAML file, you can instead modify the desired settings by defining individual environment variables with `QUACC` as the prefix. For instance, to modify the `SCRATCH_DIR` setting to be `$SCRATCH`, simply define `QUACC_SCRATCH_DIR=$SCRATCH` as a new environment variable. The environment variable takes precedence over any value specified in the YAML file. Most simple field types (e.g. `int`, `float`, `str`) will be automatically inferred from the environment variable.
+If you want to define quacc settings without writing them to a YAML file, you can instead modify the desired settings by defining individual environment variables with `QUACC` as the prefix. The environment variable takes precedence over any value specified in the YAML file. Most simple field types (e.g. `int`, `bool`, `float`, `str`) will be automatically inferred from the environment variable. To achieve the same results as the aforementioned YAML file, you would define the following environment variables:
+
+```bash
+export QUACC_SCRATCH_DIR=$SCRATCH
+export QUACC_CREATE_UNIQUE_DIR=False
+export QUACC_WORKFLOW_ENGINE=None
+```
 
 For more complex types, such as lists or dictionaries, refer to the corresponding section in the [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#parsing-environment-variable-values) documentation. We use `__` as the delimiter for nested settings.
 

--- a/src/quacc/_cli/quacc.py
+++ b/src/quacc/_cli/quacc.py
@@ -83,7 +83,6 @@ def set_(parameter: str, new_value: str) -> None:
     parameter = parameter.upper()
 
     _parameter_handler(parameter, SETTINGS.model_dump())
-    new_value = _type_handler(new_value)
 
     rich_print(f"Setting `{parameter}` to `{new_value}` in {CONFIG_FILE}")
     _update_setting(parameter, new_value, CONFIG_FILE)

--- a/src/quacc/_cli/quacc.py
+++ b/src/quacc/_cli/quacc.py
@@ -166,26 +166,6 @@ def _parameter_handler(parameter: str, settings_dict: dict) -> None:
         raise ValueError(msg)
 
 
-def _type_handler(value: str) -> Any:
-    """
-    Convert the string value to the appropriate type.
-
-    Parameters
-    ----------
-    value
-        The value to convert.
-
-    Returns
-    -------
-    Any
-    """
-    if value.lower() in {"null", "none"}:
-        value = None
-    elif value.lower() in ("true", "false"):
-        value = value.lower() == "true"
-    return value
-
-
 def _delete_setting(key: str, config_file: Path) -> None:
     """
     Remove the quacc setting from the configuration file.

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -526,4 +526,5 @@ def _type_handler(settings: dict[str, Any]) -> dict[str, Any]:
                 settings[key] = None
             elif value.lower() in {"true", "false"}:
                 settings[key] = value.lower() == "true"
+
     return settings

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -497,6 +497,6 @@ class QuaccSettings(BaseSettings):
             if isinstance(value, str):
                 if value.lower() in {"null", "none"}:
                     settings[key] = None
-                elif value.lower() in ("true", "false"):
+                elif value.lower() in {"true", "false"}:
                     settings[key] = value.lower() == "true"
         return settings

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,5 +1,5 @@
-DEBUG: True
-WORKFLOW_ENGINE: None
+DEBUG: true
+WORKFLOW_ENGINE: null
 STORE:
   MemoryStore:
     collection_name: test_store

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,5 +1,5 @@
-DEBUG: true
-WORKFLOW_ENGINE: null
+DEBUG: True
+WORKFLOW_ENGINE: None
 STORE:
   MemoryStore:
     collection_name: test_store

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -794,13 +794,13 @@ def test_constraints():
 
 def test_envvars():
     DEFAULT_SETTINGS = SETTINGS.model_copy()
-    SETTINGS.VASP_PP_PATH = "/path/to/pseudos"
-    SETTINGS.VASP_VDW = "/path/to/kernel"
+    SETTINGS.VASP_PP_PATH = str(Path("/path/to/pseudos"))
+    SETTINGS.VASP_VDW = str(Path("/path/to/kernel"))
 
     atoms = bulk("Cu")
     atoms.calc = Vasp(atoms, xc="beef-vdw")
-    assert os.environ.get("VASP_PP_PATH") == "/path/to/pseudos"
-    assert os.environ.get("ASE_VASP_VDW") == "/path/to/kernel"
+    assert os.environ.get("VASP_PP_PATH") == str(Path("/path/to/pseudos"))
+    assert os.environ.get("ASE_VASP_VDW") == str(Path("/path/to/kernel"))
 
     SETTINGS.VASP_PP_PATH = DEFAULT_SETTINGS.VASP_PP_PATH
     SETTINGS.VASP_VDW = DEFAULT_SETTINGS.VASP_VDW

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -38,7 +38,6 @@ def test_help(runner):
     response = runner.invoke(app, ["--help"])
     assert response.exit_code == 0
 
-
 def test_set(runner):
     response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "covalent"])
     assert response.exit_code == 0

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -37,6 +37,8 @@ def test_version(runner):
 def test_help(runner):
     response = runner.invoke(app, ["--help"])
     assert response.exit_code == 0
+
+
 def test_set(runner):
     response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "covalent"])
     assert response.exit_code == 0

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -40,7 +40,6 @@ def test_help(runner):
 
 
 def test_set(runner):
-
     response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "covalent"])
     assert response.exit_code == 0
     assert "covalent" in response.stdout

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -37,7 +37,6 @@ def test_version(runner):
 def test_help(runner):
     response = runner.invoke(app, ["--help"])
     assert response.exit_code == 0
-
 def test_set(runner):
     response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "covalent"])
     assert response.exit_code == 0

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -40,15 +40,6 @@ def test_help(runner):
 
 
 def test_set(runner):
-    response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "None"])
-    assert response.exit_code == 0
-    assert "None" in response.stdout
-    val = None
-    with open(TEST_YAML) as f:
-        for line in f:
-            if "WORKFLOW_ENGINE" in line:
-                val = line.split(":")[-1].strip()
-    assert not val
 
     response = runner.invoke(app, ["set", "WORKFLOW_ENGINE", "covalent"])
     assert response.exit_code == 0
@@ -69,16 +60,6 @@ def test_set(runner):
             if "VASP_PARALLEL_CMD" in line:
                 val = line.split(":")[-1].strip()
     assert val == "dummy"
-
-    response = runner.invoke(app, ["set", "GZIP_FILES", "True"])
-    assert response.exit_code == 0
-    assert "True" in response.stdout
-    val = None
-    with open(TEST_YAML) as f:
-        for line in f:
-            if "GZIP_FILES" in line:
-                val = line.split(":")[-1].strip()
-    assert val == "true"
 
 
 def test_unset(runner):

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -47,7 +47,6 @@ def test_set(runner):
             if "WORKFLOW_ENGINE" in line:
                 val = line.split(":")[-1].strip()
     assert val == "covalent"
-
     response = runner.invoke(app, ["set", "VASP_PARALLEL_CMD", "dummy"])
     assert response.exit_code == 0
     assert "dummy" in response.stdout

--- a/tests/core/recipes/gulp_recipes/test_gulp_recipes.py
+++ b/tests/core/recipes/gulp_recipes/test_gulp_recipes.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from ase.build import bulk, molecule
 
@@ -141,7 +142,7 @@ def test_envvars(tmp_path, monkeypatch):
 
     atoms = molecule("H2O")
 
-    SETTINGS.GULP_LIB = "/path/to/lib"
+    SETTINGS.GULP_LIB = str(Path("/path/to/lib"))
     assert static_job(atoms)
-    assert os.environ.get("GULP_LIB") == "/path/to/lib"
+    assert os.environ.get("GULP_LIB") == str(Path("/path/to/lib"))
     SETTINGS.GULP_LIB = DEFAULT_SETTINGS.GULP_LIB

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -25,7 +25,6 @@ def teardown_function():
     SETTINGS.GZIP_FILES = DEFAULT_SETTINGS.GZIP_FILES
     SETTINGS.CREATE_UNIQUE_DIR = DEFAULT_SETTINGS.CREATE_UNIQUE_DIR
 
-
 def test_file_v1(tmp_path, monkeypatch):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
@@ -73,7 +72,6 @@ def test_env_var2(monkeypatch):
 
     monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "none")
     assert QuaccSettings().WORKFLOW_ENGINE is None
-
 
 def test_yaml(tmp_path, monkeypatch):
     p = tmp_path / "my/new/scratch/dir"

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -25,6 +25,7 @@ def teardown_function():
     SETTINGS.GZIP_FILES = DEFAULT_SETTINGS.GZIP_FILES
     SETTINGS.CREATE_UNIQUE_DIR = DEFAULT_SETTINGS.CREATE_UNIQUE_DIR
 
+
 def test_file_v1(tmp_path, monkeypatch):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
@@ -72,6 +73,7 @@ def test_env_var2(monkeypatch):
 
     monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "none")
     assert QuaccSettings().WORKFLOW_ENGINE is None
+
 
 def test_yaml(tmp_path, monkeypatch):
     p = tmp_path / "my/new/scratch/dir"

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -60,7 +60,7 @@ def test_env_var2(monkeypatch):
     assert QuaccSettings().WORKFLOW_ENGINE is None
 
     monkeypatch.setenv("GZIP_FILES", "FaLsE")
-    assert QuaccSettings().WORKFLOW_ENGINE is False
+    assert QuaccSettings().GZIP_FILES is False
 
 
 def test_yaml(tmp_path, monkeypatch):

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -8,22 +8,7 @@ from quacc import SETTINGS
 from quacc.recipes.emt.core import relax_job, static_job
 from quacc.settings import QuaccSettings
 
-DEFAULT_SETTINGS = SETTINGS.model_copy()
-
-
 FILE_DIR = Path(__file__).parent
-
-
-def setup_function():
-    SETTINGS.STORE = None
-    SETTINGS.GZIP_FILES = True
-    SETTINGS.CREATE_UNIQUE_DIR = False
-
-
-def teardown_function():
-    SETTINGS.STORE = DEFAULT_SETTINGS.STORE
-    SETTINGS.GZIP_FILES = DEFAULT_SETTINGS.GZIP_FILES
-    SETTINGS.CREATE_UNIQUE_DIR = DEFAULT_SETTINGS.CREATE_UNIQUE_DIR
 
 
 def test_file_v1(tmp_path, monkeypatch):

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -59,6 +59,9 @@ def test_env_var2(monkeypatch):
     monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "none")
     assert QuaccSettings().WORKFLOW_ENGINE is None
 
+    monkeypatch.setenv("GZIP_FILES", "FaLsE")
+    assert QuaccSettings().WORKFLOW_ENGINE is False
+
 
 def test_yaml(tmp_path, monkeypatch):
     p = tmp_path / "my/new/scratch/dir"

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -27,19 +27,16 @@ def teardown_function():
 
 
 def test_file_v1(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
 
-    with open("quacc_test.yaml", "w") as f:
+    with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
-    monkeypatch.setenv(
-        "QUACC_CONFIG_FILE", os.path.join(os.getcwd(), "quacc_test.yaml")
-    )
+    monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
 
     assert QuaccSettings().GZIP_FILES is False
     assert QuaccSettings().WORKFLOW_ENGINE is None
     assert QuaccSettings().DEBUG is True
     assert QuaccSettings().STORE is None
-    os.remove("quacc_test.yaml")
+    os.remove(tmp_path / "quacc_test.yaml")
 
 
 def test_store(tmp_path, monkeypatch):
@@ -80,11 +77,10 @@ def test_env_var2(monkeypatch):
 
 
 def test_yaml(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
 
     p = tmp_path / "my/new/scratch/dir"
     monkeypatch.delenv("QUACC_SCRATCH_DIR", raising=False)
-    with open("quacc_test.yaml", "w") as f:
+    with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write(f"SCRATCH_DIR: {p}")
-    monkeypatch.setenv("QUACC_CONFIG_FILE", "quacc_test.yaml")
+    monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
     assert QuaccSettings().SCRATCH_DIR == p.expanduser().resolve()

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -11,7 +11,7 @@ from quacc.settings import QuaccSettings
 FILE_DIR = Path(__file__).parent
 
 
-def test_file_v1(tmp_path, monkeypatch):
+def test_file(tmp_path, monkeypatch):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
     monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -30,7 +30,7 @@ def test_file_v1(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     with open("quacc_test.yaml", "w") as f:
-        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE:\nDEBUG: true")
+        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
     monkeypatch.setenv(
         "QUACC_CONFIG_FILE", os.path.join(os.getcwd(), "quacc_test.yaml")
     )
@@ -38,6 +38,7 @@ def test_file_v1(tmp_path, monkeypatch):
     assert QuaccSettings().GZIP_FILES is False
     assert QuaccSettings().WORKFLOW_ENGINE is None
     assert QuaccSettings().DEBUG is True
+    assert QuaccSettings().STORE is None
     os.remove("quacc_test.yaml")
 
 
@@ -64,7 +65,18 @@ def test_results_dir(tmp_path, monkeypatch):
 def test_env_var(monkeypatch, tmp_path):
     p = tmp_path / "my/scratch/dir"
     monkeypatch.setenv("QUACC_SCRATCH_DIR", p)
-    assert p.expanduser().resolve() == QuaccSettings().SCRATCH_DIR
+    assert QuaccSettings().SCRATCH_DIR == p.expanduser().resolve()
+
+
+def test_env_var2(monkeypatch):
+    monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "None")
+    assert QuaccSettings().WORKFLOW_ENGINE is None
+
+    monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "null")
+    assert QuaccSettings().WORKFLOW_ENGINE is None
+
+    monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "none")
+    assert QuaccSettings().WORKFLOW_ENGINE is None
 
 
 def test_yaml(tmp_path, monkeypatch):
@@ -75,4 +87,4 @@ def test_yaml(tmp_path, monkeypatch):
     with open("quacc_test.yaml", "w") as f:
         f.write(f"SCRATCH_DIR: {p}")
     monkeypatch.setenv("QUACC_CONFIG_FILE", "quacc_test.yaml")
-    assert p.expanduser().resolve() == QuaccSettings().SCRATCH_DIR
+    assert QuaccSettings().SCRATCH_DIR == p.expanduser().resolve()

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -27,7 +27,6 @@ def teardown_function():
 
 
 def test_file_v1(tmp_path, monkeypatch):
-
     with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
     monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
@@ -77,7 +76,6 @@ def test_env_var2(monkeypatch):
 
 
 def test_yaml(tmp_path, monkeypatch):
-
     p = tmp_path / "my/new/scratch/dir"
     monkeypatch.delenv("QUACC_SCRATCH_DIR", raising=False)
     with open(tmp_path / "quacc_test.yaml", "w") as f:

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -49,7 +49,15 @@ def test_env_var(monkeypatch, tmp_path):
     assert QuaccSettings().SCRATCH_DIR == p.expanduser().resolve()
 
 
-def test_env_var2(monkeypatch):
+def test_env_var2(monkeypatch, tmp_path):
+    with open(tmp_path / "quacc_test.yaml", "w") as f:
+        f.write("")
+
+    monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
+    assert str(QuaccSettings().CONFIG_FILE) == str(
+        Path(os.path.join(tmp_path, "quacc_test.yaml"))
+    )
+
     monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "None")
     assert QuaccSettings().WORKFLOW_ENGINE is None
 
@@ -59,7 +67,7 @@ def test_env_var2(monkeypatch):
     monkeypatch.setenv("QUACC_WORKFLOW_ENGINE", "none")
     assert QuaccSettings().WORKFLOW_ENGINE is None
 
-    monkeypatch.setenv("GZIP_FILES", "FaLsE")
+    monkeypatch.setenv("QUACC_GZIP_FILES", "FaLsE")
     assert QuaccSettings().GZIP_FILES is False
 
 


### PR DESCRIPTION
Closes #1688. Providing a string of "none" or "null" (case-insensitive) will automatically transform to `None`, whether via the CLI, YAML, or environment variables. Same for "true" or "false" (case-insensitive) to `True` or `False`. This is all done at model validation time so we handle all the various settings management cases in one spot.