### PR TITLE
Issues with the grid_phonon_flow and custom decorators when using Parsl

### DIFF
--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -20,7 +20,7 @@ from quacc.calculators.espresso.utils import grid_copy_files, grid_prepare_repr
 from quacc.recipes.espresso._base import base_fn
 from quacc.recipes.espresso.core import relax_job
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.wflow_tools.customizers import customize_funcs, strip_decorator
+from quacc.wflow_tools.customizers import customize_funcs
 
 if TYPE_CHECKING:
     from typing import Any, Callable, TypedDict
@@ -360,8 +360,8 @@ def grid_phonon_flow(
         See the type-hint for the data structure.
     """
 
-    @job
-    def _ph_recover_job(grid_results: list[RunSchema]) -> RunSchema:
+    @subflow
+    def _ph_recover_subflow(grid_results: list[RunSchema]) -> RunSchema:
         prev_dirs = {}
         for result in grid_results:
             prev_dirs[result["dir_name"]] = [
@@ -371,7 +371,7 @@ def grid_phonon_flow(
                 Path("**", "wfc*.*"),
                 Path("**", "paw.txt.*"),
             ]
-        return strip_decorator(ph_recover_job)(prev_dirs)
+        return ph_recover_job(prev_dirs)
 
     @subflow
     def _grid_phonon_subflow(
@@ -467,4 +467,4 @@ def grid_phonon_flow(
         job_params["ph_job"]["input_data"], ph_init_job_results, ph_job, nblocks=nblocks
     )
 
-    return _ph_recover_job(grid_results)
+    return _ph_recover_subflow(grid_results)

--- a/tests/dask/test_espresso_recipes.py
+++ b/tests/dask/test_espresso_recipes.py
@@ -22,6 +22,8 @@ from ase.build import bulk
 from quacc.recipes.espresso.phonons import grid_phonon_flow
 from quacc.utils.files import copy_decompress_files
 
+from monty.io import zopen
+
 DATA_DIR = (
     Path(__file__).parent / ".." / "core" / "recipes" / "espresso_recipes" / "data"
 )
@@ -70,6 +72,15 @@ def test_phonon_grid_single(tmp_path, monkeypatch):
 
     for key in sections:
         assert key in grid_results["results"][1]
+
+    outfile = Path(grid_results["dir_name"], "ph.out.gz")
+
+    assert outfile.exists()
+
+    with zopen(outfile, "r") as fd:
+        lines = fd.read()
+
+    assert "Self-consistent Calculation" not in lines
 
 
 def test_phonon_grid_single_gamma(tmp_path, monkeypatch):

--- a/tests/dask/test_espresso_recipes.py
+++ b/tests/dask/test_espresso_recipes.py
@@ -20,11 +20,10 @@ pytestmark = pytest.mark.skipif(
 from pathlib import Path
 
 from ase.build import bulk
+from monty.io import zopen
 
 from quacc.recipes.espresso.phonons import grid_phonon_flow
 from quacc.utils.files import copy_decompress_files
-
-from monty.io import zopen
 
 DATA_DIR = (
     Path(__file__).parent / ".." / "core" / "recipes" / "espresso_recipes" / "data"

--- a/tests/dask/test_espresso_recipes.py
+++ b/tests/dask/test_espresso_recipes.py
@@ -78,7 +78,7 @@ def test_phonon_grid_single(tmp_path, monkeypatch):
     assert outfile.exists()
 
     with zopen(outfile, "r") as fd:
-        lines = fd.read()
+        lines = str(fd.read())
 
     assert "Self-consistent Calculation" not in lines
 


### PR DESCRIPTION
## Summary of Changes

It seems that the "job within a job" concept is not well appreciated by Parsl when using custom executors (redecorated jobs). Leading to problems as mentioned in #1852

Changing this `job` (_ph_recover_job) to a `subflow` and removing strip_decorators does make things work. We have now to understand how this can possibly affect other workflow engines.

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
