### PR TITLE
Deprecate "mace" mlp recipes (replaced with "mace-mp-0")

### DIFF
--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING
+from monty.dev import deprecated
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -16,10 +17,14 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 def pick_calculator(
-    method: Literal["mace", "m3gnet", "chgnet"], **kwargs
+    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"], **kwargs
 ) -> Calculator:
     """
     Adapted from `matcalc.util.get_universal_calculator`.
+    .. deprecated:: 0.7.6
+            method `mace` will be removed in a later version, it is replaced by 'mace-mp-0'
+            which more accurately reflects the nature of the model and allow for versioning
+            in the future.
 
     Parameters
     ----------
@@ -56,9 +61,19 @@ def pick_calculator(
 
         calc = CHGNetCalculator(**kwargs)
 
+    elif method.lower() == "mace-mp-0":
+        from mace import __version__
+        from mace.calculators import mace_mp
+
+        if "default_dtype" not in kwargs:
+            kwargs["default_dtype"] = "float64"
+        calc = mace_mp(**kwargs)
+    
     elif method.lower() == "mace":
         from mace import __version__
         from mace.calculators import mace_mp
+
+        deprecated("DEPRECATION WARNING: 'mace' has been deprecated, 'mace-mp-0' should be used instead")
 
         if "default_dtype" not in kwargs:
             kwargs["default_dtype"] = "float64"

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -70,6 +70,7 @@ def pick_calculator(
             warn(
                 "'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!",
                 DeprecationWarning,
+                stacklevel=3
             )
 
         if "default_dtype" not in kwargs:

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -69,7 +69,7 @@ def pick_calculator(
         if method.lower() == "mace":
             warn(
                 "'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!",
-                DeprecationWarning
+                DeprecationWarning,
             )
 
         if "default_dtype" not in kwargs:

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -11,7 +11,7 @@ from monty.dev import deprecated
 if TYPE_CHECKING:
     from typing import Literal
 
-    from ase.calculator.calculator import Calculator
+    from ase.calculators.calculator import Calculator
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ def pick_calculator(
     Adapted from `matcalc.util.get_universal_calculator`.
     .. deprecated:: 0.7.6
             method `mace` will be removed in a later version, it is replaced by 'mace-mp-0'
-            which more accurately reflects the nature of the model and allow for versioning
+            which more accurately reflects the nature of the model and allows for versioning
             in the future.
 
     Parameters

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -21,6 +21,7 @@ def pick_calculator(
 ) -> Calculator:
     """
     Adapted from `matcalc.util.get_universal_calculator`.
+
     .. deprecated:: 0.7.6
             method `mace` will be removed in a later version, it is replaced by 'mace-mp-0'
             which more accurately reflects the nature of the model and allows for versioning
