### PR TITLE
Raise a ValueError if RESULTS_DIR or SCRATCH_DIR is relative

### DIFF
--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -447,7 +447,7 @@ class QuaccSettings(BaseSettings):
     )
     @classmethod
     def expand_paths(cls, v: Optional[Path]) -> Optional[Path]:
-        """Expand ~/ in paths."""
+        """Expand ~/ and $ENV_VARS in paths."""
         if v is None:
             return v
         v = Path(os.path.expandvars(v)).expanduser()

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -448,19 +448,20 @@ class QuaccSettings(BaseSettings):
     @classmethod
     def expand_paths(cls, v: Optional[Path]) -> Optional[Path]:
         """Expand ~/ and $ENV_VARS in paths."""
-        if v is None:
-            return v
-        v = Path(os.path.expandvars(v)).expanduser()
+        if v:
+            v = Path(os.path.expandvars(v)).expanduser()
         return v
 
     @field_validator("RESULTS_DIR", "SCRATCH_DIR")
     @classmethod
-    def make_directories(cls, v: Path) -> None:
+    def make_directories(cls, v: Optional[Path]) -> Optional[Path]:
         """Make directories."""
-        if not v.is_absolute():
-            raise ValueError(f"{v} must be an absolute path.")
-        if not v.exists():
-            v.mkdir(parents=True)
+        if v:
+            if not v.is_absolute():
+                raise ValueError(f"{v} must be an absolute path.")
+            if not v.exists():
+                v.mkdir(parents=True)
+        return v
 
     @field_validator("STORE")
     def generate_store(cls, v: Union[dict[str, dict[str, Any]], Store]) -> Store:

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -451,14 +451,14 @@ class QuaccSettings(BaseSettings):
         if v is None:
             return v
         v = Path(os.path.expandvars(v)).expanduser()
-        if not v.is_absolute():
-            raise ValueError(f"{v} must be an absolute path.")
         return v
 
     @field_validator("RESULTS_DIR", "SCRATCH_DIR")
     @classmethod
     def make_directories(cls, v: Path) -> None:
         """Make directories."""
+        if not v.is_absolute():
+            raise ValueError(f"{v} must be an absolute path.")
         if not v.exists():
             v.mkdir(parents=True)
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -190,7 +190,7 @@ class QuaccSettings(BaseSettings):
             "projwfc": "projwfc.x",
             "pp": "pp.x",
             "wannier90": "wannier90.x",
-            "fs": "fs.x"
+            "fs": "fs.x",
         },
         description="Name for each espresso binary.",
     )
@@ -437,7 +437,10 @@ class QuaccSettings(BaseSettings):
         if v is None:
             return v
 
-        v = Path(os.path.expandvars(v)).expanduser().resolve()
+        v = Path(os.path.expandvars(v)).expanduser()
+        if not v.is_absolute():
+            raise ValueError(f"{v} must be an absolute path.")
+        v = v.resolve()
         if not v.exists():
             v.mkdir(parents=True)
         return v

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -461,7 +461,7 @@ class QuaccSettings(BaseSettings):
         """Make directories."""
         if not v.exists():
             v.mkdir(parents=True)
-    
+
     @field_validator("STORE")
     def generate_store(cls, v: Union[dict[str, dict[str, Any]], Store]) -> Store:
         """Generate the Maggma store."""

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -430,22 +430,9 @@ class QuaccSettings(BaseSettings):
 
     # --8<-- [end:settings]
 
-    @field_validator("RESULTS_DIR", "SCRATCH_DIR")
-    @classmethod
-    def resolve_and_make_paths(cls, v: Optional[Path]) -> Optional[Path]:
-        """Resolve and make paths."""
-        if v is None:
-            return v
-
-        v = Path(os.path.expandvars(v)).expanduser()
-        if not v.is_absolute():
-            raise ValueError(f"{v} must be an absolute path.")
-        v = v.resolve()
-        if not v.exists():
-            v.mkdir(parents=True)
-        return v
-
     @field_validator(
+        "RESULTS_DIR",
+        "SCRATCH_DIR",
         "ESPRESSO_PRESET_DIR",
         "ESPRESSO_PSEUDO",
         "GAUSSIAN_CMD",
@@ -461,8 +448,20 @@ class QuaccSettings(BaseSettings):
     @classmethod
     def expand_paths(cls, v: Optional[Path]) -> Optional[Path]:
         """Expand ~/ in paths."""
-        return v.expanduser() if v is not None else v
+        if v is None:
+            return v
+        v = Path(os.path.expandvars(v)).expanduser()
+        if not v.is_absolute():
+            raise ValueError(f"{v} must be an absolute path.")
+        return v
 
+    @field_validator("RESULTS_DIR", "SCRATCH_DIR")
+    @classmethod
+    def make_directories(cls, v: Path) -> None:
+        """Make directories."""
+        if not v.exists():
+            v.mkdir(parents=True)
+    
     @field_validator("STORE")
     def generate_store(cls, v: Union[dict[str, dict[str, Any]], Store]) -> Store:
         """Generate the Maggma store."""

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import pytest
 from ase.build import bulk
 from maggma.stores import MemoryStore
 
@@ -41,6 +42,13 @@ def test_results_dir(tmp_path, monkeypatch):
     relax_job(atoms)
     assert "opt.traj" in os.listdir(os.getcwd())
     os.remove("opt.traj")
+
+
+def test_bad_dir():
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        SETTINGS.RESULTS_DIR = "bad_dir"
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        SETTINGS.SCRATCH_DIR = "bad_dir"
 
 
 def test_env_var(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary of Changes

Raise a `ValueError` if `RESULTS_DIR` or `SCRATCH_DIR` is relative.

Closes #1858.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
