### PR TITLE
Remove redundant call to `get_phonopy` and fix bug in common phonon subflow

### DIFF
--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -21,8 +21,10 @@ if TYPE_CHECKING:
 
     from quacc import Job
     from quacc.schemas._aliases.phonons import PhononSchema
+
     if has_deps:
         from phonopy import Phonopy
+
 
 @subflow
 @requires(
@@ -100,7 +102,9 @@ def phonon_subflow(
         ]
 
     @job
-    def _thermo_job(atoms: Atoms, phonon: Phonopy, force_job_results: list[dict]) -> PhononSchema:
+    def _thermo_job(
+        atoms: Atoms, phonon: Phonopy, force_job_results: list[dict]
+    ) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
         phonon_results = run_phonopy(

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -83,18 +83,6 @@ def phonon_subflow(
         Dictionary of results from [quacc.schemas.phonons.summarize_phonopy][]
     """
 
-    phonon = get_phonopy(
-        atoms,
-        min_lengths=min_lengths,
-        supercell_matrix=supercell_matrix,
-        symprec=symprec,
-        displacement=displacement,
-        phonopy_kwargs=phonopy_kwargs,
-    )
-    supercells = [
-        phonopy_atoms_to_ase_atoms(s) for s in phonon.supercells_with_displacements
-    ]
-
     @subflow
     def _get_forces_subflow(supercells: list[Atoms]) -> list[dict]:
         return [
@@ -119,6 +107,19 @@ def phonon_subflow(
             additional_fields=additional_fields,
         )
 
+
+    phonon = get_phonopy(
+        atoms,
+        min_lengths=min_lengths,
+        supercell_matrix=supercell_matrix,
+        symprec=symprec,
+        displacement=displacement,
+        phonopy_kwargs=phonopy_kwargs,
+    )
+    supercells = [
+        phonopy_atoms_to_ase_atoms(s) for s in phonon.supercells_with_displacements
+    ]
+    
     if relax_job is not None:
         atoms = relax_job(atoms)["atoms"]
 

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -107,7 +107,6 @@ def phonon_subflow(
             additional_fields=additional_fields,
         )
 
-
     phonon = get_phonopy(
         atoms,
         min_lengths=min_lengths,
@@ -119,7 +118,7 @@ def phonon_subflow(
     supercells = [
         phonopy_atoms_to_ase_atoms(s) for s in phonon.supercells_with_displacements
     ]
-    
+
     if relax_job is not None:
         atoms = relax_job(atoms)["atoms"]
 

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -105,6 +105,10 @@ def phonon_subflow(
             phonopy, atoms, phonopy_results.directory, parameters=parameters
         )
 
+    if relax_job is not None:
+        atoms = relax_job(atoms)["atoms"]
+
+
     phonopy = get_phonopy(
         atoms,
         min_lengths=min_lengths,
@@ -116,9 +120,5 @@ def phonon_subflow(
     supercells = [
         phonopy_atoms_to_ase_atoms(s) for s in phonopy.supercells_with_displacements
     ]
-
-    if relax_job is not None:
-        atoms = relax_job(atoms)["atoms"]
-
     force_job_results = _get_forces_subflow(supercells)
     return _thermo_job(atoms, phonopy, force_job_results, t_step, t_min, t_max)

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -102,7 +102,7 @@ def phonon_subflow(
         )
 
         return summarize_phonopy(
-            phonon, atoms, phonopy_results.directory, parameters=parameters
+            phonopy, atoms, phonopy_results.directory, parameters=parameters
         )
 
     phonopy = get_phonopy(

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -102,7 +102,7 @@ def phonon_subflow(
         )
 
         return summarize_phonopy(
-            phonopy, atoms, phonopy_results.directory, parameters=parameters
+            phonopy, atoms, phonopy_results.directory, parameters=parameters, additional_fields={"name": "Phonopy Thermo"}
         )
 
     if relax_job is not None:

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -88,7 +88,12 @@ def phonon_subflow(
 
     @job
     def _thermo_job(
-        atoms: Atoms, phonon: Phonopy, force_job_results: list[dict], t_step: float, t_min: float, t_max: float)
+        atoms: Atoms,
+        phonon: Phonopy,
+        force_job_results: list[dict],
+        t_step: float,
+        t_min: float,
+        t_max: float,
     ) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
@@ -97,10 +102,7 @@ def phonon_subflow(
         )
 
         return summarize_phonopy(
-            phonon,
-            atoms,
-            phonon_results.directory,
-            parameters=parameters,
+            phonon, atoms, phonon_results.directory, parameters=parameters
         )
 
     phonon = get_phonopy(

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
 def phonon_subflow(
     atoms: Atoms,
     force_job: Job,
-    relax_job: Job | None = None,
     symprec: float = 1e-4,
     min_lengths: float | tuple[float, float, float] | None = 20.0,
     supercell_matrix: (
@@ -55,8 +54,6 @@ def phonon_subflow(
         Atoms object with calculator attached.
     force_job
         The static job to calculate the forces.
-    relax_job
-        The job used to relax the structure before calculating the forces.
     symprec
         Precision for symmetry detection.
     min_lengths
@@ -112,9 +109,6 @@ def phonon_subflow(
             parameters=parameters,
             additional_fields=additional_fields,
         )
-
-    if relax_job is not None:
-        atoms = relax_job(atoms)["atoms"]
 
     phonopy = get_phonopy(
         atoms,

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -89,7 +89,7 @@ def phonon_subflow(
     @job
     def _thermo_job(
         atoms: Atoms,
-        phonon: Phonopy,
+        phonopy: Phonopy,
         force_job_results: list[dict],
         t_step: float,
         t_min: float,
@@ -97,15 +97,15 @@ def phonon_subflow(
     ) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
-        phonon_results = run_phonopy(
-            phonon, forces, t_step=t_step, t_min=t_min, t_max=t_max
+        phonopy_results = run_phonopy(
+            phonopy, forces, t_step=t_step, t_min=t_min, t_max=t_max
         )
 
         return summarize_phonopy(
-            phonon, atoms, phonon_results.directory, parameters=parameters
+            phonon, atoms, phonopy_results.directory, parameters=parameters
         )
 
-    phonon = get_phonopy(
+    phonopy = get_phonopy(
         atoms,
         min_lengths=min_lengths,
         supercell_matrix=supercell_matrix,
@@ -114,11 +114,11 @@ def phonon_subflow(
         phonopy_kwargs=phonopy_kwargs,
     )
     supercells = [
-        phonopy_atoms_to_ase_atoms(s) for s in phonon.supercells_with_displacements
+        phonopy_atoms_to_ase_atoms(s) for s in phonopy.supercells_with_displacements
     ]
 
     if relax_job is not None:
         atoms = relax_job(atoms)["atoms"]
 
     force_job_results = _get_forces_subflow(supercells)
-    return _thermo_job(atoms, phonon, force_job_results, t_step, t_min, t_max)
+    return _thermo_job(atoms, phonopy, force_job_results, t_step, t_min, t_max)

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -108,7 +108,6 @@ def phonon_subflow(
     if relax_job is not None:
         atoms = relax_job(atoms)["atoms"]
 
-
     phonopy = get_phonopy(
         atoms,
         min_lengths=min_lengths,

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -44,7 +44,6 @@ def phonon_subflow(
     t_min: float = 0,
     t_max: float = 1000,
     phonopy_kwargs: dict[str, Any] | None = None,
-    additional_fields: dict[str, Any] | None = None,
 ) -> PhononSchema:
     """
     Calculate phonon properties.
@@ -74,8 +73,6 @@ def phonon_subflow(
         Max temperature (K).
     phonopy_kwargs
         Additional kwargs to pass to the Phonopy class.
-    additional_fields
-        Additional fields to store in the database.
 
     Returns
     -------
@@ -91,7 +88,7 @@ def phonon_subflow(
 
     @job
     def _thermo_job(
-        atoms: Atoms, phonon: Phonopy, force_job_results: list[dict]
+        atoms: Atoms, phonon: Phonopy, force_job_results: list[dict], t_step: float, t_min: float, t_max: float)
     ) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
@@ -104,7 +101,6 @@ def phonon_subflow(
             atoms,
             phonon_results.directory,
             parameters=parameters,
-            additional_fields=additional_fields,
         )
 
     phonon = get_phonopy(
@@ -123,4 +119,4 @@ def phonon_subflow(
         atoms = relax_job(atoms)["atoms"]
 
     force_job_results = _get_forces_subflow(supercells)
-    return _thermo_job(atoms, phonon, force_job_results)
+    return _thermo_job(atoms, phonon, force_job_results, t_step, t_min, t_max)

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -44,6 +44,7 @@ def phonon_subflow(
     t_min: float = 0,
     t_max: float = 1000,
     phonopy_kwargs: dict[str, Any] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> PhononSchema:
     """
     Calculate phonon properties.
@@ -73,6 +74,8 @@ def phonon_subflow(
         Max temperature (K).
     phonopy_kwargs
         Additional kwargs to pass to the Phonopy class.
+    additional_fields
+        Additional fields to add to the output schema.
 
     Returns
     -------
@@ -94,6 +97,7 @@ def phonon_subflow(
         t_step: float,
         t_min: float,
         t_max: float,
+        additional_fields: dict[str, Any] | None,
     ) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
@@ -102,7 +106,11 @@ def phonon_subflow(
         )
 
         return summarize_phonopy(
-            phonopy, atoms, phonopy_results.directory, parameters=parameters, additional_fields={"name": "Phonopy Thermo"}
+            phonopy,
+            atoms,
+            phonopy_results.directory,
+            parameters=parameters,
+            additional_fields=additional_fields,
         )
 
     if relax_job is not None:
@@ -120,4 +128,6 @@ def phonon_subflow(
         phonopy_atoms_to_ase_atoms(s) for s in phonopy.supercells_with_displacements
     ]
     force_job_results = _get_forces_subflow(supercells)
-    return _thermo_job(atoms, phonopy, force_job_results, t_step, t_min, t_max)
+    return _thermo_job(
+        atoms, phonopy, force_job_results, t_step, t_min, t_max, additional_fields
+    )

--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
 
     from quacc import Job
     from quacc.schemas._aliases.phonons import PhononSchema
-
+    if has_deps:
+        from phonopy import Phonopy
 
 @subflow
 @requires(
@@ -99,15 +100,7 @@ def phonon_subflow(
         ]
 
     @job
-    def _thermo_job(atoms: Atoms, force_job_results: list[dict]) -> PhononSchema:
-        phonon = get_phonopy(
-            atoms,
-            min_lengths=min_lengths,
-            supercell_matrix=supercell_matrix,
-            symprec=symprec,
-            displacement=displacement,
-            phonopy_kwargs=phonopy_kwargs,
-        )
+    def _thermo_job(atoms: Atoms, phonon: Phonopy, force_job_results: list[dict]) -> PhononSchema:
         parameters = force_job_results[-1].get("parameters")
         forces = [output["results"]["forces"] for output in force_job_results]
         phonon_results = run_phonopy(
@@ -126,4 +119,4 @@ def phonon_subflow(
         atoms = relax_job(atoms)["atoms"]
 
     force_job_results = _get_forces_subflow(supercells)
-    return _thermo_job(atoms, force_job_results)
+    return _thermo_job(atoms, phonon, force_job_results)

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -92,11 +92,12 @@ def phonon_flow(
         parameters=job_params,
         decorators=job_decorators,
     )
+    if run_relax:
+        atoms = relax_job(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,
         static_job_,
-        relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_lengths=min_lengths,
         supercell_matrix=supercell_matrix,

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -93,7 +93,7 @@ def phonon_flow(
         decorators=job_decorators,
     )
     if run_relax:
-        atoms = relax_job(atoms)["atoms"]
+        atoms = relax_job_(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -104,5 +104,5 @@ def phonon_flow(
         t_step=t_step,
         t_min=t_min,
         t_max=t_max,
-        additional_fields={"name": "EMT Phonons"}
+        additional_fields={"name": "EMT Phonons"},
     )

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -104,5 +104,4 @@ def phonon_flow(
         t_step=t_step,
         t_min=t_min,
         t_max=t_max,
-        additional_fields={"name": "EMT Phonons"},
     )

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -104,4 +104,5 @@ def phonon_flow(
         t_step=t_step,
         t_min=t_min,
         t_max=t_max,
+        additional_fields={"name": "EMT Phonons"}
     )

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -105,11 +105,12 @@ def phonon_flow(
         parameters=job_params,
         decorators=job_decorators,
     )
+    if run_relax:
+        atoms = relax_job(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,
         static_job_,
-        relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_lengths=min_lengths,
         supercell_matrix=supercell_matrix,

--- a/src/quacc/recipes/mlp/phonons.py
+++ b/src/quacc/recipes/mlp/phonons.py
@@ -106,7 +106,7 @@ def phonon_flow(
         decorators=job_decorators,
     )
     if run_relax:
-        atoms = relax_job(atoms)["atoms"]
+        atoms = relax_job_(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,

--- a/src/quacc/recipes/tblite/phonons.py
+++ b/src/quacc/recipes/tblite/phonons.py
@@ -105,11 +105,12 @@ def phonon_flow(
         parameters=job_params,
         decorators=job_decorators,
     )
+    if run_relax:
+        atoms = relax_job(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,
         static_job_,
-        relax_job=relax_job_ if run_relax else None,
         symprec=symprec,
         min_lengths=min_lengths,
         supercell_matrix=supercell_matrix,

--- a/src/quacc/recipes/tblite/phonons.py
+++ b/src/quacc/recipes/tblite/phonons.py
@@ -106,7 +106,7 @@ def phonon_flow(
         decorators=job_decorators,
     )
     if run_relax:
-        atoms = relax_job(atoms)["atoms"]
+        atoms = relax_job_(atoms)["atoms"]
 
     return phonon_subflow(
         atoms,


### PR DESCRIPTION
This PR removes the redundant call to `get_phonopy()` in `quacc.recipes.common.phonons`. It also fixes a bug (?) where the `Phonopy` object was constructed based on the _unrelaxed_ structure rather than the relaxed structure.