### PR TITLE
Allow for thread-safe execution

### DIFF
--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -81,7 +81,8 @@ def calc_setup(
     # for all threads in the current process. However, elsewhere in the code,
     # we use absolute paths to avoid issues. We keep this here for now because some
     # old ASE calculators do not support the `directory` keyword argument.
-    os.chdir(tmpdir)
+    if SETTINGS.THREAD_SAFE:
+        os.chdir(tmpdir)
 
     return tmpdir, job_results_dir
 
@@ -126,7 +127,8 @@ def calc_cleanup(atoms: Atoms, tmpdir: Path | str, job_results_dir: Path | str) 
     # for all threads in the current process. However, elsewhere in the code,
     # we use absolute paths to avoid issues. We keep this here for now because some
     # old ASE calculators do not support the `directory` keyword argument.
-    os.chdir(job_results_dir)
+    if SETTINGS.THREAD_SAFE:
+        os.chdir(job_results_dir)
 
     # Gzip files in tmpdir
     if SETTINGS.GZIP_FILES:

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -81,7 +81,7 @@ def calc_setup(
     # for all threads in the current process. However, elsewhere in the code,
     # we use absolute paths to avoid issues. We keep this here for now because some
     # old ASE calculators do not support the `directory` keyword argument.
-    if SETTINGS.THREAD_SAFE:
+    if SETTINGS.CHDIR:
         os.chdir(tmpdir)
 
     return tmpdir, job_results_dir
@@ -127,7 +127,7 @@ def calc_cleanup(atoms: Atoms, tmpdir: Path | str, job_results_dir: Path | str) 
     # for all threads in the current process. However, elsewhere in the code,
     # we use absolute paths to avoid issues. We keep this here for now because some
     # old ASE calculators do not support the `directory` keyword argument.
-    if SETTINGS.THREAD_SAFE:
+    if SETTINGS.CHDIR:
         os.chdir(job_results_dir)
 
     # Gzip files in tmpdir

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -103,16 +103,17 @@ class QuaccSettings(BaseSettings):
             """
         ),
     )
-    THREAD_SAFE: bool = Field(
-        False,
+    CHDIR: bool = Field(
+        True,
         description=(
             """
-            Whether quacc needs to be thread-safe. Setting this parameter to True
-            will ensure that `os.chdir` calls are not made during the calculation.
-            The `os.chdir` call is necessary for some ASE calculators that don't
-            have proper `directory` handling, but this breaks thread-safety.
-            In general, we recommend leaving this parameter as `False` unless you
-            are sure that you need it.
+            Whether quacc will make `os.chdir` calls to change the working directory
+            to be the location where the calculation is run. By default, we leave this
+            as `True` because not all ASE calculators properly support a `directory`
+            parameter. In most cases, this is fine, but it breaks thread safety.
+            If you need to run multiple, parallel calculations in a single Python process,
+            such as in a multithreaded job execution mode, then this setting needs
+            to be `False`. Note that not all calculators properly support this, however.
             """
         ),
     )

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -103,6 +103,19 @@ class QuaccSettings(BaseSettings):
             """
         ),
     )
+    THREAD_SAFE: bool = Field(
+        False,
+        description=(
+            """
+            Whether quacc needs to be thread-safe. Setting this parameter to True
+            will ensure that `os.chdir` calls are not made during the calculation.
+            The `os.chdir` call is necessary for some ASE calculators that don't
+            have proper `directory` handling, but this breaks thread-safety.
+            In general, we recommend leaving this parameter as `False` unless you
+            are sure that you need it.
+            """
+        ),
+    )
     GZIP_FILES: bool = Field(
         True, description="Whether generated files should be gzip'd."
     )

--- a/tests/core/recipes/lj_recipes/test_lj_recipes.py
+++ b/tests/core/recipes/lj_recipes/test_lj_recipes.py
@@ -104,13 +104,7 @@ def test_freq_job_threads(tmp_path, monkeypatch):
 
     output = freq_job(relax_job(atoms)["atoms"])
     assert output["natoms"] == len(atoms)
-    assert output["parameters"]["epsilon"] == 1.0
-    assert output["parameters"]["sigma"] == 1.0
-    assert output["parameters"]["rc"] == 3
-    assert output["parameters"]["ro"] == 0.66 * 3
     assert len(output["results"]["vib_freqs_raw"]) == 3 * len(atoms)
