### PR TITLE
No longer raise a warning if vdw_kernel.bindat is missing

### DIFF
--- a/docs/install/codes.md
+++ b/docs/install/codes.md
@@ -139,13 +139,10 @@ To use quacc with VASP, you will need to define several environment variables, a
 ```bash
 export QUACC_VASP_PARALLEL_CMD="srun -N 2 --ntasks-per-node 24"
 export QUACC_VASP_PP_PATH="/path/to/POTCARs"
-export QUACC_VASP_VDW="/path/to/directory/containing/kernel"
 ```
 
 The `VASP_PARALLEL_CMD` setting tells Custodian and/or ASE how to parallelize VASP. Note that it does not include the executable.
 
 The `VASP_PP_PATH` setting should point to the directory containing your VASP pseudopotentials. There should be two subdirectories name `potpaw_PBE` and `potpaw` for the PBE and LDA pseudopotentials, respectively. If your pseudopotential directories have a different name, create a symbolic link with the required naming scheme. We recommend setting `QUACC_VASP_PP_PATH` in your `~/.bashrc` file since this rarely changes.
-
-The `VASP_VDW` environment variable is necessary if you are using a vdW functional and should point to the directory that contains the `vdw_kernel.bindat` file distributed with VASP. We also recommend including this in your `~/.bashrc` file since this rarely changes.
 
 Additional settings can be specified as well, such as the name of the VASP executables if they differ from the default values (i.e. `vasp_std`, `vasp_gam`).

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -186,10 +186,6 @@ class Vasp(Vasp_):
         # Set the ASE_VASP_VDW environmentvariable
         if SETTINGS.VASP_VDW:
             os.environ["ASE_VASP_VDW"] = str(SETTINGS.VASP_VDW)
-        if self.user_calc_params.get("luse_vdw") and "ASE_VASP_VDW" not in os.environ:
-            raise OSError(
-                "VASP_VDW setting was not provided, yet you requested a vdW functional."
-            )
 
         # Return vanilla ASE command
         vasp_cmd = (

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -438,13 +438,6 @@ def test_lasph_aggressive():
     SETTINGS.VASP_INCAR_COPILOT = DEFAULT_SETTINGS.VASP_INCAR_COPILOT
 
 
-def test_vdw():
-    atoms = bulk("Cu")
-
-    with pytest.raises(OSError, match="VASP_VDW setting was not provided"):
-        Vasp(atoms, xc="beef-vdw")
-
-
 def test_efermi():
     atoms = bulk("Cu")
     calc = Vasp(atoms)


### PR DESCRIPTION
## Summary of Changes

In VASP 6.4.3+, the vdw_kernel.bindat file is not needed for vdW runs. The warning is removed.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
