### PR TITLE
Espresso: faster tests

### DIFF
--- a/tests/core/recipes/espresso_recipes/conftest.py
+++ b/tests/core/recipes/espresso_recipes/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+def DEFAULT_PARALLEL_INFO():
+    from shutil import which
+
+    import psutil
+
+    if which("mpirun") and psutil.cpu_count(logical=False) > 2:
+        return {"binary": "mpirun", "-np": 2}
+    else:
+        return {}

--- a/tests/core/recipes/espresso_recipes/conftest.py
+++ b/tests/core/recipes/espresso_recipes/conftest.py
@@ -10,4 +10,4 @@ def ESPRESSO_PARALLEL_INFO():
     if which("mpirun") and psutil.cpu_count(logical=False) >= 2:
         return {"binary": "mpirun", "-np": 2}
     else:
-        return {}
+        return None

--- a/tests/core/recipes/espresso_recipes/conftest.py
+++ b/tests/core/recipes/espresso_recipes/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def DEFAULT_PARALLEL_INFO():
+def ESPRESSO_PARALLEL_INFO():
     from shutil import which
 
     import psutil

--- a/tests/core/recipes/espresso_recipes/test_bands.py
+++ b/tests/core/recipes/espresso_recipes/test_bands.py
@@ -14,9 +14,12 @@ pytestmark = pytest.mark.skipif(
 
 DATA_DIR = Path(__file__).parent / "data"
 
+DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
+
 
 def test_bands_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR / "dos_test", Path("pwscf.save", "*.gz"), tmp_path)
     copy_decompress_files(DATA_DIR, "Si.upf.gz", tmp_path)
@@ -26,12 +29,16 @@ def test_bands_flow(tmp_path, monkeypatch):
         "bands_pw_job": {
             "input_data": {"control": {"pseudo_dir": tmp_path}},
             "pseudopotentials": pseudopotentials,
+            "parallel_info": DEFAULT_PARALLEL_INFO,
         },
-        "bands_pp_job": {},
-        "fermi_surface_job": {"input_data": {"fermi": {}}},
+        "bands_pp_job": {"parallel_info": DEFAULT_PARALLEL_INFO},
+        "fermi_surface_job": {
+            "input_data": {"fermi": {}},
+            "parallel_info": DEFAULT_PARALLEL_INFO,
+        },
     }
 
-    output = bands_flow(atoms, tmp_path, line_density=1,job_params=job_params)
+    output = bands_flow(atoms, tmp_path, line_density=1, job_params=job_params)
     assert (
         output["bands_pw"]["parameters"]["input_data"]["control"]["calculation"]
         == "bands"
@@ -52,6 +59,7 @@ def test_bands_flow(tmp_path, monkeypatch):
 
 def test_bands_flow_with_fermi(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR / "dos_test", Path("pwscf.save", "*.gz"), tmp_path)
     copy_decompress_files(DATA_DIR, "Si.upf.gz", tmp_path)
@@ -62,8 +70,12 @@ def test_bands_flow_with_fermi(tmp_path, monkeypatch):
             "input_data": {"control": {"pseudo_dir": tmp_path}},
             "pseudopotentials": pseudopotentials,
             "kspacing": 0.9,
+            "parallel_info": DEFAULT_PARALLEL_INFO,
         },
