### PR TITLE
Increase hackability of recipes

### DIFF
--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -95,7 +95,11 @@ def run_and_summarize(
     if SETTINGS.GULP_LIB:
         os.environ["GULP_LIB"] = str(SETTINGS.GULP_LIB)
     atoms.calc = GULP(
-        command=GULP_CMD, keywords=gulp_keywords, options=gulp_options, library=library, **calc_kwargs
+        command=GULP_CMD,
+        keywords=gulp_keywords,
+        options=gulp_options,
+        library=library,
+        **calc_kwargs,
     )
     final_atoms = run_calc(
         atoms,

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -36,6 +36,7 @@ def run_and_summarize(
     option_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    **calc_kwargs,
 ) -> RunSchema:
     """
     Base job function for GULP recipes.
@@ -62,7 +63,9 @@ def run_and_summarize(
         Additional field to supply to the summarizer.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-
+    **calc_kwargs
+        Any other keyword arguments to pass to the `GULP` calculator.
+        
     Returns
     -------
     RunSchema

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -95,7 +95,7 @@ def run_and_summarize(
     if SETTINGS.GULP_LIB:
         os.environ["GULP_LIB"] = str(SETTINGS.GULP_LIB)
     atoms.calc = GULP(
-        command=GULP_CMD, keywords=gulp_keywords, options=gulp_options, library=library
+        command=GULP_CMD, keywords=gulp_keywords, options=gulp_options, library=library, **calc_kwargs
     )
     final_atoms = run_calc(
         atoms,

--- a/src/quacc/recipes/onetep/_base.py
+++ b/src/quacc/recipes/onetep/_base.py
@@ -50,7 +50,7 @@ def run_and_summarize(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-    atoms.calc = _prep_calculator(calc_defaults=calc_defaults, calc_swaps=calc_swaps)
+    atoms.calc = prep_calculator(calc_defaults=calc_defaults, calc_swaps=calc_swaps)
     final_atoms = run_calc(atoms, copy_files=copy_files)
 
     return summarize_run(final_atoms, atoms, additional_fields=additional_fields)
@@ -96,14 +96,14 @@ def run_and_summarize_opt(
     """
     opt_flags = recursive_dict_merge(opt_defaults, opt_params)
 
-    atoms.calc = _prep_calculator(calc_defaults=calc_defaults, calc_swaps=calc_swaps)
+    atoms.calc = prep_calculator(calc_defaults=calc_defaults, calc_swaps=calc_swaps)
 
     dyn = run_opt(atoms, copy_files=copy_files, **opt_flags)
 
     return summarize_opt_run(dyn, additional_fields=additional_fields)
 
 
-def _prep_calculator(
+def prep_calculator(
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,
 ) -> Onetep:

--- a/src/quacc/recipes/orca/_base.py
+++ b/src/quacc/recipes/orca/_base.py
@@ -35,6 +35,7 @@ def run_and_summarize(
     block_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    **calc_kwargs,
 ) -> cclibSchema:
     """
     Base job function for ORCA recipes.
@@ -61,19 +62,22 @@ def run_and_summarize(
         Any additional fields to supply to the summarizer.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    **calc_kwargs
+        Any other keyword arguments to pass to the `ORCA` calculator.
 
     Returns
     -------
     cclibSchema
         Dictionary of results
     """
-    atoms.calc = _prep_calculator(
+    atoms.calc = prep_calculator(
         charge=charge,
         spin_multiplicity=spin_multiplicity,
         default_inputs=default_inputs,
         default_blocks=default_blocks,
         input_swaps=input_swaps,
         block_swaps=block_swaps,
+        **calc_kwargs,
     )
 
     atoms = run_calc(atoms, geom_file=GEOM_FILE, copy_files=copy_files)
@@ -93,6 +97,7 @@ def run_and_summarize_opt(
     opt_params: dict[str, Any] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    **calc_kwargs,
 ) -> cclibASEOptSchema:
     """
     Base job function for ORCA recipes with ASE optimizer.
@@ -123,19 +128,22 @@ def run_and_summarize_opt(
         Any additional fields to supply to the summarizer.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    **calc_kwargs
+        Any other keyword arguments to pass to the `ORCA` calculator.
 
     Returns
     -------
     cclibASEOptSchema
         Dictionary of results
     """
-    atoms.calc = _prep_calculator(
+    atoms.calc = prep_calculator(
         charge=charge,
         spin_multiplicity=spin_multiplicity,
         default_inputs=default_inputs,
         default_blocks=default_blocks,
         input_swaps=input_swaps,
         block_swaps=block_swaps,
+        **calc_kwargs,
     )
 
     opt_flags = recursive_dict_merge(opt_defaults, opt_params)
@@ -143,13 +151,14 @@ def run_and_summarize_opt(
     return summarize_cclib_opt_run(dyn, LOG_FILE, additional_fields=additional_fields)
 
 
-def _prep_calculator(
+def prep_calculator(
     charge: int = 0,
     spin_multiplicity: int = 1,
     default_inputs: list[str] | None = None,
     default_blocks: list[str] | None = None,
     input_swaps: list[str] | None = None,
     block_swaps: list[str] | None = None,
+    **calc_kwargs,
 ) -> ORCA:
     """
     Prepare the ORCA calculator.
@@ -170,6 +179,8 @@ def _prep_calculator(
     block_swaps
         List of orcablock swaps for the calculator. To remove entries
         from the defaults, put a `#` in front of the name.
+    **calc_kwargs
+        Any other keyword arguments to pass to the `ORCA` calculator.
 
     Returns
     -------
@@ -189,4 +200,5 @@ def _prep_calculator(
         mult=spin_multiplicity,
         orcasimpleinput=orcasimpleinput,
         orcablocks=orcablocks,
+        **calc_kwargs,
     )

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -30,7 +30,7 @@ def static_job(
     method: str = "wb97x-v",
     basis: str = "def2-tzvp",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
-    **kwargs,
+    **calc_kwargs,
 ) -> RunSchema:
     """
     Function to carry out a single-point calculation.
@@ -49,7 +49,7 @@ def static_job(
         Basis set
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-    **kwargs
+    **calc_kwargs
         Custom kwargs for the Psi4 calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
         keys, refer to the [ase.calculators.psi4.Psi4][] calculator.
@@ -74,7 +74,7 @@ def static_job(
         charge=charge,
         spin_multiplicity=spin_multiplicity,
         calc_defaults=calc_defaults,
-        calc_swaps=kwargs,
+        calc_swaps=calc_kwargs,
         additional_fields={"name": "Psi4 Static"},
         copy_files=copy_files,
     )


### PR DESCRIPTION
## Summary of Changes

This PR increases the "hackability" of recipes for users that are doing funky things with a custom calculator. Namely, some recipes don't take a `**calc_kwargs` because, well, there is no need to. An example of this is the ORCA recipes since the ASE `ORCA` calculator takes `orcasimpleinput` and `orcablocks` as dedicated keyword arguments; there is no need for the user to pass an arbitrary set of `**calc_kwargs` because the possible options are clearly enumerated in ASE. However, if someone makes a custom `ORCA` calculator where they add on additional keyword arguments, then they can't get passed anywhere. This is likely a rare edge case, but it's pretty painless to implement.
