### PR TITLE
Modify VASP double relaxes to be a flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.6.8]
 
+### Added
+
+- Added an option to prevent `os.chdir` calls for multithread safety
+- Added a common elastic calculation
+
 ### Fixed
 
 - Fixed MP VASP double relaxes, where the same relaxation was done twice by mistake

--- a/docs/user/recipes/recipes_list.md
+++ b/docs/user/recipes/recipes_list.md
@@ -234,7 +234,7 @@ The list of available quacc recipes is shown below. The "Req'd Extras" column sp
 | ------------------------------- | ---------------- | ----------------------------------------------- | ------------ |
 | VASP Static                     | `#!Python @job`  | [quacc.recipes.vasp.core.static_job][]          |              |
 | VASP Relax                      | `#!Python @job`  | [quacc.recipes.vasp.core.relax_job][]           |              |
-| VASP Double Relax               | `#!Python @job`  | [quacc.recipes.vasp.core.double_relax_job][]    |              |
+| VASP Double Relax               | `#!Python @flow` | [quacc.recipes.vasp.core.double_relax_flow][]   |              |
 | VASP Slab Static                | `#!Python @job`  | [quacc.recipes.vasp.slabs.static_job][]         |              |
 | VASP Slab Relax                 | `#!Python @job`  | [quacc.recipes.vasp.slabs.relax_job][]          |              |
 | VASP Bulk to Slabs              | `#!Python @flow` | [quacc.recipes.vasp.slabs.bulk_to_slabs_flow][] |              |

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from quacc import job, strip_decorator
+from quacc import job
 from quacc.recipes.vasp._base import base_fn
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ def relax_job(
 
 
 @job
-def double_relax_job(
+def double_relax_flow(
     atoms: Atoms,
     preset: str | None = "BulkSet",
     relax_cell: bool = True,
@@ -161,12 +161,10 @@ def double_relax_job(
     relax2_kwargs = relax2_kwargs or {}
 
     # Run first relaxation
-    summary1 = strip_decorator(relax_job)(
-        atoms, preset=preset, relax_cell=relax_cell, **relax1_kwargs
-    )
+    summary1 = relax_job(atoms, preset=preset, relax_cell=relax_cell, **relax1_kwargs)
 
     # Run second relaxation
-    summary2 = strip_decorator(relax_job)(
+    summary2 = relax_job(
         summary1["atoms"],
         preset=preset,
         relax_cell=relax_cell,

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -408,7 +408,7 @@ def mp_metagga_relax_flow(
     double_relax_results = mp_metagga_relax_job_(
         relax_results["atoms"],
         bandgap=relax_results["output"]["bandgap"],
-        copy_files={relax_results["dir_name"]): ["CHGCAR*", "WAVECAR*"],
+        copy_files={relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
     )
 
     # Run the static

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 @job
 def mp_gga_relax_job(
-    atoms: Atoms, SourceDirectory | dict[SourceDirectory, Filenames] | None = None, **calc_kwargs
+    atoms: Atoms, copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None, **calc_kwargs
 ) -> VaspSchema:
     """
     Function to relax a structure with the original Materials Project GGA(+U) settings.

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
 
     from quacc.schemas._aliases.vasp import (
-        DoubleRelaxSchema,
         MPGGARelaxFlowSchema,
         MPMetaGGARelaxFlowSchema,
         VaspSchema,
@@ -47,9 +46,9 @@ if TYPE_CHECKING:
 @job
 def mp_gga_relax_job(
     atoms: Atoms, copy_files: str | Path | list[str | Path] | None = None, **calc_kwargs
-) -> DoubleRelaxSchema:
+) -> VaspSchema:
     """
-    Function to (double) relax a structure with the original Materials Project GGA(+U) settings.
+    Function to relax a structure with the original Materials Project GGA(+U) settings.
 
     Parameters
     ----------
@@ -64,36 +63,53 @@ def mp_gga_relax_job(
 
     Returns
     -------
-    DoubleRelaxSchema
+    VaspSchema
         Dictionary of results.
     """
 
-    def _relax(
-        atoms: Atoms,
-        copy_files: str | Path | list[str | Path] | None = None,
-        calc_kwargs: dict[str, Any] | None = None,
-    ) -> VaspSchema:
-        """A helper function to run a relaxation with the MP GGA settings."""
-        calc_defaults = {"pmg_input_set": MPRelaxSet}
-        return base_fn(
-            atoms,
-            calc_defaults=calc_defaults,
-            calc_swaps=calc_kwargs,
-            additional_fields={"name": "MP GGA Relax"},
-            copy_files=copy_files,
-        )
-
-    summary1 = _relax(atoms, copy_files=copy_files, calc_kwargs=calc_kwargs)
-    summary2 = _relax(
-        summary1["atoms"],
-        copy_files=[
-            Path(summary1["dir_name"]) / "CHGCAR",
-            Path(summary1["dir_name"]) / "WAVECAR",
-        ],
-        calc_kwargs=calc_kwargs,
+    calc_defaults = {"pmg_input_set": MPRelaxSet}
+    return base_fn(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        additional_fields={"name": "MP GGA Relax"},
+        copy_files=copy_files,
     )
 
-    return {"relax1": summary1, "relax2": summary2}
+
+@job
+def mp_gga_relax_job(
+    atoms: Atoms, copy_files: str | Path | list[str | Path] | None = None, **calc_kwargs
+) -> VaspSchema:
+    """
+    Function to relax a structure with the original Materials Project GGA(+U) settings.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    copy_files
+        File(s) to copy to the runtime directory. If a directory is provided, it will be recursively unpacked.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to
+        `None` to remove a pre-existing key entirely. For a list of available
+        keys, refer to [ase.calculators.vasp.vasp.Vasp][].
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results.
+    """
+
+    calc_defaults = {"pmg_input_set": MPRelaxSet}
+
+    return base_fn(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        additional_fields={"name": "MP GGA Relax"},
+        copy_files=copy_files,
+    )
 
 
 @job
@@ -201,9 +217,9 @@ def mp_metagga_relax_job(
     bandgap: float | None = None,
     copy_files: str | Path | list[str | Path] | None = None,
     **calc_kwargs,
-) -> DoubleRelaxSchema:
+) -> VaspSchema:
     """
-    Function to (double) relax a structure with Materials Project r2SCAN workflow settings. By default, this uses
+    Function to relax a structure with Materials Project r2SCAN workflow settings. By default, this uses
     an r2SCAN relax step.
 
     Reference: https://doi.org/10.1103/PhysRevMaterials.6.013801
@@ -223,47 +239,25 @@ def mp_metagga_relax_job(
 
     Returns
     -------
-    DoubleRelaxSchema
+    VaspSchema
         Dictionary of results.
     """
 
-    def _relax(
-        atoms: Atoms,
-        copy_files: str | Path | list[str | Path] | None = None,
-        bandgap: float | None = None,
-        calc_kwargs: dict[str, Any] | None = None,
-    ) -> VaspSchema:
-        """A helper function to run a relaxation with the MP r2SCAN settings."""
-        calc_defaults = {
-            "pmg_input_set": partial(
-                MPScanRelaxSet, bandgap=bandgap or 0.0, auto_ismear=False
-            ),
-            "laechg": False,  # Deviation from MP (but logical)
-            "lvtot": False,  # Deviation from MP (but logical)
-            "lwave": True,
-        }
-        return base_fn(
-            atoms,
-            calc_defaults=calc_defaults,
-            calc_swaps=calc_kwargs,
-            additional_fields={"name": "MP Meta-GGA Relax"},
-            copy_files=copy_files,
-        )
-
-    summary1 = _relax(
-        atoms, copy_files=copy_files, bandgap=bandgap, calc_kwargs=calc_kwargs
+    calc_defaults = {
+        "pmg_input_set": partial(
+            MPScanRelaxSet, bandgap=bandgap or 0.0, auto_ismear=False
+        ),
+        "laechg": False,  # Deviation from MP (but logical)
+        "lvtot": False,  # Deviation from MP (but logical)
+        "lwave": True,
+    }
+    return base_fn(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        additional_fields={"name": "MP Meta-GGA Relax"},
+        copy_files=copy_files,
     )
-    summary2 = _relax(
-        summary1["atoms"],
-        copy_files=[
-            Path(summary1["dir_name"]) / "CHGCAR",
-            Path(summary1["dir_name"]) / "WAVECAR",
-        ],
-        bandgap=bandgap,
-        calc_kwargs=calc_kwargs,
-    )
-
-    return {"relax1": summary1, "relax2": summary2}
 
 
 @job
@@ -325,11 +319,15 @@ def mp_gga_relax_flow(
     """
     Materials Project GGA workflow consisting of:
 
-    1. MP-compatible (double) relax
+    1. MP-compatible relax
         - name: "mp_gga_relax_job"
         - job: [quacc.recipes.vasp.mp.mp_gga_relax_job][]
 
-    2. MP-compatible static
+    2. MP-compatible (second) relax
+        - name: "mp_gga_relax_job"
+        - job: [quacc.recipes.vasp.mp.mp_gga_relax_job][]
+
+    3. MP-compatible static
         - name: "mp_gga_static_job"
         - job: [quacc.recipes.vasp.mp.mp_gga_static_job][]
 
@@ -359,17 +357,30 @@ def mp_gga_relax_flow(
     # Run the relax
     relax_results = mp_gga_relax_job_(atoms)
 
-    # Run the static
-    static_results = mp_gga_static_job_(
-        relax_results["relax2"]["atoms"],
-        bandgap=relax_results["relax2"]["output"]["bandgap"],
+    # Run the second relax
+    double_relax_results = mp_gga_relax_job_(
+        relax_results["atoms"],
         copy_files=[
-            Path(relax_results["relax2"]["dir_name"]) / "CHGCAR",
-            Path(relax_results["relax2"]["dir_name"]) / "WAVECAR",
+            Path(relax_results["dir_name"]) / "CHGCAR",
+            Path(relax_results["dir_name"]) / "WAVECAR",
         ],
     )
 
-    return {"relax": relax_results, "static": static_results}
+    # Run the static
+    static_results = mp_gga_static_job_(
+        double_relax_results["atoms"],
+        bandgap=double_relax_results["output"]["bandgap"],
+        copy_files=[
+            Path(double_relax_results["dir_name"]) / "CHGCAR",
+            Path(double_relax_results["dir_name"]) / "WAVECAR",
+        ],
+    )
+
+    return {
+        "relax1": relax_results,
+        "relax2": double_relax_results,
+        "static": static_results,
+    }
 
 
 @flow
@@ -385,11 +396,15 @@ def mp_metagga_relax_flow(
         - name: "mp_metagga_prerelax_job"
         - job: [quacc.recipes.vasp.mp.mp_metagga_prerelax_job][]
 
-    2. MP-compatible (double) relax
+    2. MP-compatible relax
         - name: "mp_metagga_relax_job"
         - job: [quacc.recipes.vasp.mp.mp_metagga_relax_job][]
 
-    3. MP-compatible static
+    3. MP-compatible (second) relax
+        - name: "mp_metagga_relax_job"
+        - job: [quacc.recipes.vasp.mp.mp_metagga_relax_job][]
+
+    4. MP-compatible static
         - name: "mp_metagga_static_job"
         - job: [quacc.recipes.vasp.mp.mp_metagga_static_job][]
 
@@ -411,15 +426,17 @@ def mp_metagga_relax_flow(
     MPMetaGGARelaxFlowSchema
         Dictionary of results. See the type-hint for the data structure.
     """
-    (
-        mp_metagga_prerelax_job_,
-        mp_metagga_relax_job_,
-        mp_metagga_static_job_,
-    ) = customize_funcs(
-        ["mp_metagga_prerelax_job", "mp_metagga_relax_job", "mp_metagga_static_job"],
-        [mp_metagga_prerelax_job, mp_metagga_relax_job, mp_metagga_static_job],
-        parameters=job_params,
-        decorators=job_decorators,
+    (mp_metagga_prerelax_job_, mp_metagga_relax_job_, mp_metagga_static_job_) = (
+        customize_funcs(
+            [
+                "mp_metagga_prerelax_job",
+                "mp_metagga_relax_job",
+                "mp_metagga_static_job",
+            ],
+            [mp_metagga_prerelax_job, mp_metagga_relax_job, mp_metagga_static_job],
+            parameters=job_params,
+            decorators=job_decorators,
+        )
     )
 
     # Run the prerelax
@@ -435,18 +452,29 @@ def mp_metagga_relax_flow(
         ],
     )
 
+    # Run the second relax
+    double_relax_results = mp_metagga_relax_job_(
+        relax_results["atoms"],
+        bandgap=relax_results["output"]["bandgap"],
+        copy_files=[
+            Path(relax_results["dir_name"]) / "CHGCAR",
+            Path(relax_results["dir_name"]) / "WAVECAR",
+        ],
+    )
+
     # Run the static
     static_results = mp_metagga_static_job_(
-        relax_results["relax2"]["atoms"],
-        bandgap=relax_results["relax2"]["output"]["bandgap"],
+        double_relax_results["atoms"],
+        bandgap=double_relax_results["output"]["bandgap"],
         copy_files=[
-            Path(relax_results["relax2"]["dir_name"]) / "CHGCAR",
-            Path(relax_results["relax2"]["dir_name"]) / "WAVECAR",
+            Path(double_relax_results["dir_name"]) / "CHGCAR",
+            Path(double_relax_results["dir_name"]) / "WAVECAR",
         ],
     )
 
     return {
         "prerelax": prerelax_results,
-        "relax": relax_results,
+        "relax1": relax_results,
+        "relax2": double_relax_results,
         "static": static_results,
     }

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -74,6 +74,7 @@ def mp_gga_relax_job(
         calc_swaps=calc_kwargs,
         additional_fields={"name": "MP GGA Relax"},
         copy_files=copy_files,
+    )
 
 
 @job

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -323,10 +323,7 @@ def mp_gga_relax_flow(
     # Run the second relax
     double_relax_results = mp_gga_relax_job_(
         relax_results["atoms"],
-        copy_files=[
-            Path(relax_results["dir_name"]) / "CHGCAR",
-            Path(relax_results["dir_name"]) / "WAVECAR",
-        ],
+        copy_files={relax_results["dir_name"]): ["CHGCAR*", "WAVECAR*"]}
     )
 
     # Run the static
@@ -411,10 +408,7 @@ def mp_metagga_relax_flow(
     double_relax_results = mp_metagga_relax_job_(
         relax_results["atoms"],
         bandgap=relax_results["output"]["bandgap"],
-        copy_files=[
-            Path(relax_results["dir_name"]) / "CHGCAR",
-            Path(relax_results["dir_name"]) / "WAVECAR",
-        ],
+        copy_files={relax_results["dir_name"]): ["CHGCAR*", "WAVECAR*"],
     )
 
     # Run the static

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -45,7 +45,9 @@ if TYPE_CHECKING:
 
 @job
 def mp_gga_relax_job(
-    atoms: Atoms, copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None, **calc_kwargs
+    atoms: Atoms,
+    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    **calc_kwargs,
 ) -> VaspSchema:
     """
     Function to relax a structure with the original Materials Project GGA(+U) settings.
@@ -224,6 +226,7 @@ def mp_metagga_relax_job(
         copy_files=copy_files,
     )
 
+
 @job
 def mp_metagga_static_job(
     atoms: Atoms,
@@ -324,7 +327,7 @@ def mp_gga_relax_flow(
     # Run the second relax
     double_relax_results = mp_gga_relax_job_(
         relax_results["atoms"],
-        copy_files={relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]}
+        copy_files={relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
     )
 
     # Run the static

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -323,7 +323,7 @@ def mp_gga_relax_flow(
     # Run the second relax
     double_relax_results = mp_gga_relax_job_(
         relax_results["atoms"],
-        copy_files={relax_results["dir_name"]): ["CHGCAR*", "WAVECAR*"]}
+        copy_files={relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]}
     )
 
     # Run the static

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -78,41 +78,6 @@ def mp_gga_relax_job(
 
 
 @job
-def mp_gga_relax_job(
-    atoms: Atoms, copy_files: str | Path | list[str | Path] | None = None, **calc_kwargs
-) -> VaspSchema:
-    """
-    Function to relax a structure with the original Materials Project GGA(+U) settings.
-
-    Parameters
-    ----------
-    atoms
-        Atoms object
-    copy_files
-        File(s) to copy to the runtime directory. If a directory is provided, it will be recursively unpacked.
-    **calc_kwargs
-        Custom kwargs for the Vasp calculator. Set a value to
-        `None` to remove a pre-existing key entirely. For a list of available
-        keys, refer to [ase.calculators.vasp.vasp.Vasp][].
-
-    Returns
-    -------
-    VaspSchema
-        Dictionary of results.
-    """
-
-    calc_defaults = {"pmg_input_set": MPRelaxSet}
-
-    return base_fn(
-        atoms,
-        calc_defaults=calc_defaults,
-        calc_swaps=calc_kwargs,
-        additional_fields={"name": "MP GGA Relax"},
-        copy_files=copy_files,
-    )
-
-
-@job
 def mp_gga_static_job(
     atoms: Atoms,
     bandgap: float | None = None,

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -334,7 +334,7 @@ def mp_gga_relax_flow(
     static_results = mp_gga_static_job_(
         double_relax_results["atoms"],
         bandgap=double_relax_results["output"]["bandgap"],
-        copy_files={relax_results["relax2"]["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
+        copy_files={double_relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
     )
 
     return {
@@ -419,7 +419,7 @@ def mp_metagga_relax_flow(
     static_results = mp_metagga_static_job_(
         double_relax_results["atoms"],
         bandgap=double_relax_results["output"]["bandgap"],
-        copy_files={relax_results["relax2"]["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
+        copy_files={double_relax_results["dir_name"]: ["CHGCAR*", "WAVECAR*"]},
     )
 
     return {

--- a/src/quacc/schemas/_aliases/vasp.py
+++ b/src/quacc/schemas/_aliases/vasp.py
@@ -51,13 +51,6 @@ class VaspSchema(RunSchema, TaskDoc):
     chargemol: ChargemolSchema
 
 
-class DoubleRelaxSchema(VaspSchema):
-    """Type hint associated with double relaxation jobs."""
-
-    relax1: VaspSchema
-    relax2: VaspSchema
-
-
 class MPGGARelaxFlowSchema(VaspSchema):
     """Type hint associated with the MP GGA relaxation flows."""
 

--- a/src/quacc/schemas/_aliases/vasp.py
+++ b/src/quacc/schemas/_aliases/vasp.py
@@ -58,19 +58,18 @@ class DoubleRelaxSchema(VaspSchema):
     relax2: VaspSchema
 
 
-class MPMetaGGARelaxFlowSchema(VaspSchema):
-    """Type hint associated with the MP meta-GGA relaxation flows."""
-
-    prerelax: VaspSchema
-    relax: VaspSchema
-    static: VaspSchema
-
-
 class MPGGARelaxFlowSchema(VaspSchema):
     """Type hint associated with the MP GGA relaxation flows."""
 
-    relax: VaspSchema
+    relax1: VaspSchema
+    relax2: VaspSchema
     static: VaspSchema
+
+
+class MPMetaGGARelaxFlowSchema(MPGGARelaxFlowSchema):
+    """Type hint associated with the MP meta-GGA relaxation flows."""
+
+    prerelax: VaspSchema
 
 
 class QMOFRelaxSchema(VaspSchema):

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -460,7 +460,6 @@ def test_mp_metagga_relax_job(tmp_path, monkeypatch):
     output = mp_metagga_relax_job(atoms)
     assert output["parameters"] == ref_parameters
     assert output["nsites"] == len(atoms)
-    assert output["parameters"] == ref_parameters2
 
     output = mp_metagga_relax_job(atoms, bandgap=0)
     assert output["nsites"] == len(atoms)

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -2,7 +2,7 @@ import pytest
 from ase.build import bulk, molecule
 
 from quacc import SETTINGS
-from quacc.recipes.vasp.core import double_relax_job, relax_job, static_job
+from quacc.recipes.vasp.core import double_relax_flow, relax_job, static_job
 from quacc.recipes.vasp.mp import (
     mp_gga_relax_flow,
     mp_gga_relax_job,
@@ -98,12 +98,12 @@ def test_relax_job(tmp_path, monkeypatch):
     assert output["parameters"]["isif"] == 2
 
 
-def test_doublerelax_job(tmp_path, monkeypatch):
+def test_doublerelax_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     atoms = bulk("Al")
 
-    output = double_relax_job(atoms)
+    output = double_relax_flow(atoms)
     assert output["relax1"]["nsites"] == len(atoms)
     assert output["relax1"]["parameters"]["isym"] == 0
     assert output["relax1"]["parameters"]["nsw"] > 0
@@ -117,7 +117,7 @@ def test_doublerelax_job(tmp_path, monkeypatch):
     assert output["relax2"]["parameters"]["lwave"] is False
     assert output["relax2"]["parameters"]["encut"] == 520
 
-    output = double_relax_job(atoms, relax2_kwargs={"nelmin": 6})
+    output = double_relax_flow(atoms, relax2_kwargs={"nelmin": 6})
     assert output["relax1"]["nsites"] == len(atoms)
     assert output["relax1"]["parameters"]["isym"] == 0
     assert output["relax1"]["parameters"]["nsw"] > 0
@@ -132,7 +132,7 @@ def test_doublerelax_job(tmp_path, monkeypatch):
     assert output["relax2"]["parameters"]["encut"] == 520
     assert output["relax2"]["parameters"]["nelmin"] == 6
 
-    output = double_relax_job(atoms, relax_cell=False)
+    output = double_relax_flow(atoms, relax_cell=False)
     assert output["relax1"]["nsites"] == len(atoms)
     assert output["relax1"]["parameters"]["isym"] == 0
     assert output["relax1"]["parameters"]["nsw"] > 0
@@ -146,7 +146,7 @@ def test_doublerelax_job(tmp_path, monkeypatch):
     assert output["relax2"]["parameters"]["encut"] == 520
     assert output["relax2"]["parameters"]["isif"] == 2
 
-    assert double_relax_job(atoms, relax1_kwargs={"kpts": [1, 1, 1]})
+    assert double_relax_flow(atoms, relax1_kwargs={"kpts": [1, 1, 1]})
 
 
 def test_slab_static_job(tmp_path, monkeypatch):
@@ -458,29 +458,29 @@ def test_mp_metagga_relax_job(tmp_path, monkeypatch):
     ref_parameters2["magmom"] = [0.0]
 
     output = mp_metagga_relax_job(atoms)
-    assert output["relax1"]["parameters"] == ref_parameters
-    assert output["relax2"]["nsites"] == len(atoms)
-    assert output["relax2"]["parameters"] == ref_parameters2
+    assert output["parameters"] == ref_parameters
+    assert output["nsites"] == len(atoms)
+    assert output["parameters"] == ref_parameters2
 
     output = mp_metagga_relax_job(atoms, bandgap=0)
-    assert output["relax2"]["nsites"] == len(atoms)
-    assert output["relax2"]["parameters"]["metagga"].lower() == "r2scan"
-    assert output["relax2"]["parameters"]["ediffg"] == -0.02
-    assert output["relax2"]["parameters"]["encut"] == 680
-    assert output["relax2"]["parameters"]["kspacing"] == 0.22
-    assert output["relax2"]["parameters"]["ismear"] == 0
-    assert output["relax2"]["parameters"]["sigma"] == 0.05
-    assert output["relax2"]["parameters"]["pp"] == "pbe"
+    assert output["nsites"] == len(atoms)
+    assert output["parameters"]["metagga"].lower() == "r2scan"
+    assert output["parameters"]["ediffg"] == -0.02
+    assert output["parameters"]["encut"] == 680
+    assert output["parameters"]["kspacing"] == 0.22
+    assert output["parameters"]["ismear"] == 0
+    assert output["parameters"]["sigma"] == 0.05
+    assert output["parameters"]["pp"] == "pbe"
 
     output = mp_metagga_relax_job(atoms, bandgap=100)
-    assert output["relax2"]["nsites"] == len(atoms)
-    assert output["relax2"]["parameters"]["metagga"].lower() == "r2scan"
-    assert output["relax2"]["parameters"]["ediffg"] == -0.02
-    assert output["relax2"]["parameters"]["encut"] == 680
-    assert output["relax2"]["parameters"]["kspacing"] == 0.44
-    assert output["relax2"]["parameters"]["ismear"] == 0
-    assert output["relax2"]["parameters"]["sigma"] == 0.05
-    assert output["relax2"]["parameters"]["pp"] == "pbe"
+    assert output["nsites"] == len(atoms)
+    assert output["parameters"]["metagga"].lower() == "r2scan"
+    assert output["parameters"]["ediffg"] == -0.02
+    assert output["parameters"]["encut"] == 680
+    assert output["parameters"]["kspacing"] == 0.44
+    assert output["parameters"]["ismear"] == 0
+    assert output["parameters"]["sigma"] == 0.05
+    assert output["parameters"]["pp"] == "pbe"
 
 
 def test_mp_metagga_static_job(tmp_path, monkeypatch):
@@ -526,13 +526,13 @@ def test_mp_metagga_relax_flow(tmp_path, monkeypatch):
 
     output = mp_metagga_relax_flow(atoms)
     assert output["static"]["nsites"] == len(atoms)
-    assert output["relax"]["relax2"]["parameters"]["metagga"].lower() == "r2scan"
-    assert output["relax"]["relax2"]["parameters"]["ediffg"] == -0.02
-    assert output["relax"]["relax2"]["parameters"]["encut"] == 680
-    assert output["relax"]["relax2"]["parameters"]["ismear"] == 0
-    assert output["relax"]["relax2"]["parameters"]["sigma"] == 0.05
-    assert output["relax"]["relax2"]["parameters"]["kspacing"] == 0.22
-    assert output["relax"]["relax2"]["parameters"]["pp"] == "pbe"
+    assert output["relax2"]["parameters"]["metagga"].lower() == "r2scan"
+    assert output["relax2"]["parameters"]["ediffg"] == -0.02
+    assert output["relax2"]["parameters"]["encut"] == 680
+    assert output["relax2"]["parameters"]["ismear"] == 0
+    assert output["relax2"]["parameters"]["sigma"] == 0.05
+    assert output["relax2"]["parameters"]["kspacing"] == 0.22
+    assert output["relax2"]["parameters"]["pp"] == "pbe"
     assert output["prerelax"]["parameters"]["gga"] == "ps"
     assert output["prerelax"]["parameters"]["ismear"] == 0
     assert output["prerelax"]["parameters"]["pp"] == "pbe"
@@ -540,14 +540,14 @@ def test_mp_metagga_relax_flow(tmp_path, monkeypatch):
     atoms = bulk("C")
     output = mp_metagga_relax_flow(atoms)
     assert output["static"]["nsites"] == len(atoms)
-    assert output["relax"]["relax2"]["parameters"]["metagga"].lower() == "r2scan"
-    assert output["relax"]["relax2"]["parameters"]["ediffg"] == -0.02
-    assert output["relax"]["relax2"]["parameters"]["encut"] == 680
-    assert output["relax"]["relax2"]["parameters"]["ismear"] == 0
-    assert output["relax"]["relax2"]["parameters"]["kspacing"] == pytest.approx(
+    assert output["relax2"]["parameters"]["metagga"].lower() == "r2scan"
+    assert output["relax2"]["parameters"]["ediffg"] == -0.02
+    assert output["relax2"]["parameters"]["encut"] == 680
+    assert output["relax2"]["parameters"]["ismear"] == 0
+    assert output["relax2"]["parameters"]["kspacing"] == pytest.approx(
         0.28329488761304206
     )
-    assert output["relax"]["relax2"]["parameters"]["pp"] == "pbe"
+    assert output["relax2"]["parameters"]["pp"] == "pbe"
     assert output["prerelax"]["parameters"]["ismear"] == 0
     assert output["prerelax"]["parameters"]["pp"] == "pbe"
 
@@ -559,14 +559,14 @@ def test_mp_metagga_relax_flow(tmp_path, monkeypatch):
     assert output["static"]["parameters"]["ismear"] == -5
     assert output["static"]["parameters"]["nsw"] == 0
     assert output["static"]["parameters"]["algo"] == "fast"
-    assert output["relax"]["relax2"]["parameters"]["metagga"].lower() == "r2scan"
-    assert output["relax"]["relax2"]["parameters"]["ediffg"] == -0.02
-    assert output["relax"]["relax2"]["parameters"]["encut"] == 680
-    assert output["relax"]["relax2"]["parameters"]["ismear"] == 0
-    assert output["relax"]["relax2"]["parameters"]["kspacing"] == pytest.approx(
+    assert output["relax2"]["parameters"]["metagga"].lower() == "r2scan"
+    assert output["relax2"]["parameters"]["ediffg"] == -0.02
+    assert output["relax2"]["parameters"]["encut"] == 680
+    assert output["relax2"]["parameters"]["ismear"] == 0
+    assert output["relax2"]["parameters"]["kspacing"] == pytest.approx(
         0.28329488761304206
     )
-    assert output["relax"]["relax2"]["parameters"]["pp"] == "pbe"
+    assert output["relax2"]["parameters"]["pp"] == "pbe"
     assert output["prerelax"]["parameters"]["ismear"] == 0
     assert output["prerelax"]["parameters"]["pp"] == "pbe"
 
@@ -576,7 +576,8 @@ def test_mp_gga_relax_job():
     atoms[0].symbol = "O"
     output = mp_gga_relax_job(atoms)
 
-    ref_parameters = {
+    assert output["nsites"] == len(atoms)
+    assert output["parameters"] == {
         "algo": "fast",
         "ediff": 0.0001,
         "efermi": "midgap",  # added by copilot
@@ -606,12 +607,7 @@ def test_mp_gga_relax_job():
         "pp": "pbe",
         "setups": {"O": "", "Ni": "_pv"},
     }
-
-    assert output["relax2"]["nsites"] == len(atoms)
-    assert output["relax1"]["parameters"] == ref_parameters
-    assert output["relax1"]["atoms"].get_chemical_symbols() == ["O", "Ni"]
-    assert output["relax2"]["atoms"].get_chemical_symbols() == ["O", "Ni"]
-    assert output["relax2"]["parameters"] == ref_parameters
+    assert output["atoms"].get_chemical_symbols() == ["O", "Ni"]
 
 
 def test_mp_gga_static_job():
@@ -685,8 +681,8 @@ def test_mp_gga_relax_flow():
         "pp": "pbe",
         "setups": {"O": "", "Ni": "_pv"},
     }
-    assert output["relax"]["relax1"]["parameters"] == relax_params
-    assert output["relax"]["relax2"]["parameters"] == relax_params
+    assert output["relax1"]["parameters"] == relax_params
+    assert output["relax2"]["parameters"] == relax_params
     assert output["static"]["parameters"] == {
         "algo": "fast",
         "ediff": 0.0001,
@@ -727,4 +723,4 @@ def test_mp_relax_flow_custom():
         ],
         job_params={"mp_metagga_relax_job": {"nsw": 0}},
     )
-    assert output["relax"]["relax2"]["parameters"]["nsw"] == 0
+    assert output["relax2"]["parameters"]["nsw"] == 0


### PR DESCRIPTION
## Summary of Changes

This PR addresses https://github.com/Quantum-Accelerators/quacc/discussions/1777 by having each VASP relaxation in a double-relax to be its own job. 

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have used `black`, `isort`, and `ruff` as described in the [style guide](https://quantum-accelerators.github.io/quacc/dev/contributing.html#style).
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
