### PR TITLE
Remove redundant `atoms_info` in output schema

### DIFF
--- a/src/quacc/schemas/_aliases/atoms.py
+++ b/src/quacc/schemas/_aliases/atoms.py
@@ -15,6 +15,5 @@ class AtomsSchema(StructureMetadata, MoleculeMetadata):
     """Type hint associated with [quacc.schemas.atoms.atoms_to_metadata][]"""
 
     atoms: Atoms
-    atoms_info: dict[str, Any]  # from atoms.info
     structure: Structure  # if atoms.pbc.any()
     molecule: Molecule  # if not atoms.pbc.any()

--- a/src/quacc/schemas/_aliases/atoms.py
+++ b/src/quacc/schemas/_aliases/atoms.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from quacc.schemas._aliases.emmet import MoleculeMetadata, StructureMetadata
 

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -12,7 +12,6 @@ from ase import units
 from ase.io import read
 from ase.vibrations import Vibrations
 from ase.vibrations.data import VibrationsData
-from pymatgen.io.ase import MSONAtoms
 
 from quacc import SETTINGS, __version__
 from quacc.atoms.core import get_final_atoms_from_dynamics
@@ -187,7 +186,6 @@ def summarize_opt_run(
             if hasattr(dyn, "traj_atoms")
             else read(dyn.trajectory.filename, index=":")
         )
-    trajectory = [MSONAtoms(atoms) for atoms in trajectory]
 
     initial_atoms = trajectory[0]
     final_atoms = get_final_atoms_from_dynamics(dyn)

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -12,6 +12,7 @@ from ase import units
 from ase.io import read
 from ase.vibrations import Vibrations
 from ase.vibrations.data import VibrationsData
+from pymatgen.io.ase import MSONAtoms
 
 from quacc import SETTINGS, __version__
 from quacc.atoms.core import get_final_atoms_from_dynamics
@@ -186,6 +187,7 @@ def summarize_opt_run(
             if hasattr(dyn, "traj_atoms")
             else read(dyn.trajectory.filename, index=":")
         )
+    trajectory = [MSONAtoms(atoms) for atoms in trajectory]
 
     initial_atoms = trajectory[0]
     final_atoms = get_final_atoms_from_dynamics(dyn)

--- a/src/quacc/schemas/atoms.py
+++ b/src/quacc/schemas/atoms.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from emmet.core.structure import MoleculeMetadata, StructureMetadata

--- a/src/quacc/schemas/atoms.py
+++ b/src/quacc/schemas/atoms.py
@@ -82,9 +82,6 @@ def atoms_to_metadata(
     else:
         metadata = {}
 
-    # Copy the info flags as a separate entry in the DB for easy querying
-    results["atoms_info"] = deepcopy(atoms.info)
-
     # Store Atoms object
     results["atoms"] = atoms
 

--- a/tests/core/schemas/test_ase.py
+++ b/tests/core/schemas/test_ase.py
@@ -71,8 +71,6 @@ def test_summarize_run3(tmp_path, monkeypatch):
     results = summarize_run(atoms, initial_atoms)
     assert atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
-    assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
 
 def test_summarize_run4(tmp_path, monkeypatch):
@@ -183,7 +181,6 @@ def test_summarize_opt_run(tmp_path, monkeypatch):
 
     results = summarize_opt_run(dyn)
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
     # test document can be jsanitized and decoded
@@ -251,7 +248,6 @@ def test_summarize_vib_run(tmp_path, monkeypatch):
 
     results = _summarize_vib_run(vib)
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
     # test document can be jsanitized and decoded
@@ -318,7 +314,6 @@ def test_summarize_ideal_gas_thermo(tmp_path, monkeypatch):
     )
     results = _summarize_ideal_gas_thermo(igt)
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
     # Make sure spin works right

--- a/tests/core/schemas/test_ase.py
+++ b/tests/core/schemas/test_ase.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import gzip
 import os