-    assert len(output["results"]["vib_freqs"]) == 3 * len(atoms) - 6
-    assert len(output["parameters_thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
     assert output["parameters_thermo"]["n_imag"] == 0
 
-    SETTINGS.CHDIR = True
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR = True

--- a/tests/core/recipes/lj_recipes/test_lj_recipes.py
+++ b/tests/core/recipes/lj_recipes/test_lj_recipes.py
@@ -93,3 +93,23 @@ def test_freq_job(tmp_path, monkeypatch):
     assert len(output["results"]["vib_freqs"]) == 3 * len(atoms) - 6
     assert len(output["parameters_thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
     assert output["parameters_thermo"]["n_imag"] == 0
+
+def test_freq_job_threads(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    SETTINGS.CHDIR = False
+
+    atoms = molecule("H2O")
+
+    output = freq_job(relax_job(atoms)["atoms"])
+    assert output["natoms"] == len(atoms)
+    assert output["parameters"]["epsilon"] == 1.0
+    assert output["parameters"]["sigma"] == 1.0
+    assert output["parameters"]["rc"] == 3
+    assert output["parameters"]["ro"] == 0.66 * 3
+    assert len(output["results"]["vib_freqs_raw"]) == 3 * len(atoms)
+    assert len(output["results"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert len(output["parameters_thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
+    assert output["parameters_thermo"]["n_imag"] == 0
+
+    SETTINGS.CHDIR = True

--- a/tests/core/recipes/lj_recipes/test_lj_recipes.py
+++ b/tests/core/recipes/lj_recipes/test_lj_recipes.py
@@ -94,6 +94,7 @@ def test_freq_job(tmp_path, monkeypatch):
     assert len(output["parameters_thermo"]["vib_freqs"]) == 3 * len(atoms) - 6
     assert output["parameters_thermo"]["n_imag"] == 0
 
+
 def test_freq_job_threads(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -122,4 +122,3 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
     assert np.shape(output["results"]["forces"]) == (8, 3)
     assert output["atoms"] != atoms
     assert output["atoms"].get_volume() != pytest.approx(atoms.get_volume())
-

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -141,4 +141,4 @@ def test_relax_job_threads(tmp_path, monkeypatch):
     output = relax_job(atoms, method=method)
     assert output["results"]["energy"] == pytest.approx(-32.6711566550002)
 
-    SETTINGS.MODEL_COPY = False
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -5,10 +5,7 @@ torch = pytest.importorskip("torch")
 import numpy as np
 from ase.build import bulk
 
-from quacc import SETTINGS
 from quacc.recipes.mlp.core import relax_job, static_job
-
-DEFAULT_SETTINGS = SETTINGS.model_copy()
 
 methods = []
 try:
@@ -126,19 +123,3 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
     assert output["atoms"] != atoms
     assert output["atoms"].get_volume() != pytest.approx(atoms.get_volume())
 
-
-def test_relax_job_threads(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-
-    from quacc import SETTINGS
-
-    SETTINGS.CHDIR = False
-
-    _set_dtype(64)
-
-    atoms = bulk("Cu") * (2, 2, 2)
-    atoms[0].position += 0.1
-    output = relax_job(atoms, method=method)
-    assert output["results"]["energy"] == pytest.approx(-32.6711566550002)
-
-    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -126,10 +126,12 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
     assert output["atoms"] != atoms
     assert output["atoms"].get_volume() != pytest.approx(atoms.get_volume())
 
+
 def test_relax_job_threads(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     from quacc import SETTINGS
+
     SETTINGS.CHDIR = False
 
     _set_dtype(64)
@@ -138,5 +140,5 @@ def test_relax_job_threads(tmp_path, monkeypatch):
     atoms[0].position += 0.1
     output = relax_job(atoms, method=method)
     assert output["results"]["energy"] == pytest.approx(-32.6711566550002)
-    
+
     SETTINGS.MODEL_COPY = False

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -5,7 +5,10 @@ torch = pytest.importorskip("torch")
 import numpy as np
 from ase.build import bulk
 
+from quacc import SETTINGS
 from quacc.recipes.mlp.core import relax_job, static_job
+
+DEFAULT_SETTINGS = SETTINGS.model_copy()
 
 methods = []
 try:
@@ -122,3 +125,18 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
     assert np.shape(output["results"]["forces"]) == (8, 3)
     assert output["atoms"] != atoms
     assert output["atoms"].get_volume() != pytest.approx(atoms.get_volume())
+
+def test_relax_job_threads(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    from quacc import SETTINGS
+    SETTINGS.CHDIR = False
+
+    _set_dtype(64)
+
+    atoms = bulk("Cu") * (2, 2, 2)
+    atoms[0].position += 0.1
+    output = relax_job(atoms, method=method)
+    assert output["results"]["energy"] == pytest.approx(-32.6711566550002)
+    
+    SETTINGS.MODEL_COPY = False

--- a/tests/parsl/test_emt_recipes.py
+++ b/tests/parsl/test_emt_recipes.py
@@ -6,10 +6,16 @@ from ase.build import bulk
 
 from quacc.recipes.emt.core import relax_job  # skipcq: PYL-C0412
 from quacc.recipes.emt.slabs import bulk_to_slabs_flow  # skipcq: PYL-C0412
+from quacc import SETTINGS
 
+DEFAULT_SETTINGS = SETTINGS.model_copy()
 
-def test_parsl_functools(tmp_path, monkeypatch):
+@pytest.mark.parametrize("chdir", [True, False])
+def test_parsl_functools(tmp_path, monkeypatch, chdir):
     monkeypatch.chdir(tmp_path)
+
+    SETTINGS.CHDIR = chdir
+    
     atoms = bulk("Cu")
     result = bulk_to_slabs_flow(
         atoms, job_params={"relax_job": {"opt_params": {"fmax": 0.1}}}, run_static=False
@@ -18,10 +24,15 @@ def test_parsl_functools(tmp_path, monkeypatch):
     assert "atoms" in result[-1]
     assert result[-1]["fmax"] == 0.1
 
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
 
-def test_phonon_flow(tmp_path, monkeypatch):
+
+@pytest.mark.parametrize("chdir", [True, False])
+def test_phonon_flow(tmp_path, monkeypatch, chdir):
     pytest.importorskip("phonopy")
     from quacc.recipes.emt.phonons import phonon_flow
+
+    SETTINGS.CHDIR = chdir
 
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
@@ -30,10 +41,14 @@ def test_phonon_flow(tmp_path, monkeypatch):
         101,
     )
 
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
 
-def test_phonon_flow_multistep(tmp_path, monkeypatch):
+@pytest.mark.parametrize("chdir", [True, False])
+def test_phonon_flow_multistep(tmp_path, monkeypatch, chdir):
     pytest.importorskip("phonopy")
     from quacc.recipes.emt.phonons import phonon_flow
+
+    SETTINGS.CHDIR = chdir
 
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
@@ -42,3 +57,5 @@ def test_phonon_flow_multistep(tmp_path, monkeypatch):
     assert output.result()["results"]["thermal_properties"]["temperatures"].shape == (
         101,
     )
+
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir

--- a/tests/parsl/test_emt_recipes.py
+++ b/tests/parsl/test_emt_recipes.py
@@ -4,18 +4,19 @@ parsl = pytest.importorskip("parsl")
 
 from ase.build import bulk
 
+from quacc import SETTINGS
 from quacc.recipes.emt.core import relax_job  # skipcq: PYL-C0412
 from quacc.recipes.emt.slabs import bulk_to_slabs_flow  # skipcq: PYL-C0412
-from quacc import SETTINGS
 
 DEFAULT_SETTINGS = SETTINGS.model_copy()
+
 
 @pytest.mark.parametrize("chdir", [True, False])
 def test_parsl_functools(tmp_path, monkeypatch, chdir):
     monkeypatch.chdir(tmp_path)
 
     SETTINGS.CHDIR = chdir
-    
+
     atoms = bulk("Cu")
     result = bulk_to_slabs_flow(
         atoms, job_params={"relax_job": {"opt_params": {"fmax": 0.1}}}, run_static=False
@@ -42,6 +43,7 @@ def test_phonon_flow(tmp_path, monkeypatch, chdir):
     )
 
     SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
+
 
 @pytest.mark.parametrize("chdir", [True, False])
 def test_phonon_flow_multistep(tmp_path, monkeypatch, chdir):

--- a/tests/parsl/test_emt_recipes.py
+++ b/tests/parsl/test_emt_recipes.py
@@ -25,7 +25,7 @@ def test_parsl_functools(tmp_path, monkeypatch, chdir):
     assert "atoms" in result[-1]
     assert result[-1]["fmax"] == 0.1
 
-    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR
 
 
 @pytest.mark.parametrize("chdir", [True, False])
@@ -42,7 +42,7 @@ def test_phonon_flow(tmp_path, monkeypatch, chdir):
         101,
     )
 
-    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR
 
 
 @pytest.mark.parametrize("chdir", [True, False])
@@ -60,4 +60,4 @@ def test_phonon_flow_multistep(tmp_path, monkeypatch, chdir):
         101,
     )
 
-    SETTINGS.CHDIR = DEFAULT_SETTINGS.chdir
+    SETTINGS.CHDIR = DEFAULT_SETTINGS.CHDIR


### PR DESCRIPTION
## Summary of Changes

This PR adds a new quacc setting, `CHDIR`, that will allow the user to specify whether any `os.chdir` calls are made, thereby allowing for multiple jobs to be run on a single Python process.

Closes #1641.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
