### PR TITLE
Remove `slowconv` from defaults and make executable commands `str` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Calculator executable commands are now `str` type instead of `Path`
+- Removed `slowconv` from the default parameters of the ORCA recipes
 - The Q-Chem calculator now uses the TaskDoc from emmet in its `results` attribute
 
 ### Fixed

--- a/src/quacc/recipes/onetep/_base.py
+++ b/src/quacc/recipes/onetep/_base.py
@@ -130,7 +130,7 @@ def _prep_calculator(
         pseudo_path=str(SETTINGS.ONETEP_PP_PATH) if SETTINGS.ONETEP_PP_PATH else ".",
         parallel_info=SETTINGS.ONETEP_PARALLEL_CMD,
         profile=OnetepProfile(
-            str(SETTINGS.ONETEP_CMD)
+            SETTINGS.ONETEP_CMD
         ),  # TODO: If the ASE merge is successful, we need to change ONETEP_PARALLEL_CMD to a list[str] and remove parallel info.
         # If we also have access to post_args we can point not to the binary but to the launcher which takes -t nthreads as a post_args
         **calc_flags,

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -65,7 +65,7 @@ def static_job(
         See the type-hint for the data structure.
     """
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
-    default_inputs = [xc, basis, "engrad", "normalprint", "slowconv"]
+    default_inputs = [xc, basis, "engrad", "normalprint"]
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
     return run_and_summarize(
@@ -132,7 +132,7 @@ def relax_job(
     """
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
 
-    default_inputs = [xc, basis, "normalprint", "opt", "slowconv"]
+    default_inputs = [xc, basis, "normalprint", "opt"]
     if run_freq:
         default_inputs.append("freq")
 
@@ -200,7 +200,7 @@ def ase_relax_job(
         See the type-hint for the data structure.
     """
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
-    default_inputs = [xc, basis, "engrad", "normalprint", "slowconv"]
+    default_inputs = [xc, basis, "engrad", "normalprint"]
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
     return run_and_summarize_opt(

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -151,8 +151,8 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
     # ORCA Settings
     # ---------------------------
-    ORCA_CMD: Path = Field(
-        Path(which("orca") or "orca"),
+    ORCA_CMD: str = Field(
+        which("orca") or "orca",
         description=(
             """
             Path to the ORCA executable. This must be the full, absolute path
@@ -195,14 +195,14 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
     # Gaussian Settings
     # ---------------------------
-    GAUSSIAN_CMD: Path = Field(
-        Path("g16"), description=("Path to the Gaussian executable.")
+    GAUSSIAN_CMD: str = Field(
+        "g16", description=("Path to the Gaussian executable.")
     )
 
     # ---------------------------
     # ONETEP Settings
     # ---------------------------
-    ONETEP_CMD: Optional[Path] = Field(
+    ONETEP_CMD: Optional[str] = Field(
         Path("onetep.arch"), description=("Path to the ONETEP executable.")
     )
     ONETEP_PARALLEL_CMD: Optional[dict] = Field(
@@ -218,7 +218,7 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
     # GULP Settings
     # ---------------------------
-    GULP_CMD: Path = Field(Path("gulp"), description=("Path to the GULP executable."))
+    GULP_CMD: str = Field("gulp", description=("Path to the GULP executable."))
     GULP_LIB: Optional[Path] = Field(
         None,
         description=(
@@ -425,10 +425,7 @@ class QuaccSettings(BaseSettings):
         "SCRATCH_DIR",
         "ESPRESSO_PRESET_DIR",
         "ESPRESSO_PSEUDO",
-        "GAUSSIAN_CMD",
-        "GULP_CMD",
         "GULP_LIB",
-        "ORCA_CMD",
         "QCHEM_LOCAL_SCRATCH",
         "NEWTONNET_MODEL_PATH",
         "VASP_PRESET_DIR",

--- a/tests/core/recipes/orca_recipes/test_orca_recipes.py
+++ b/tests/core/recipes/orca_recipes/test_orca_recipes.py
@@ -18,7 +18,7 @@ def test_static_job(tmp_path, monkeypatch):
     assert output["natoms"] == len(atoms)
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-tzvp engrad normalprint slowconv wb97x-d3bj xyzfile"
+        == "def2-tzvp engrad normalprint wb97x-d3bj xyzfile"
     )
     assert output["parameters"]["charge"] == 0
     assert output["parameters"]["mult"] == 1
@@ -46,7 +46,7 @@ def test_static_job_parallel(tmp_path, monkeypatch):
     assert output["parameters"]["mult"] == 3
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-svp engrad normalprint slowconv wb97x-d3bj xyzfile"
+        == "def2-svp engrad normalprint wb97x-d3bj xyzfile"
     )
     assert "%scf maxiter 300 end" in output["parameters"]["orcablocks"]
     assert output.get("attributes")
@@ -64,7 +64,7 @@ def test_relax_job(tmp_path, monkeypatch):
     assert output["parameters"]["mult"] == 1
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-tzvp normalprint opt slowconv wb97x-d3bj xyzfile"
+        == "def2-tzvp normalprint opt wb97x-d3bj xyzfile"
     )
     assert output["trajectory"][0] != output["trajectory"][-1]
 
@@ -79,7 +79,7 @@ def test_relax_job(tmp_path, monkeypatch):
     assert output["natoms"] == len(atoms)
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-svp hf normalprint opt slowconv xyzfile"
+        == "def2-svp hf normalprint opt xyzfile"
     )
     assert (
         output["parameters"]["orcablocks"] == "%pal nprocs 2 end\n%scf maxiter 300 end"
@@ -102,7 +102,7 @@ def test_relax_freq_job(tmp_path, monkeypatch):
         charge=0,
         spin_multiplicity=1,
         nprocs=2,
-        orcasimpleinput=["#slowconv"],
+        orcasimpleinput=["#normalprint"],
         run_freq=True,
     )
     assert output["natoms"] == len(atoms)
@@ -110,7 +110,7 @@ def test_relax_freq_job(tmp_path, monkeypatch):
     assert output["parameters"]["mult"] == 1
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-svp freq hf normalprint opt xyzfile"
+        == "def2-svp freq hf opt xyzfile"
     )
     assert output["trajectory"][0] != output["trajectory"][-1]
 
@@ -126,7 +126,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
     assert output["parameters"]["mult"] == 1
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-tzvp engrad normalprint slowconv wb97x-d3bj xyzfile"
+        == "def2-tzvp engrad normalprint slconv wb97x-d3bj xyzfile"
     )
     assert output["fmax"] == 0.1
     assert output.get("trajectory")

--- a/tests/core/recipes/orca_recipes/test_orca_recipes.py
+++ b/tests/core/recipes/orca_recipes/test_orca_recipes.py
@@ -126,7 +126,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
     assert output["parameters"]["mult"] == 1
     assert (
         output["parameters"]["orcasimpleinput"]
-        == "def2-tzvp engrad normalprint slconv wb97x-d3bj xyzfile"
+        == "def2-tzvp engrad normalprint wb97x-d3bj xyzfile"
     )
     assert output["fmax"] == 0.1
     assert output.get("trajectory")


### PR DESCRIPTION
## Summary of Changes

1. Remove `slowconv` from ORCA recipe defaults
2. Make the various executable commands `str` type instead of `Path` type since apparently (?) there is the possibility for a weird permission error if it's a `Path`. Not quite sure how, but alas...