+import pickle
 from copy import deepcopy
 from pathlib import Path
 
@@ -14,7 +16,6 @@ from ase.units import invcm
 from ase.vibrations import Vibrations
 from maggma.stores import MemoryStore
 from monty.json import MontyDecoder, jsanitize
-from monty.serialization import loadfn
 
 from quacc.schemas.ase import (
     _summarize_ideal_gas_thermo,
@@ -41,12 +42,13 @@ def test_summarize_run(tmpdir, monkeypatch):
     assert results["input_atoms"]["atoms"] == initial_atoms
     assert Path(results["dir_name"]).is_dir()
 
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
+    with gzip.open(Path(results["dir_name"], "quacc_results.pkl.gz"), "rb") as f:
+        pickle_results = pickle.load(f)
+    assert pickle_results.keys() == results.keys()
 
-    assert json_results["nsites"] == results["nsites"]
-    assert json_results["results"]["energy"] == results["results"]["energy"]
-    assert json_results["atoms"].info == results["atoms"].info
+    assert pickle_results["nsites"] == results["nsites"]
+    assert pickle_results["results"]["energy"] == results["results"]["energy"]
+    assert pickle_results["atoms"].info == results["atoms"].info
 
 
 def test_summarize_run2(tmp_path, monkeypatch):
@@ -134,14 +136,15 @@ def test_summarize_opt_run(tmp_path, monkeypatch):
     assert results["fmax"] == dyn.fmax
     assert results["parameters_opt"]["max_steps"] == 100
 
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
+    with gzip.open(Path(results["dir_name"], "quacc_results.pkl.gz"), "rb") as f:
+        pickle_results = pickle.load(f)
 
-    assert json_results.keys() == results.keys()
+    assert pickle_results.keys() == results.keys()
 
     # assert things on the trajectory are the same
-    assert json_results["trajectory"] == results["trajectory"]
+    assert pickle_results["trajectory"] == results["trajectory"]
     assert (
-        json_results["trajectory_results"][-1]["energy"]
+        pickle_results["trajectory_results"][-1]["energy"]
         == results["trajectory_results"][-1]["energy"]
     )
 

--- a/tests/core/schemas/test_cclib_schema.py
+++ b/tests/core/schemas/test_cclib_schema.py
@@ -129,7 +129,6 @@ def test_cclib_summarize_run(tmp_path, monkeypatch):
     results = cclib_summarize_run(atoms, ".log", directory=tmp_path / "test1")
     assert atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
 

--- a/tests/core/schemas/test_cclib_schema.py
+++ b/tests/core/schemas/test_cclib_schema.py
@@ -128,7 +128,6 @@ def test_cclib_summarize_run(tmp_path, monkeypatch):
     atoms.info["test_dict"] = {"hi": "there", "foo": "bar"}
     results = cclib_summarize_run(atoms, ".log", directory=tmp_path / "test1")
     assert atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
-    assert results.get("atoms_info", {}) != {}
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
 

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -99,7 +99,6 @@ def test_vasp_summarize_run(run1, monkeypatch, tmp_path):
     results = vasp_summarize_run(atoms, directory=p)
     results_atoms = results["atoms"]
     assert atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
-    assert results.get("atoms_info", {}) != {}
     assert results_atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
     # Make sure magnetic moments are handled appropriately

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -100,7 +100,6 @@ def test_vasp_summarize_run(run1, monkeypatch, tmp_path):
     results_atoms = results["atoms"]
     assert atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results.get("atoms_info", {}) != {}
-    assert results["atoms_info"].get("test_dict", None) == {"hi": "there", "foo": "bar"}
     assert results_atoms.info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
     # Make sure magnetic moments are handled appropriately


### PR DESCRIPTION
## Summary of Changes

Remove the redundant `atoms_info` key in the output schemas, since this is already captured by MSONable `Atoms`.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
