### PR TITLE
Fix Espresso DOS flows from crashing with workflow engines

### DIFF
--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -195,6 +195,8 @@ def _prepare_atoms(
         Atoms object with attached Espresso calculator.
     """
     atoms = Atoms() if atoms is None else atoms
+    calc_defaults = calc_defaults or {}
+    calc_swaps = calc_swaps or {}
 
     calc_defaults["input_data"] = Namelist(calc_defaults.get("input_data"))
     calc_swaps["input_data"] = Namelist(calc_swaps.get("input_data"))

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -269,7 +269,7 @@ def bands_flow(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    (bands_pw_job_, bands_pp_job_, fermi_surface_job_) = customize_funcs(
+    bands_pw_job_, bands_pp_job_, fermi_surface_job_ = customize_funcs(
         ["bands_pw_job", "bands_pp_job", "fermi_surface_job"],
         [bands_pw_job, bands_pp_job, fermi_surface_job],
         parameters=job_params,

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -68,7 +68,7 @@ def dos_job(
     """
     return run_and_summarize(
         template=EspressoTemplate("dos", test_run=test_run),
-        calc_defaults={},
+        calc_defaults=None,
         calc_swaps=calc_kwargs,
         parallel_info=parallel_info,
         additional_fields={"name": "dos.x Density-of-States"},
@@ -109,7 +109,7 @@ def projwfc_job(
     """
     return run_and_summarize(
         template=EspressoTemplate("projwfc", test_run=test_run),
-        calc_defaults={},
+        calc_defaults=None,
         calc_swaps=calc_kwargs,
         parallel_info=parallel_info,
         additional_fields={"name": "projwfc.x Projects-wavefunctions"},
@@ -162,7 +162,7 @@ def dos_flow(
         "input_data": {"system": {"occupations": "tetrahedra"}},
     }
     non_scf_job_defaults = recursive_dict_merge(
-        job_params.get("static_job", {}),
+        job_params.get("static_job"),
         {
             "kspacing": 0.01,
             "input_data": {
@@ -171,12 +171,11 @@ def dos_flow(
             },
         },
     )
-    dos_job_defaults = {}
 
     calc_defaults = {
         "static_job": static_job_defaults,
         "non_scf_job": non_scf_job_defaults,
-        "dos_job": dos_job_defaults,
+        "dos_job": None,
     }
     job_params = recursive_dict_merge(calc_defaults, job_params)
 
@@ -243,7 +242,7 @@ def projwfc_flow(
         "input_data": {"system": {"occupations": "tetrahedra"}},
     }
     non_scf_job_defaults = recursive_dict_merge(
-        job_params.get("static_job", {}),
+        job_params.get("static_job"),
         {
             "kspacing": 0.01,
             "input_data": {
@@ -252,12 +251,11 @@ def projwfc_flow(
             },
         },
     )
-    projwfc_job_defaults = {}
 
     calc_defaults = {
         "static_job": static_job_defaults,
         "non_scf_job": non_scf_job_defaults,
-        "projwfc_job": projwfc_job_defaults,
+        "projwfc_job": None,
     }
     job_params = recursive_dict_merge(calc_defaults, job_params)
 

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 from quacc import flow, job
 from quacc.calculators.espresso.espresso import EspressoTemplate
-from quacc.calculators.espresso.utils import pw_copy_files
 from quacc.recipes.espresso._base import run_and_summarize
 from quacc.recipes.espresso.core import non_scf_job, static_job
 from quacc.utils.dicts import recursive_dict_merge
@@ -189,20 +188,8 @@ def dos_flow(
     )
 
     static_results = static_job_(atoms)
-    files_to_copy = pw_copy_files(
-        job_params["static_job"].get("input_data"),
-        static_results["dir_name"],
-        include_wfc=False,
-    )
-
-    non_scf_results = non_scf_job_(atoms, files_to_copy)
-    files_to_copy = pw_copy_files(
-        job_params["non_scf_job"].get("input_data"),
-        non_scf_results["dir_name"],
-        include_wfc=False,
-    )
-
-    dos_results = dos_job_(files_to_copy)
+    non_scf_results = non_scf_job_(atoms, static_results["dir_name"])
+    dos_results = dos_job_(non_scf_results["dir_name"])
 
     return {
         "static_job": static_results,
@@ -282,20 +269,8 @@ def projwfc_flow(
     )
 
     static_results = static_job_(atoms)
-    files_to_copy = pw_copy_files(
-        job_params["static_job"].get("input_data"),
-        static_results["dir_name"],
-        include_wfc=False,
-    )
-
-    non_scf_results = non_scf_job_(atoms, files_to_copy)
-    files_to_copy = pw_copy_files(
-        job_params["non_scf_job"].get("input_data"),
-        non_scf_results["dir_name"],
-        include_wfc=True,
-    )
-
-    projwfc_results = projwfc_job_(files_to_copy)
+    non_scf_results = non_scf_job_(atoms, static_results["dir_name"])
+    projwfc_results = projwfc_job_(non_scf_results["dir_name"])
 
     return {
         "static_job": static_results,

--- a/src/quacc/utils/dicts.py
+++ b/src/quacc/utils/dicts.py
@@ -30,7 +30,7 @@ def recursive_dict_merge(
     """
     Recursively merge several dictionaries, taking the latter in the list as higher
     preference. Also removes any entries that have a value of `remove_trigger` from the
-    final dictionary.
+    final dictionary. If a `None` is provided, it is assumed to be `{}`.
 
     This function should be used instead of the | operator when merging nested dictionaries,
     e.g. `{"a": {"b": 1}} | {"a": {"c": 2}}` will return `{"a": {"c": 2}}` whereas
@@ -60,7 +60,7 @@ def _recursive_dict_pair_merge(
     dict1: MutableMapping[str, Any] | None, dict2: MutableMapping[str, Any] | None
 ) -> MutableMapping[str, Any]:
     """
-    Recursively merges two dictionaries.
+    Recursively merges two dictionaries. If a `None` is provided, it is assumed to be `{}`.
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #1787. Before, `pw_copy_files()` was being called on `Future` objects, which is not permitted. Here, I have just naively assumed we'll copy everything, and we'll let Espresso overwrite things as needed. Is this suitable or a no-go, @Nekkrad / @tomdemeyere?