### PR TITLE
Use `MSONAtoms` spec for MSONable Atoms

### DIFF
--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 
-def atoms_as_dict(s: Atoms) -> dict[str, Any]:
+def atoms_as_dict(atoms: Atoms) -> dict[str, Any]:
     from ase.io.jsonio import encode
     from monty.json import jsanitize
 

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -39,7 +39,7 @@ def atoms_as_dict(atoms: Atoms) -> dict[str, Any]:
     return {
         "@module": "pymatgen.io.ase",
         "@class": "MSONAtoms",
-        "atoms_json": encode(s),
+        "atoms_json": encode(atoms),
         "atoms_no_info": jsanitize(atoms.info, strict=True),
     }
 

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -36,7 +36,12 @@ def atoms_as_dict(s: Atoms) -> dict[str, Any]:
     # Uses Monty's MSONable spec
     atoms_no_info = atoms.copy()
     atoms_no_info.info = {}
-    return {"@module": "pymatgen.io.ase", "@class": "MSONAtoms", "atoms_json": encode(s),"atoms_no_info": jsanitize(atoms.info, strict=True)}
+    return {
+        "@module": "pymatgen.io.ase",
+        "@class": "MSONAtoms",
+        "atoms_json": encode(s),
+        "atoms_no_info": jsanitize(atoms.info, strict=True),
+    }
 
 
 def atoms_from_dict(d: dict[str, Any]) -> Atoms:

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -44,7 +44,7 @@ def atoms_as_dict(s: Atoms) -> dict[str, Any]:
     }
 
 
-def atoms_from_dict(d: dict[str, Any]) -> Atoms:
+def atoms_from_dict(dct: dict[str, Any]) -> Atoms:
     from ase.io.jsonio import decode
     from monty.json import MontyDecoder
     from pymatgen.io.ase import MSONAtoms


### PR DESCRIPTION
Follow the Pymatgen `MSONAtoms` spec for MSONable `Atoms` objects. For details, see:
- https://github.com/materialsproject/pymatgen/pull/3619
- https://github.com/materialsproject/pymatgen/pull/3670