### PR TITLE
The optimizer trajectory now has the proper JSON extension, not pickle

### DIFF
--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -186,7 +186,7 @@ def run_opt(
     optimizer_kwargs = recursive_dict_merge(
         {
             "logfile": "-" if SETTINGS.DEBUG else tmpdir / "opt.log",
-            "restart": tmpdir / "opt.pckl",
+            "restart": tmpdir / "opt.json",
         },
         optimizer_kwargs,
     )


### PR DESCRIPTION
## Summary of Changes

Apparently, a while back ASE changed from pickle to JSON for the optimizer trajectory, so we've been dumping to a pickle file extension even though it's JSON format. I fixed the file extension now.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
