### PR TITLE
Remove double `_` methods

### DIFF
--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -76,7 +76,7 @@ def run_and_summarize(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-    atoms = _prepare_atoms(
+    atoms = prepare_atoms(
         atoms=atoms,
         preset=preset,
         template=template,
@@ -86,7 +86,7 @@ def run_and_summarize(
         parallel_info=parallel_info,
     )
 
-    updated_copy_files = _prepare_copy(
+    updated_copy_files = prepare_copy(
         copy_files=copy_files,
         calc_params=atoms.calc.user_calc_params,
         binary=atoms.calc.template.binary,
@@ -159,7 +159,7 @@ def run_and_summarize_opt(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.summarize_run][]
     """
-    atoms = _prepare_atoms(
+    atoms = prepare_atoms(
         atoms=atoms,
         preset=preset,
         template=template,
@@ -169,7 +169,7 @@ def run_and_summarize_opt(
         parallel_info=parallel_info,
     )
 
-    updated_copy_files = _prepare_copy(
+    updated_copy_files = prepare_copy(
         copy_files=copy_files,
         calc_params=atoms.calc.user_calc_params,
         binary=atoms.calc.template.binary,
@@ -186,7 +186,7 @@ def run_and_summarize_opt(
     )
 
 
-def _prepare_atoms(
+def prepare_atoms(
     atoms: Atoms | None = None,
     preset: str | None = None,
     template: EspressoTemplate | None = None,
@@ -252,7 +252,7 @@ def _prepare_atoms(
     return atoms
 
 
-def _prepare_copy(
+def prepare_copy(
     copy_files: (
         SourceDirectory
         | list[SourceDirectory]


### PR DESCRIPTION
## Summary of Changes

No need for us to hide methods that are already hidden.

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