@@ -67,9 +68,8 @@ def pick_calculator(
 
         if method.lower() == "mace":
             warn(
-                "\033[33m'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!\033[0m",
-                DeprecationWarning,
-                stacklevel=3,
+                "'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!",
+                DeprecationWarning
             )
 
         if "default_dtype" not in kwargs:

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING
+
 from monty.dev import deprecated
 
 if TYPE_CHECKING:
@@ -68,12 +69,12 @@ def pick_calculator(
         if "default_dtype" not in kwargs:
             kwargs["default_dtype"] = "float64"
         calc = mace_mp(**kwargs)
-    
+
     elif method.lower() == "mace":
         from mace import __version__
         from mace.calculators import mace_mp
 
-        deprecated("DEPRECATION WARNING: 'mace' has been deprecated, 'mace-mp-0' should be used instead")
+        mace_warning()
 
         if "default_dtype" not in kwargs:
             kwargs["default_dtype"] = "float64"
@@ -85,3 +86,11 @@ def pick_calculator(
     calc.parameters["version"] = __version__
 
     return calc
+
+
+@deprecated(
+    None,
+    "\u001b[33mWarning: 'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!\u001b[0m",
+)
+def mace_warning():
+    return

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING
-
-from monty.dev import deprecated
+from warnings import warn
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -62,19 +61,16 @@ def pick_calculator(
 
         calc = CHGNetCalculator(**kwargs)
 
-    elif method.lower() == "mace-mp-0":
+    elif method.lower() in ["mace-mp-0", "mace"]:
         from mace import __version__
         from mace.calculators import mace_mp
 
-        if "default_dtype" not in kwargs:
-            kwargs["default_dtype"] = "float64"
-        calc = mace_mp(**kwargs)
-
-    elif method.lower() == "mace":
-        from mace import __version__
-        from mace.calculators import mace_mp
-
-        mace_warning()
+        if method.lower() == "mace":
+            warn(
+                "\033[33m'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!\033[0m",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
         if "default_dtype" not in kwargs:
             kwargs["default_dtype"] = "float64"
@@ -86,11 +82,3 @@ def pick_calculator(
     calc.parameters["version"] = __version__
 
     return calc
-
-
-@deprecated(
-    None,
-    "\u001b[33mWarning: 'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!\u001b[0m",
-)
-def mace_warning():
-    return

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 def pick_calculator(
-    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"], **kwargs
+    method: Literal["mace-mp-0", "m3gnet", "chgnet"], **kwargs
 ) -> Calculator:
     """
     Adapted from `matcalc.util.get_universal_calculator`.

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -70,7 +70,7 @@ def pick_calculator(
             warn(
                 "'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!",
                 DeprecationWarning,
-                stacklevel=3
+                stacklevel=3,
             )
 
         if "default_dtype" not in kwargs:

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @job
-def staftic_job(
+def static_job(
     atoms: Atoms,
     method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
     **calc_kwargs,

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -20,9 +20,7 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms,
-    method: Literal["mace-mp-0", "m3gnet", "chgnet"],
-    **calc_kwargs,
+    atoms: Atoms, method: Literal["mace-mp-0", "m3gnet", "chgnet"], **calc_kwargs
 ) -> RunSchema:
     """
     Carry out a single-point calculation.

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -19,8 +19,10 @@ if TYPE_CHECKING:
 
 
 @job
-def static_job(
-    atoms: Atoms, method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"], **calc_kwargs
+def staftic_job(
+    atoms: Atoms,
+    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
+    **calc_kwargs,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms, method: Literal["mace", "m3gnet", "chgnet"], **calc_kwargs
+    atoms: Atoms, method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"], **calc_kwargs
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -53,7 +53,7 @@ def static_job(
 @job
 def relax_job(
     atoms: Atoms,
-    method: Literal["mace", "m3gnet", "chgnet"],
+    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
     relax_cell: bool = False,
     opt_params: dict[str, Any] | None = None,
     **calc_kwargs,

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 @job
 def static_job(
     atoms: Atoms,
-    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
+    method: Literal["mace-mp-0", "m3gnet", "chgnet"],
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -55,7 +55,7 @@ def static_job(
 @job
 def relax_job(
     atoms: Atoms,
-    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
+    method: Literal["mace-mp-0", "m3gnet", "chgnet"],
     relax_cell: bool = False,
     opt_params: dict[str, Any] | None = None,
     **calc_kwargs,

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 )
 def phonon_flow(
     atoms: Atoms,
-    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
+    method: Literal["mace-mp-0", "m3gnet", "chgnet"],
     symprec: float = 1e-4,
     min_lengths: float | tuple[float, float, float] | None = 20.0,
     supercell_matrix: (

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 )
 def phonon_flow(
     atoms: Atoms,
-    method: Literal["mace", "m3gnet", "chgnet"],
+    method: Literal["mace-mp-0", "m3gnet", "chgnet", "mace"],
     symprec: float = 1e-4,
     min_lengths: float | tuple[float, float, float] | None = 20.0,
     supercell_matrix: (

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -14,6 +14,7 @@ try:
     import mace
 
     methods.append("mace")
+    methods.append("mace-mp-0")
 
 except ImportError:
     mace = None
@@ -48,7 +49,7 @@ def _set_dtype(size, type_="float"):
 def test_static_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace":
+    if method == "mace" or method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
@@ -56,6 +57,7 @@ def test_static_job(tmp_path, monkeypatch, method):
     ref_energy = {
         "chgnet": -4.083308219909668,
         "m3gnet": -4.0938973,
+        "mace-mp-0": -4.083906650543213,
         "mace": -4.083906650543213,
     }
     atoms = bulk("Cu")
@@ -69,13 +71,14 @@ def test_static_job(tmp_path, monkeypatch, method):
 def test_relax_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace":
+    if method == "mace" or method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
     ref_energy = {
         "chgnet": -32.665428161621094,
         "m3gnet": -32.75003433227539,
+        "mace-mp-0": -32.6711566550002,
         "mace": -32.6711566550002,
     }
 
@@ -106,7 +109,7 @@ def test_relax_job_dispersion(tmp_path, monkeypatch):
 def test_relax_cell_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace":
+    if method == "mace" or method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
@@ -114,6 +117,7 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
     ref_energy = {
         "chgnet": -32.66698455810547,
         "m3gnet": -32.750858306884766,
+        "mace-mp-0": -32.67840391814377,
         "mace": -32.67840391814377,
     }
 

--- a/tests/core/recipes/mlp_recipes/test_core_recipes.py
+++ b/tests/core/recipes/mlp_recipes/test_core_recipes.py
@@ -13,7 +13,6 @@ methods = []
 try:
     import mace
 
-    methods.append("mace")
     methods.append("mace-mp-0")
 
 except ImportError:
@@ -49,7 +48,7 @@ def _set_dtype(size, type_="float"):
 def test_static_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace" or method == "mace-mp-0":
+    if method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
@@ -58,7 +57,6 @@ def test_static_job(tmp_path, monkeypatch, method):
         "chgnet": -4.083308219909668,
         "m3gnet": -4.0938973,
         "mace-mp-0": -4.083906650543213,
-        "mace": -4.083906650543213,
     }
     atoms = bulk("Cu")
     output = static_job(atoms, method=method)
@@ -71,7 +69,7 @@ def test_static_job(tmp_path, monkeypatch, method):
 def test_relax_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace" or method == "mace-mp-0":
+    if method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
@@ -79,7 +77,6 @@ def test_relax_job(tmp_path, monkeypatch, method):
         "chgnet": -32.665428161621094,
         "m3gnet": -32.75003433227539,
         "mace-mp-0": -32.6711566550002,
-        "mace": -32.6711566550002,
     }
 
     atoms = bulk("Cu") * (2, 2, 2)
@@ -98,7 +95,7 @@ def test_relax_job_dispersion(tmp_path, monkeypatch):
 
     atoms = bulk("Cu") * (2, 2, 2)
     atoms[0].position += 0.1
-    output = relax_job(atoms, method="mace", dispersion=True)
+    output = relax_job(atoms, method="mace-mp-0", dispersion=True)
     assert output["results"]["energy"] == pytest.approx(-37.340311589504076)
     assert np.shape(output["results"]["forces"]) == (8, 3)
     assert output["atoms"] != atoms
@@ -109,7 +106,7 @@ def test_relax_job_dispersion(tmp_path, monkeypatch):
 def test_relax_cell_job(tmp_path, monkeypatch, method):
     monkeypatch.chdir(tmp_path)
 
-    if method == "mace" or method == "mace-mp-0":
+    if method == "mace-mp-0":
         _set_dtype(64)
     else:
         _set_dtype(32)
@@ -118,7 +115,6 @@ def test_relax_cell_job(tmp_path, monkeypatch, method):
         "chgnet": -32.66698455810547,
         "m3gnet": -32.750858306884766,
         "mace-mp-0": -32.67840391814377,
-        "mace": -32.67840391814377,
     }
 
     atoms = bulk("Cu") * (2, 2, 2)


### PR DESCRIPTION
## Summary of Changes

Closes #1972 by adding support for 'mace-mp-0' and adding a deprecated warning for 'mace' in the mlp recipe. 

Adding 'mace-mp-0':
- Added as a Literal in the arguments for static_job() and relax_job() in core.py, phonon_flow() in phonons.py, and pick_calculator() in _base.py
- Added an elif conditional for 'mace-mp-0' in pick_calculator() in _base.py 
- Added 'mace-mp-0 as a Literal for tests in test_core_recipes.py in mlp_recipes test folder.

Deprecating 'mace':
- Added 'import deprecated from monty.dev' in _base.py
- Updated pick_calculator() docstring with deprecation warning according to NumPy docstring standard in _base.py
- Added mace_warning() with 'deprecated' decorator invoked in pick_calculator() in _base.py

Additional:
- Changed 'from ase.calculator.calculator' to 'from ase.calculators.calculator' in _base.py in mlp recipe to match ase documentation and other recipes.


### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