-        "fermi_surface_job": {"input_data": {"fermi": {}}},
+        "fermi_surface_job": {
+            "input_data": {"fermi": {}},
+            "parallel_info": DEFAULT_PARALLEL_INFO,
+        },
     }
 
     output = bands_flow(

--- a/tests/core/recipes/espresso_recipes/test_bands.py
+++ b/tests/core/recipes/espresso_recipes/test_bands.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(
 DATA_DIR = Path(__file__).parent / "data"
 
 
-def test_bands_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_bands_flow(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -27,12 +27,12 @@ def test_bands_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         "bands_pw_job": {
             "input_data": {"control": {"pseudo_dir": tmp_path}},
             "pseudopotentials": pseudopotentials,
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
-        "bands_pp_job": {"parallel_info": DEFAULT_PARALLEL_INFO},
+        "bands_pp_job": {"parallel_info": ESPRESSO_PARALLEL_INFO},
         "fermi_surface_job": {
             "input_data": {"fermi": {}},
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
     }
 
@@ -55,7 +55,7 @@ def test_bands_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert output["bands_pp"]["name"] == "bands.x post-processing"
 
 
-def test_bands_flow_with_fermi(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_bands_flow_with_fermi(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -68,11 +68,11 @@ def test_bands_flow_with_fermi(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
             "input_data": {"control": {"pseudo_dir": tmp_path}},
             "pseudopotentials": pseudopotentials,
             "kspacing": 0.9,
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
         "fermi_surface_job": {
             "input_data": {"fermi": {}},
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
     }
 

--- a/tests/core/recipes/espresso_recipes/test_bands.py
+++ b/tests/core/recipes/espresso_recipes/test_bands.py
@@ -14,10 +14,8 @@ pytestmark = pytest.mark.skipif(
 
 DATA_DIR = Path(__file__).parent / "data"
 
-DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
 
-
-def test_bands_flow(tmp_path, monkeypatch):
+def test_bands_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -57,7 +55,7 @@ def test_bands_flow(tmp_path, monkeypatch):
     assert output["bands_pp"]["name"] == "bands.x post-processing"
 
 
-def test_bands_flow_with_fermi(tmp_path, monkeypatch):
+def test_bands_flow_with_fermi(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -30,10 +30,8 @@ from quacc.utils.files import copy_decompress_files
 
 DATA_DIR = Path(__file__).parent / "data"
 
-DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
 
-
-def test_static_job(tmp_path, monkeypatch):
+def test_static_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -68,7 +66,7 @@ def test_static_job(tmp_path, monkeypatch):
     assert results["parameters"].get("kpts") is None
 
 
-def test_static_job_v2(tmp_path, monkeypatch):
+def test_static_job_v2(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -113,7 +111,7 @@ def test_static_job_v2(tmp_path, monkeypatch):
     assert Path(pp_results["dir_name"], "pseudo_charge_density.cube.gz").is_file()
 
 
-def test_static_job_outdir(tmp_path, monkeypatch):
+def test_static_job_outdir(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -152,7 +150,7 @@ def test_static_job_outdir(tmp_path, monkeypatch):
     assert new_input_data["control"]["calculation"] == "scf"
 
 
-def test_static_job_outdir_abs(tmp_path, monkeypatch):
+def test_static_job_outdir_abs(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -213,7 +211,7 @@ def test_static_job_test_run(tmp_path, monkeypatch):
         )
 
 
-def test_relax_job(tmp_path, monkeypatch):
+def test_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -243,7 +241,7 @@ def test_relax_job(tmp_path, monkeypatch):
     assert new_input_data["control"]["calculation"] == "relax"
 
 
-def test_ase_relax_job(tmp_path, monkeypatch):
+def test_ase_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -278,7 +276,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
     assert new_input_data["control"]["calculation"] == "scf"
 
 
-def test_ase_relax_cell_job(tmp_path, monkeypatch):
+def test_ase_relax_cell_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -307,7 +305,7 @@ def test_ase_relax_cell_job(tmp_path, monkeypatch):
         )
 
 
-def test_relax_job_cell(tmp_path, monkeypatch):
+def test_relax_job_cell(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -342,7 +340,7 @@ def test_relax_job_cell(tmp_path, monkeypatch):
     assert new_input_data["control"]["calculation"] == "vc-relax"
 
 
-def test_non_scf_job(tmp_path, monkeypatch):
+def test_non_scf_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -388,7 +386,7 @@ def test_non_scf_job(tmp_path, monkeypatch):
     assert results["parameters"].get("kpts") is None
 
 
-def test_pw_copy(tmp_path, monkeypatch):
+def test_pw_copy(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -31,7 +31,7 @@ from quacc.utils.files import copy_decompress_files
 DATA_DIR = Path(__file__).parent / "data"
 
 
-def test_static_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_static_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -47,7 +47,7 @@ def test_static_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -66,7 +66,7 @@ def test_static_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert results["parameters"].get("kpts") is None
 
 
-def test_static_job_v2(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_static_job_v2(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -87,7 +87,7 @@ def test_static_job_v2(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kspacing=0.5,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -111,7 +111,7 @@ def test_static_job_v2(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert Path(pp_results["dir_name"], "pseudo_charge_density.cube.gz").is_file()
 
 
-def test_static_job_outdir(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_static_job_outdir(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -132,7 +132,7 @@ def test_static_job_outdir(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -150,7 +150,7 @@ def test_static_job_outdir(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert new_input_data["control"]["calculation"] == "scf"
 
 
-def test_static_job_outdir_abs(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_static_job_outdir_abs(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -174,7 +174,7 @@ def test_static_job_outdir_abs(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
             input_data=input_data,
             pseudopotentials=pseudopotentials,
             kpts=None,
-            parallel_info=DEFAULT_PARALLEL_INFO,
+            parallel_info=ESPRESSO_PARALLEL_INFO,
         )
 
 
@@ -211,7 +211,7 @@ def test_static_job_test_run(tmp_path, monkeypatch):
         )
 
 
-def test_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_relax_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -228,7 +228,7 @@ def test_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -241,7 +241,7 @@ def test_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert new_input_data["control"]["calculation"] == "relax"
 
 
-def test_ase_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_ase_relax_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -259,7 +259,7 @@ def test_ase_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         pseudopotentials=pseudopotentials,
         kpts=None,
         opt_params={"max_steps": 10, "fmax": 1.0e-1, "optimizer": BFGS},
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -276,7 +276,7 @@ def test_ase_relax_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert new_input_data["control"]["calculation"] == "scf"
 
 
-def test_ase_relax_cell_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_ase_relax_cell_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -301,11 +301,11 @@ def test_ase_relax_cell_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
             pseudopotentials=pseudopotentials,
             kpts=None,
             opt_params={"max_steps": 2, "fmax": 1.0e-1, "optimizer": BFGS},
-            parallel_info=DEFAULT_PARALLEL_INFO,
+            parallel_info=ESPRESSO_PARALLEL_INFO,
         )
 
 
-def test_relax_job_cell(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_relax_job_cell(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -326,7 +326,7 @@ def test_relax_job_cell(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -340,7 +340,7 @@ def test_relax_job_cell(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert new_input_data["control"]["calculation"] == "vc-relax"
 
 
-def test_non_scf_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_non_scf_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -355,7 +355,7 @@ def test_non_scf_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
     files_to_copy = pw_copy_files(
         input_data, static_result["dir_name"], include_wfc=False
@@ -365,7 +365,7 @@ def test_non_scf_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         files_to_copy,
         input_data=input_data,
         pseudopotentials=pseudopotentials,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -386,7 +386,7 @@ def test_non_scf_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert results["parameters"].get("kpts") is None
 
 
-def test_pw_copy(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_pw_copy(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -402,7 +402,7 @@ def test_pw_copy(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     new_input_data = results["parameters"]["input_data"]
@@ -417,7 +417,7 @@ def test_pw_copy(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         pseudopotentials=pseudopotentials,
         kpts=None,
         copy_files=files_to_copy,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
     assert new_input_data["system"]["ecutwfc"] == 30.0
     assert new_input_data["system"]["ecutrho"] == 240.0

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -30,9 +30,12 @@ from quacc.utils.files import copy_decompress_files
 
 DATA_DIR = Path(__file__).parent / "data"
 
+DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
+
 
 def test_static_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -42,7 +45,11 @@ def test_static_job(tmp_path, monkeypatch):
     input_data = {"control": {"pseudo_dir": tmp_path}}
 
     results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -63,6 +70,7 @@ def test_static_job(tmp_path, monkeypatch):
 
 def test_static_job_v2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -77,7 +85,11 @@ def test_static_job_v2(tmp_path, monkeypatch):
     pseudopotentials = {"Si": "Si.upf"}
 
     results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kspacing=0.5
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kspacing=0.5,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -103,6 +115,7 @@ def test_static_job_v2(tmp_path, monkeypatch):
 
 def test_static_job_outdir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -117,7 +130,11 @@ def test_static_job_outdir(tmp_path, monkeypatch):
     pseudopotentials = {"Si": "Si.upf"}
 
     results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -137,6 +154,7 @@ def test_static_job_outdir(tmp_path, monkeypatch):
 
 def test_static_job_outdir_abs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -154,7 +172,11 @@ def test_static_job_outdir_abs(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         static_job(
-            atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+            atoms,
+            input_data=input_data,
+            pseudopotentials=pseudopotentials,
+            kpts=None,
+            parallel_info=DEFAULT_PARALLEL_INFO,
         )
 
 
@@ -193,6 +215,7 @@ def test_static_job_test_run(tmp_path, monkeypatch):
 
 def test_relax_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -203,7 +226,11 @@ def test_relax_job(tmp_path, monkeypatch):
     input_data = {"control": {"pseudo_dir": tmp_path}}
 
     results = relax_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -218,6 +245,7 @@ def test_relax_job(tmp_path, monkeypatch):
 
 def test_ase_relax_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -233,6 +261,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
         pseudopotentials=pseudopotentials,
         kpts=None,
         opt_params={"max_steps": 10, "fmax": 1.0e-1, "optimizer": BFGS},
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -251,6 +280,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
 
 def test_ase_relax_cell_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -273,11 +303,13 @@ def test_ase_relax_cell_job(tmp_path, monkeypatch):
             pseudopotentials=pseudopotentials,
             kpts=None,
             opt_params={"max_steps": 2, "fmax": 1.0e-1, "optimizer": BFGS},
+            parallel_info=DEFAULT_PARALLEL_INFO,
         )
 
 
 def test_relax_job_cell(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -296,6 +328,7 @@ def test_relax_job_cell(tmp_path, monkeypatch):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     with pytest.raises(AssertionError):
@@ -311,6 +344,7 @@ def test_relax_job_cell(tmp_path, monkeypatch):
 
 def test_non_scf_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -319,13 +353,21 @@ def test_non_scf_job(tmp_path, monkeypatch):
     pseudopotentials = {"Si": "Si.upf"}
     input_data = {"control": {"pseudo_dir": tmp_path}}
     static_result = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
     files_to_copy = pw_copy_files(
         input_data, static_result["dir_name"], include_wfc=False
     )
     results = non_scf_job(
-        atoms, files_to_copy, input_data=input_data, pseudopotentials=pseudopotentials
+        atoms,
+        files_to_copy,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -348,6 +390,7 @@ def test_non_scf_job(tmp_path, monkeypatch):
 
 def test_pw_copy(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -357,7 +400,11 @@ def test_pw_copy(tmp_path, monkeypatch):
     input_data = {"control": {"pseudo_dir": tmp_path, "max_seconds": 5}}
 
     results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kpts=None
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kpts=None,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     new_input_data = results["parameters"]["input_data"]
@@ -372,6 +419,7 @@ def test_pw_copy(tmp_path, monkeypatch):
         pseudopotentials=pseudopotentials,
         kpts=None,
         copy_files=files_to_copy,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
     assert new_input_data["system"]["ecutwfc"] == 30.0
     assert new_input_data["system"]["ecutrho"] == 240.0

--- a/tests/core/recipes/espresso_recipes/test_dos.py
+++ b/tests/core/recipes/espresso_recipes/test_dos.py
@@ -14,10 +14,8 @@ pytestmark = pytest.mark.skipif(
 
 DATA_DIR = Path(__file__).parent / "data"
 
-DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
 
-
-def test_dos_job(tmp_path, monkeypatch):
+def test_dos_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -28,7 +26,7 @@ def test_dos_job(tmp_path, monkeypatch):
     assert output["results"]["pwscf_dos"]["fermi"] == pytest.approx(7.199)
 
 
-def test_projwfc_job(tmp_path, monkeypatch):
+def test_projwfc_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -40,7 +38,7 @@ def test_projwfc_job(tmp_path, monkeypatch):
     assert output["parameters"]["input_data"]["projwfc"] == {}
 
 
-def test_dos_flow(tmp_path, monkeypatch):
+def test_dos_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -99,7 +97,7 @@ def test_dos_flow(tmp_path, monkeypatch):
     assert output["dos_job"]["results"]["pwscf_dos"]["fermi"] == pytest.approx(6.772)
 
 
-def test_projwfc_flow(tmp_path, monkeypatch):
+def test_projwfc_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 

--- a/tests/core/recipes/espresso_recipes/test_dos.py
+++ b/tests/core/recipes/espresso_recipes/test_dos.py
@@ -15,30 +15,30 @@ pytestmark = pytest.mark.skipif(
 DATA_DIR = Path(__file__).parent / "data"
 
 
-def test_dos_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_dos_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR / "dos_test", [Path("pwscf.save", "*.gz")], tmp_path)
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
-    output = dos_job(tmp_path, parallel_info=DEFAULT_PARALLEL_INFO)
+    output = dos_job(tmp_path, parallel_info=ESPRESSO_PARALLEL_INFO)
 
     assert output["results"]["pwscf_dos"]["fermi"] == pytest.approx(7.199)
 
 
-def test_projwfc_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_projwfc_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR / "dos_test", [Path("pwscf.save", "*.gz")], tmp_path)
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
-    output = projwfc_job(tmp_path, parallel_info=DEFAULT_PARALLEL_INFO)
+    output = projwfc_job(tmp_path, parallel_info=ESPRESSO_PARALLEL_INFO)
 
     assert output["name"] == "projwfc.x Projects-wavefunctions"
     assert output["parameters"]["input_data"]["projwfc"] == {}
 
 
-def test_dos_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_dos_flow(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -55,9 +55,9 @@ def test_dos_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         "static_job": {
             "input_data": input_data,
             "pseudopotentials": pseudopotentials,
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
-        "non_scf_job": {"kspacing": 0.05, "parallel_info": DEFAULT_PARALLEL_INFO},
+        "non_scf_job": {"kspacing": 0.05, "parallel_info": ESPRESSO_PARALLEL_INFO},
     }
 
     output = dos_flow(atoms, job_params=job_params)
@@ -97,7 +97,7 @@ def test_dos_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     assert output["dos_job"]["results"]["pwscf_dos"]["fermi"] == pytest.approx(6.772)
 
 
-def test_projwfc_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_projwfc_flow(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -114,9 +114,9 @@ def test_projwfc_flow(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         "static_job": {
             "input_data": input_data,
             "pseudopotentials": pseudopotentials,
-            "parallel_info": DEFAULT_PARALLEL_INFO,
+            "parallel_info": ESPRESSO_PARALLEL_INFO,
         },
-        "non_scf_job": {"kspacing": 0.05, "parallel_info": DEFAULT_PARALLEL_INFO},
+        "non_scf_job": {"kspacing": 0.05, "parallel_info": ESPRESSO_PARALLEL_INFO},
     }
 
     output = projwfc_flow(atoms, job_params=job_params)

--- a/tests/core/recipes/espresso_recipes/test_dos.py
+++ b/tests/core/recipes/espresso_recipes/test_dos.py
@@ -14,21 +14,27 @@ pytestmark = pytest.mark.skipif(
 
 DATA_DIR = Path(__file__).parent / "data"
 
+DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
+
 
 def test_dos_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+
     copy_decompress_files(DATA_DIR / "dos_test", [Path("pwscf.save", "*.gz")], tmp_path)
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
-    output = dos_job(tmp_path)
+    output = dos_job(tmp_path, parallel_info=DEFAULT_PARALLEL_INFO)
 
     assert output["results"]["pwscf_dos"]["fermi"] == pytest.approx(7.199)
 
 
 def test_projwfc_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+
     copy_decompress_files(DATA_DIR / "dos_test", [Path("pwscf.save", "*.gz")], tmp_path)
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
-    output = projwfc_job(tmp_path)
+    output = projwfc_job(tmp_path, parallel_info=DEFAULT_PARALLEL_INFO)
 
     assert output["name"] == "projwfc.x Projects-wavefunctions"
     assert output["parameters"]["input_data"]["projwfc"] == {}
@@ -36,6 +42,7 @@ def test_projwfc_job(tmp_path, monkeypatch):
 
 def test_dos_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
     atoms = bulk("Si")
@@ -47,8 +54,12 @@ def test_dos_flow(tmp_path, monkeypatch):
     pseudopotentials = {"Si": "Si.upf"}
 
     job_params = {
-        "static_job": {"input_data": input_data, "pseudopotentials": pseudopotentials},
-        "non_scf_job": {"kspacing": 0.05},
+        "static_job": {
+            "input_data": input_data,
+            "pseudopotentials": pseudopotentials,
+            "parallel_info": DEFAULT_PARALLEL_INFO,
+        },
+        "non_scf_job": {"kspacing": 0.05, "parallel_info": DEFAULT_PARALLEL_INFO},
     }
 
     output = dos_flow(atoms, job_params=job_params)
@@ -90,6 +101,7 @@ def test_dos_flow(tmp_path, monkeypatch):
 
 def test_projwfc_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
     atoms = bulk("Si")
@@ -101,8 +113,12 @@ def test_projwfc_flow(tmp_path, monkeypatch):
     pseudopotentials = {"Si": "Si.upf"}
 
     job_params = {
-        "static_job": {"input_data": input_data, "pseudopotentials": pseudopotentials},
-        "non_scf_job": {"kspacing": 0.05},
+        "static_job": {
+            "input_data": input_data,
+            "pseudopotentials": pseudopotentials,
+            "parallel_info": DEFAULT_PARALLEL_INFO,
+        },
+        "non_scf_job": {"kspacing": 0.05, "parallel_info": DEFAULT_PARALLEL_INFO},
     }
 
     output = projwfc_flow(atoms, job_params=job_params)

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -23,7 +23,7 @@ DEFAULT_SETTINGS = SETTINGS.model_copy()
 DATA_DIR = Path(__file__).parent / "data"
 
 
-def test_phonon_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_phonon_job(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -48,11 +48,13 @@ def test_phonon_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kspacing=0.5,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     ph_results = phonon_job(
-        pw_results["dir_name"], input_data=ph_loose, parallel_info=DEFAULT_PARALLEL_INFO
+        pw_results["dir_name"],
+        input_data=ph_loose,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(
@@ -85,7 +87,7 @@ def test_phonon_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     SETTINGS.ESPRESSO_PSEUDO = DEFAULT_SETTINGS.ESPRESSO_PSEUDO
 
 
-def test_phonon_job_list_to_do(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
+def test_phonon_job_list_to_do(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -110,7 +112,7 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=input_data,
         pseudopotentials=pseudopotentials,
         kspacing=0.5,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     qpts = [(0, 0, 0, 1), (1 / 3, 0, 0, 1), (1 / 2, 0, 0, 1)]
@@ -122,7 +124,7 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
         input_data=ph_loose,
         qpts=qpts,
         nat_todo_indices=nat_todo,
-        parallel_info=DEFAULT_PARALLEL_INFO,
+        parallel_info=ESPRESSO_PARALLEL_INFO,
     )
 
     assert_allclose(

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -22,9 +22,12 @@ from quacc.utils.files import copy_decompress_files
 DEFAULT_SETTINGS = SETTINGS.model_copy()
 DATA_DIR = Path(__file__).parent / "data"
 
+DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
+
 
 def test_phonon_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     atoms = bulk("Li")
 
@@ -43,10 +46,16 @@ def test_phonon_job(tmp_path, monkeypatch):
     pseudopotentials = {"Li": "Li.upf"}
 
     pw_results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kspacing=0.5
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kspacing=0.5,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
-    ph_results = phonon_job(pw_results["dir_name"], input_data=ph_loose)
+    ph_results = phonon_job(
+        pw_results["dir_name"], input_data=ph_loose, parallel_info=DEFAULT_PARALLEL_INFO
+    )
 
     assert_allclose(
         ph_results["results"][1]["atoms"].get_positions(),
@@ -80,6 +89,7 @@ def test_phonon_job(tmp_path, monkeypatch):
 
 def test_phonon_job_list_to_do(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     atoms = bulk("Li")
 
@@ -98,7 +108,11 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch):
     pseudopotentials = {"Li": "Li.upf"}
 
     pw_results = static_job(
-        atoms, input_data=input_data, pseudopotentials=pseudopotentials, kspacing=0.5
+        atoms,
+        input_data=input_data,
+        pseudopotentials=pseudopotentials,
+        kspacing=0.5,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     qpts = [(0, 0, 0, 1), (1 / 3, 0, 0, 1), (1 / 2, 0, 0, 1)]
@@ -110,6 +124,7 @@ def test_phonon_job_list_to_do(tmp_path, monkeypatch):
         input_data=ph_loose,
         qpts=qpts,
         nat_todo_indices=nat_todo,
+        parallel_info=DEFAULT_PARALLEL_INFO,
     )
 
     assert_allclose(

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -22,10 +22,8 @@ from quacc.utils.files import copy_decompress_files
 DEFAULT_SETTINGS = SETTINGS.model_copy()
 DATA_DIR = Path(__file__).parent / "data"
 
-DEFAULT_PARALLEL_INFO = {"binary": "mpirun", "-np": 2}
 
-
-def test_phonon_job(tmp_path, monkeypatch):
+def test_phonon_job(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
@@ -87,7 +85,7 @@ def test_phonon_job(tmp_path, monkeypatch):
     SETTINGS.ESPRESSO_PSEUDO = DEFAULT_SETTINGS.ESPRESSO_PSEUDO
 
 
-def test_phonon_job_list_to_do(tmp_path, monkeypatch):
+def test_phonon_job_list_to_do(tmp_path, monkeypatch, DEFAULT_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 

--- a/tests/dask/test_emt_recipes.py
+++ b/tests/dask/test_emt_recipes.py
@@ -13,7 +13,7 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow  # skipcq: PYL-C0412
 client = get_client()
 
 
-def test_functools(tmp_path, monkeypatch):
+def test_functools(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     delayed = bulk_to_slabs_flow(

--- a/tests/dask/test_emt_recipes.py
+++ b/tests/dask/test_emt_recipes.py
@@ -13,7 +13,7 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow  # skipcq: PYL-C0412
 client = get_client()
 
 
-def test_functools(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
+def test_functools(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     delayed = bulk_to_slabs_flow(
@@ -25,7 +25,7 @@ def test_functools(tmp_path, monkeypatch, ESPRESSO_PARALLEL_INFO):
     assert result[-1]["fmax"] == 0.1
 
 
-def test_copy_files(tmp_path, monkeypatch, caplog):
+def test_copy_files(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
 

--- a/tests/dask/test_espresso_recipes.py
+++ b/tests/dask/test_espresso_recipes.py
@@ -30,6 +30,7 @@ client = default_client()
 
 def test_phonon_grid_single(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -73,6 +74,7 @@ def test_phonon_grid_single(tmp_path, monkeypatch):
 
 def test_phonon_grid_single_gamma(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -115,6 +117,7 @@ def test_phonon_grid_single_gamma(tmp_path, monkeypatch):
 
 def test_phonon_grid_qplot(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -159,6 +162,7 @@ def test_phonon_grid_qplot(tmp_path, monkeypatch):
 
 def test_phonon_grid_disp(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Si.upf.gz"], tmp_path)
 
@@ -210,6 +214,7 @@ def test_phonon_grid_disp(tmp_path, monkeypatch):
 
 def test_phonon_grid_v2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     copy_decompress_files(DATA_DIR, ["Li.upf.gz"], tmp_path)
 


### PR DESCRIPTION
## Summary of Changes

As discussed in https://github.com/Quantum-Accelerators/quacc/pull/1789 some parallelization flags can help make espresso tests faster

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).

Closes #1818.