### PR TITLE
Add an option to store intermediate log files during ASE opt

### DIFF
--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -216,9 +216,9 @@ def run_opt(
 
     # Run optimization
     with traj, optimizer(atoms, **optimizer_kwargs) as dyn:
-        opt = dyn.irun(fmax=fmax, steps=max_steps, **run_kwargs)
-        for i, _ in enumerate(opt):
-            if store_intermediate_files:
+        if store_intermediate_files:
+            opt = dyn.irun(fmax=fmax, steps=max_steps, **run_kwargs)
+            for i, _ in enumerate(opt):
                 _copy_intermediate_files(
                     tmpdir,
                     i,
@@ -228,6 +228,8 @@ def run_opt(
                         optimizer_kwargs["logfile"],
                     ],
                 )
+        else:
+            dyn.run(fmax=fmax, steps=max_steps, **run_kwargs)
 
     # Store the trajectory atoms
     dyn.traj_atoms = read(traj_file, index=":")

--- a/tests/core/recipes/orca_recipes/test_orca_recipes.py
+++ b/tests/core/recipes/orca_recipes/test_orca_recipes.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 from ase.build import molecule
@@ -127,3 +128,15 @@ def test_ase_relax_job(tmp_path, monkeypatch):
     assert output.get("trajectory")
     assert output.get("trajectory_results")
     assert output.get("attributes")
+
+
+def test_ase_relax_job_store(tmp_path, monkeypatch):
+
+    monkeypatch.chdir(tmp_path)
+
+    atoms = molecule("H2O")
+    output = ase_relax_job(atoms, opt_params={"store_intermediate_files": True})
+    nsteps = len(output["trajectory"])
+    for i in range(nsteps):
+        assert f"step{i}" in os.listdir(output["dir_name"])
+        assert "orca.xyz.gz" in os.listdir(Path(output["dir_name"], f"step{i}"))

--- a/tests/core/recipes/orca_recipes/test_orca_recipes.py
+++ b/tests/core/recipes/orca_recipes/test_orca_recipes.py
@@ -131,7 +131,6 @@ def test_ase_relax_job(tmp_path, monkeypatch):
 
 
 def test_ase_relax_job_store(tmp_path, monkeypatch):
-
     monkeypatch.chdir(tmp_path)
 
     atoms = molecule("H2O")

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 from pathlib import Path
@@ -5,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from quacc.utils.files import (
+    check_logfile,
     copy_decompress_files_from_dir,
     copy_decompress_tree,
     make_unique_dir,
@@ -106,3 +108,15 @@ def test_copy_decompress_files_from_dir_v2(tmp_path, monkeypatch):
 def test_copy_decompress_files_from_dir_v3(caplog):
     with caplog.at_level(logging.WARNING):
         copy_decompress_files_from_dir("fake", "test")
+
+
+def test_check_logfile(tmp_path):
+    with open(tmp_path / "logs.out", "w") as f:
+        f.write("trigger")
+    assert check_logfile(str(tmp_path / "logs.out"), "trigger") is True
+    assert check_logfile(str(tmp_path / "logs.out"), "test") is False
+
+    with gzip.open(tmp_path / "logs2.out.gz", "wb") as gf:
+        gf.write(b"trigger")
+    assert check_logfile(str(tmp_path / "logs2.out"), "trigger") is True
+    assert check_logfile(str(tmp_path / "logs2.out"), "test") is False


### PR DESCRIPTION
Closes #1710.

Allows for the storage of intermediate log files during an ASE optimization.

```python
from quacc.recipes.orca.core import ase_relax_job
from ase.build import molecule

atoms = molecule("H2O")
ase_relax_job(atoms, nprocs=1, opt_params={"store_intermediate_files": True})
```

This would store the intermediate results in a folder step0, step1, step2, etc.
