### PR TITLE
Support special Parsl keywords

### DIFF
--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -566,6 +566,7 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
         return delayed(wrapper, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "parsl":
         from parsl import join_app
+
         wrapped_fn = _get_parsl_wrapped_func(_func, **kwargs)
         return join_app(wrapped_fn, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "prefect":

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -580,7 +580,22 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
     elif SETTINGS.WORKFLOW_ENGINE == "parsl":
         from parsl import join_app
 
-        return join_app(_func, **kwargs)
+        stdout = kwargs.pop("stdout", None)
+        stderr = kwargs.pop("stderr", None)
+        walltime = kwargs.pop("walltime", None)
+        parsl_resource_specification = kwargs.pop("parsl_resource_specification", None)
+
+        def wrapper(
+            *f_args,
+            stdout=stdout,
+            stderr=stderr,
+            walltime=walltime,
+            parsl_resource_specification=parsl_resource_specification,
+            **f_kwargs,
+        ):
+            return _func(*f_args, **f_kwargs)
+
+        return join_app(wrapper, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -177,6 +177,8 @@ def job(_func: Callable | None = None, **kwargs) -> Job:
         ):
             return _func(*f_args, **f_kwargs)
 
+        wrapper.__name__ = _func.__name__
+
         return python_app(wrapper, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "redun":
         from redun import task
@@ -594,6 +596,8 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
             **f_kwargs,
         ):
             return _func(*f_args, **f_kwargs)
+
+        wrapper.__name__ = _func.__name__
 
         return join_app(wrapper, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "prefect":

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -162,7 +162,7 @@ def job(_func: Callable | None = None, **kwargs) -> Job:
     elif SETTINGS.WORKFLOW_ENGINE == "parsl":
         from parsl import python_app
 
-        wrapped_fn = _get_parsl_wrapped_func(_func, kwargs)
+        wrapped_fn = _get_parsl_wrapped_func(_func, **kwargs)
 
         return python_app(wrapped_fn, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "redun":

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -594,18 +594,15 @@ def _get_parsl_wrapped_func(
         The function to wrap.
     decorator_kwargs
         Decorator keyword arguments, including Parsl-specific ones that
-        are meant to be passed to the underlying function. The `stdout`,
-        `stderr`, `walltime`, and `parsl_resource_specification` arguments
-        will be injected into the function call and removed from the
-        decorator arguments.
+        are meant to be passed to the underlying function. The `walltime`
+        and `parsl_resource_specification` arguments will be injected
+        into the function call and removed from the decorator arguments.
 
     Returns
     -------
     callable
         The wrapped function.
     """
-    stdout = decorator_kwargs.pop("stdout", None)
-    stderr = decorator_kwargs.pop("stderr", None)
     walltime = decorator_kwargs.pop("walltime", None)
     parsl_resource_specification = decorator_kwargs.pop(
         "parsl_resource_specification", None
@@ -613,8 +610,6 @@ def _get_parsl_wrapped_func(
 
     def wrapper(
         *f_args,
-        stdout=stdout,  # noqa: ARG001
-        stderr=stderr,  # noqa: ARG001
         walltime=walltime,  # noqa: ARG001
         parsl_resource_specification=parsl_resource_specification,  # noqa: ARG001
         **f_kwargs,

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -568,6 +568,7 @@ def subflow(_func: Callable | None = None, **kwargs) -> Subflow:
         from parsl import join_app
 
         wrapped_fn = _get_parsl_wrapped_func(_func, **kwargs)
+
         return join_app(wrapped_fn, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -162,7 +162,22 @@ def job(_func: Callable | None = None, **kwargs) -> Job:
     elif SETTINGS.WORKFLOW_ENGINE == "parsl":
         from parsl import python_app
 
-        return python_app(_func, **kwargs)
+        stdout = kwargs.pop("stdout", None)
+        stderr = kwargs.pop("stderr", None)
+        walltime = kwargs.pop("walltime", None)
+        parsl_resource_specification = kwargs.pop("parsl_resource_specification", None)
+
+        def wrapper(
+            *f_args,
+            stdout=stdout,
+            stderr=stderr,
+            walltime=walltime,
+            parsl_resource_specification=parsl_resource_specification,
+            **f_kwargs,
+        ):
+            return _func(*f_args, **f_kwargs)
+
+        return python_app(wrapper, **kwargs)
     elif SETTINGS.WORKFLOW_ENGINE == "redun":
         from redun import task
 

--- a/tests/parsl/test_syntax.py
+++ b/tests/parsl/test_syntax.py
@@ -143,3 +143,7 @@ def test_special_params(tmpdir, monkeypatch):
 
     assert add(1, 2).result() == 3
     assert add2(1, 2).result() == [4, 6, 8, 10, 12, 14]
+    assert "mystdout.txt" in tmpdir
+    assert "mystderr.txt" in tmpdir
+    assert "mystdout2.txt" in tmpdir
+    assert "mystderr2.txt" in tmpdir

--- a/tests/parsl/test_syntax.py
+++ b/tests/parsl/test_syntax.py
@@ -123,27 +123,13 @@ def test_strip_decorators():
 def test_special_params(tmpdir, monkeypatch):
     monkeypatch.chdir(tmpdir)
 
-    @job(
-        stdout="mystdout.txt",
-        stderr="mystderr.txt",
-        walltime=30,
-        parsl_resource_specification={},
-    )
+    @job(walltime=30, parsl_resource_specification={})
     def add(a, b):
         return a + b
 
-    @subflow(
-        stdout="mystdout2.txt",
-        stderr="mystderr2.txt",
-        walltime=20,
-        parsl_resource_specification={},
-    )
+    @subflow(walltime=20, parsl_resource_specification={})
     def add2(a, b):
         return [add(i, i + 2) for i in range(a, b + 5)]
 
     assert add(1, 2).result() == 3
     assert add2(1, 2).result() == [4, 6, 8, 10, 12, 14]
-    assert "mystdout.txt" in tmpdir
-    assert "mystderr.txt" in tmpdir
-    assert "mystdout2.txt" in tmpdir
-    assert "mystderr2.txt" in tmpdir

--- a/tests/parsl/test_syntax.py
+++ b/tests/parsl/test_syntax.py
@@ -118,3 +118,27 @@ def test_strip_decorators():
 
     stripped_add3 = strip_decorator(add3)
     assert stripped_add3(1, 2) == 3
+
+def test_special_params(tmpdir, monkeypatch):
+    monkeypatch.chdir(tmpdir)
+
+    @job(
+        stdout="mystdout.txt",
+        stderr="mystderr.txt",
+        walltime=30,
+        parsl_resource_specification={},
+    )
+    def add(a, b):
+        return a + b
+
+    @subflow(
+        stdout="mystdout2.txt",
+        stderr="mystderr2.txt",
+        walltime=20,
+        parsl_resource_specification={},
+    )
+    def add2(a, b):
+        return [add(i, i + 2) for i in range(a, b + 5)]
+
+    assert add(1, 2).result() == 3
+    assert add2(1, 2).result() == [4, 6, 8, 10, 12, 14]


### PR DESCRIPTION
## Summary of Changes

Closes https://github.com/Quantum-Accelerators/quacc/issues/1886.

Adding `@wraps` does not work, special keywords are not passed to Parsl correctly in this case (I don't know why).

To perform proper testing, an `HighThroughputExecutor` will have to be loaded in the test.
### Checklist

- [x] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [x] My PR is on a custom branch and is _not_ named `main`.
- [x] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
