### PR TITLE
Rename `_base` functions to be interpretable

### DIFF
--- a/src/quacc/recipes/dftb/_base.py
+++ b/src/quacc/recipes/dftb/_base.py
@@ -22,7 +22,7 @@ LOG_FILE = "dftb.out"
 GEOM_FILE = "geo_end.gen"
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from quacc import job
-from quacc.recipes.dftb._base import base_fn
+from quacc.recipes.dftb._base import run
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -57,7 +57,7 @@ def static_job(
     if "xtb" in method.lower():
         calc_defaults["Hamiltonian_Method"] = method
 
-    return base_fn(
+    return run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -115,7 +115,7 @@ def relax_job(
     if "xtb" in method.lower():
         calc_defaults["Hamiltonian_Method"] = method
 
-    return base_fn(
+    return run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from quacc.utils.files import Filenames, SourceDirectory
 
 
-def base_fn(
+def run(
     atoms: Atoms | None = None,
     preset: str | None = None,
     template: EspressoTemplate | None = None,
@@ -85,7 +85,7 @@ def base_fn(
     )
 
 
-def base_opt_fn(
+def run_ase_opt(
     atoms: Atoms | None = None,
     preset: str | None = None,
     relax_cell: bool = False,

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -13,7 +13,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from quacc import flow, job
 from quacc.calculators.espresso.espresso import EspressoTemplate
-from quacc.recipes.espresso._base import base_fn
+from quacc.recipes.espresso._base import run
 from quacc.utils.kpts import convert_pmg_kpts
 from quacc.wflow_tools.customizers import customize_funcs
 
@@ -93,7 +93,7 @@ def bands_pw_job(
             cell=atoms.get_cell(),
         )
 
-    return base_fn(
+    return run(
         atoms,
         template=EspressoTemplate("pw", test_run=test_run),
         calc_defaults=calc_defaults,
@@ -138,7 +138,7 @@ def bands_pp_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    return base_fn(
+    return run(
         atoms,
         template=EspressoTemplate("bands", test_run=test_run),
         calc_defaults={},
@@ -184,7 +184,7 @@ def fermi_surface_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    return base_fn(
+    return run(
         atoms,
         template=EspressoTemplate("fs", test_run=test_run),
         calc_defaults={},

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -8,7 +8,7 @@ from ase.optimize import LBFGS
 
 from quacc import job
 from quacc.calculators.espresso.espresso import EspressoTemplate
-from quacc.recipes.espresso._base import base_fn, base_opt_fn
+from quacc.recipes.espresso._base import run, run_ase_opt
 
 if TYPE_CHECKING:
     from typing import Any
@@ -60,7 +60,7 @@ def static_job(
     """
     calc_defaults = {"input_data": {"control": {"calculation": "scf"}}}
 
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         template=EspressoTemplate("pw", test_run=test_run),
@@ -120,7 +120,7 @@ def relax_job(
         }
     }
 
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         template=EspressoTemplate("pw", test_run=test_run),
@@ -189,7 +189,7 @@ def ase_relax_job(
 
     opt_defaults = {"optimizer": LBFGS}
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         preset=preset,
         relax_cell=relax_cell,
@@ -246,7 +246,7 @@ def post_processing_job(
         }
     }
 
-    return base_fn(
+    return run(
         template=EspressoTemplate("pp", test_run=test_run),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -297,7 +297,7 @@ def non_scf_job(
     """
     calc_defaults = {"input_data": {"control": {"calculation": "nscf"}}}
 
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         template=EspressoTemplate("pw", test_run=test_run),

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from quacc import flow, job
 from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.calculators.espresso.utils import pw_copy_files
-from quacc.recipes.espresso._base import base_fn
+from quacc.recipes.espresso._base import run
 from quacc.recipes.espresso.core import non_scf_job, static_job
 from quacc.utils.dicts import recursive_dict_merge
 from quacc.wflow_tools.customizers import customize_funcs
@@ -67,7 +67,7 @@ def dos_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    return base_fn(
+    return run(
         template=EspressoTemplate("dos", test_run=test_run),
         calc_defaults={},
         calc_swaps=calc_kwargs,
@@ -108,7 +108,7 @@ def projwfc_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    return base_fn(
+    return run(
         template=EspressoTemplate("projwfc", test_run=test_run),
         calc_defaults={},
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -17,7 +17,7 @@ from ase.io.espresso import Namelist
 from quacc import Job, flow, job, subflow
 from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.calculators.espresso.utils import grid_copy_files, grid_prepare_repr
-from quacc.recipes.espresso._base import base_fn
+from quacc.recipes.espresso._base import run
 from quacc.recipes.espresso.core import relax_job
 from quacc.utils.dicts import recursive_dict_merge
 from quacc.wflow_tools.customizers import customize_funcs, strip_decorator
@@ -79,7 +79,7 @@ def phonon_job(
         "qpts": (0, 0, 0),
     }
 
-    return base_fn(
+    return run(
         template=EspressoTemplate("ph", test_run=test_run),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -128,7 +128,7 @@ def q2r_job(
 
     copy_files = {prev_dir: [f"{fildyn}*"]}
 
-    return base_fn(
+    return run(
         template=EspressoTemplate("q2r"),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -177,7 +177,7 @@ def matdyn_job(
 
     copy_files = {prev_dir: [f"{flfrc}*"]}
 
-    return base_fn(
+    return run(
         template=EspressoTemplate("matdyn"),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/gaussian/_base.py
+++ b/src/quacc/recipes/gaussian/_base.py
@@ -24,7 +24,7 @@ LOG_FILE = f"{_LABEL}.log"
 GAUSSIAN_CMD = f"{SETTINGS.GAUSSIAN_CMD} < {_LABEL}.com > {LOG_FILE}"
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import psutil
 
 from quacc import job
-from quacc.recipes.gaussian._base import base_fn
+from quacc.recipes.gaussian._base import run
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
@@ -70,7 +70,7 @@ def static_job(
         "gfinput": "",
         "ioplist": ["6/7=3", "2/9=2000"],  # see ASE issue #660
     }
-    return base_fn(
+    return run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -138,7 +138,7 @@ def relax_job(
     if freq:
         calc_defaults["freq"] = ""
 
-    return base_fn(
+    return run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -27,7 +27,7 @@ GEOM_FILE_NOPBC = "gulp.xyz"
 GULP_CMD = f"{SETTINGS.GULP_CMD} < gulp.gin > gulp.got"
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     library: str | None = None,
     keyword_defaults: list[str] | None = None,

--- a/src/quacc/recipes/gulp/core.py
+++ b/src/quacc/recipes/gulp/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from quacc import job
-from quacc.recipes.gulp._base import base_fn
+from quacc.recipes.gulp._base import run
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
@@ -54,7 +54,7 @@ def static_job(
     keyword_defaults = ["gfnff", "gwolf"] if use_gfnff else []
     option_defaults = ["dump every gulp.res"]
 
-    return base_fn(
+    return run(
         atoms,
         library=library,
         keyword_defaults=keyword_defaults,
@@ -112,7 +112,7 @@ def relax_job(
 
     option_defaults = ["dump every gulp.res"]
 
-    return base_fn(
+    return run(
         atoms,
         library=library,
         keyword_defaults=keyword_defaults,

--- a/src/quacc/recipes/onetep/_base.py
+++ b/src/quacc/recipes/onetep/_base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from quacc.utils.files import Filenames, SourceDirectory
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,
@@ -56,7 +56,7 @@ def base_fn(
     return summarize_run(final_atoms, atoms, additional_fields=additional_fields)
 
 
-def base_opt_fn(
+def run_ase_opt(
     atoms: Atoms,
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,

--- a/src/quacc/recipes/onetep/core.py
+++ b/src/quacc/recipes/onetep/core.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from ase.optimize import LBFGS
 
 from quacc import job
-from quacc.recipes.onetep._base import base_fn, base_opt_fn
+from quacc.recipes.onetep._base import run, run_ase_opt
 from quacc.utils.dicts import recursive_dict_merge
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ def static_job(
     """
     calc_defaults = BASE_SET
 
-    return base_fn(
+    return run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -103,7 +103,7 @@ def ase_relax_job(
 
     opt_defaults = {"optimizer": LBFGS, "relax_cell": relax_cell}
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/orca/_base.py
+++ b/src/quacc/recipes/orca/_base.py
@@ -25,7 +25,7 @@ LOG_FILE = f"{_LABEL}.out"
 GEOM_FILE = f"{_LABEL}.xyz"
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     charge: int = 0,
     spin_multiplicity: int = 1,
@@ -81,7 +81,7 @@ def base_fn(
     return cclib_summarize_run(atoms, LOG_FILE, additional_fields=additional_fields)
 
 
-def base_opt_fn(
+def run_ase_opt(
     atoms: Atoms,
     charge: int = 0,
     spin_multiplicity: int = 1,

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import psutil
 
 from quacc import job
-from quacc.recipes.orca._base import base_fn, base_opt_fn
+from quacc.recipes.orca._base import run, run_ase_opt
 
 if TYPE_CHECKING:
     from typing import Any, Literal
@@ -68,7 +68,7 @@ def static_job(
     default_inputs = [xc, basis, "engrad", "normalprint", "slowconv"]
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
-    return base_fn(
+    return run(
         atoms,
         charge,
         spin_multiplicity,
@@ -138,7 +138,7 @@ def relax_job(
 
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
-    return base_fn(
+    return run(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,
@@ -203,7 +203,7 @@ def ase_relax_job(
     default_inputs = [xc, basis, "engrad", "normalprint", "slowconv"]
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,

--- a/src/quacc/recipes/psi4/_base.py
+++ b/src/quacc/recipes/psi4/_base.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from quacc.utils.files import Filenames, SourceDirectory
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     charge: int = 0,
     spin_multiplicity: int = 1,

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from monty.dev import requires
 
 from quacc import job
-from quacc.recipes.psi4._base import base_fn
+from quacc.recipes.psi4._base import run
 
 try:
     import psi4
@@ -69,7 +69,7 @@ def static_job(
         "multiplicity": spin_multiplicity,
         "reference": "uks" if spin_multiplicity > 1 else "rks",
     }
-    return base_fn(
+    return run(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,

--- a/src/quacc/recipes/qchem/_base.py
+++ b/src/quacc/recipes/qchem/_base.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from quacc.utils.files import Filenames, SourceDirectory
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     charge: int = 0,
     spin_multiplicity: int = 1,
@@ -69,7 +69,7 @@ def base_fn(
     )
 
 
-def base_opt_fn(
+def run_ase_opt(
     atoms: Atoms,
     charge: int = 0,
     spin_multiplicity: int = 1,

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from quacc import job
-from quacc.recipes.qchem._base import base_fn, base_opt_fn
+from quacc.recipes.qchem._base import run, run_ase_opt
 from quacc.utils.dicts import recursive_dict_merge
 
 try:
@@ -80,7 +80,7 @@ def static_job(
         _BASE_SET, {"rem": {"job_type": "force", "method": method, "basis": basis}}
     )
 
-    return base_fn(
+    return run(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,
@@ -140,7 +140,7 @@ def relax_job(
     )
     opt_defaults = {"optimizer": Sella} if has_sella else {}
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,
@@ -194,7 +194,7 @@ def freq_job(
         _BASE_SET, {"rem": {"job_type": "freq", "method": method, "basis": basis}}
     )
 
-    return base_fn(
+    return run(
         atoms,
         charge=charge,
         spin_multiplicity=spin_multiplicity,

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from monty.dev import requires
 
 from quacc import SETTINGS, job, strip_decorator
-from quacc.recipes.qchem._base import base_opt_fn
+from quacc.recipes.qchem._base import run_ase_opt
 from quacc.recipes.qchem.core import _BASE_SET, relax_job
 from quacc.utils.dicts import recursive_dict_merge
 
@@ -79,7 +79,7 @@ def ts_job(
     if opt_params and opt_params.get("optimizer", Sella) is not Sella:
         raise ValueError("Only Sella should be used for TS optimization.")
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         charge,
         spin_multiplicity,
@@ -150,7 +150,7 @@ def irc_job(
     if opt_params and opt_params.get("optimizer", IRC) is not IRC:
         raise ValueError("Only Sella's IRC should be used for IRC optimization.")
 
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         charge,
         spin_multiplicity,

--- a/src/quacc/recipes/vasp/_base.py
+++ b/src/quacc/recipes/vasp/_base.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from quacc.utils.files import Filenames, SourceDirectory
 
 
-def base_fn(
+def run(
     atoms: Atoms,
     preset: str | None = None,
     calc_defaults: dict[str, Any] | None = None,
@@ -66,7 +66,7 @@ def base_fn(
     )
 
 
-def base_opt_fn(
+def run_ase_opt(
     atoms: Atoms,
     preset: str | None = None,
     calc_defaults: dict[str, Any] | None = None,

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -10,7 +10,7 @@ from monty.os.path import zpath
 from pymatgen.io.vasp import Vasprun
 
 from quacc import flow, job
-from quacc.recipes.vasp._base import base_fn, base_opt_fn
+from quacc.recipes.vasp._base import run, run_ase_opt
 
 if TYPE_CHECKING:
     from typing import Any
@@ -59,7 +59,7 @@ def static_job(
         "nedos": 3001,
         "nsw": 0,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -112,7 +112,7 @@ def relax_job(
         "nsw": 200,
         "symprec": 1e-8,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -213,7 +213,7 @@ def ase_relax_job(
     """
     calc_defaults = {"lcharg": False, "lwave": False, "nsw": 0}
     opt_defaults = {"relax_cell": relax_cell}
-    return base_opt_fn(
+    return run_ase_opt(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -310,7 +310,7 @@ def non_scf_job(
     if calculate_optics:
         calc_defaults.update({"cshift": 1e-5, "loptics": True, "lreal": False})
 
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,

--- a/src/quacc/recipes/vasp/mp.py
+++ b/src/quacc/recipes/vasp/mp.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet, MPStaticSet
 
 from quacc import flow, job
-from quacc.recipes.vasp._base import base_fn
+from quacc.recipes.vasp._base import run
 from quacc.wflow_tools.customizers import customize_funcs
 
 try:
@@ -105,7 +105,7 @@ def mp_gga_relax_job(
         Dictionary of results.
     """
     calc_defaults = {"pmg_input_set": MPRelaxSet}
-    output = base_fn(
+    output = run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -154,7 +154,7 @@ def mp_gga_static_job(
         "lwave": True,  # Deviation from MP (but logical)
         "lreal": False,
     }
-    output = base_fn(
+    output = run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -210,7 +210,7 @@ def mp_metagga_prerelax_job(
         "lwave": True,
         "metagga": None,
     }
-    output = base_fn(
+    output = run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -261,7 +261,7 @@ def mp_metagga_relax_job(
         "lvtot": False,  # Deviation from MP (but logical)
         "lwave": True,
     }
-    output = base_fn(
+    output = run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
@@ -314,7 +314,7 @@ def mp_metagga_static_job(
         "lwave": True,  # Deviation from MP (but logical)
         "nsw": 0,
     }
-    output = base_fn(
+    output = run(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -13,7 +13,7 @@ from ase.optimize import BFGSLineSearch
 
 from quacc import job
 from quacc.calculators.vasp import Vasp
-from quacc.recipes.vasp._base import base_fn
+from quacc.recipes.vasp._base import run
 from quacc.runners.ase import run_opt
 from quacc.schemas.ase import summarize_opt_run
 from quacc.utils.dicts import recursive_dict_merge
@@ -175,7 +175,7 @@ def _loose_relax_positions(
         "lwave": True,
         "nsw": 250,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -216,7 +216,7 @@ def _loose_relax_cell(
         "lwave": True,
         "nsw": 500,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -259,7 +259,7 @@ def _double_relax(
         "lwave": True,
         "nsw": 500 if relax_cell else 250,
     }
-    summary1 = base_fn(
+    summary1 = run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -274,7 +274,7 @@ def _double_relax(
     del calc_defaults["lreal"]
 
     # Run second relaxation
-    summary2 = base_fn(
+    summary2 = run(
         summary1["atoms"],
         preset=preset,
         calc_defaults=calc_defaults,
@@ -311,7 +311,7 @@ def _static(atoms: Atoms, preset: str | None = "QMOFSet", **calc_kwargs) -> Vasp
         "lwave": True,
         "nsw": 0,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from quacc import flow, job
 from quacc.recipes.common.slabs import bulk_to_slabs_subflow, slab_to_ads_subflow
-from quacc.recipes.vasp._base import base_fn
+from quacc.recipes.vasp._base import run
 from quacc.wflow_tools.customizers import customize_funcs
 
 if TYPE_CHECKING:
@@ -58,7 +58,7 @@ def static_job(
         "nedos": 3001,
         "nsw": 0,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,
@@ -108,7 +108,7 @@ def relax_job(
         "nsw": 200,
         "symprec": 1e-8,
     }
-    return base_fn(
+    return run(
         atoms,
         preset=preset,
         calc_defaults=calc_defaults,


### PR DESCRIPTION
Renamed `base_fn` and `base_opt_fn` to `run` and `run_ase_opt`, respectively.