### PR TITLE
Change NEDOS from 5001 to 3001 in VASP `static_job`

### DIFF
--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -56,7 +56,7 @@ def static_job(
         "lreal": False,
         "lvhar": True,
         "lwave": True,
-        "nedos": 5001,
+        "nedos": 3001,
         "nsw": 0,
     }
     return base_fn(


### PR DESCRIPTION
## Summary of Changes

Here, I have changed the default NEDOS from 5001 to 3001 in the VASP static jobs. The value of 3001 represents a 10x increase from the default, which seems logical. A dedicated NSCF job will be made with #1840 anyway, which will be more robust in terms of DOS.