### PR TITLE
Fix copying of WAVECAR in QMOF recipes

### DIFF
--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -128,7 +128,7 @@ def _prerelax(
         Atoms object
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-    **kwargs
+    **calc_kwargs
         Custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely.
 
@@ -173,7 +173,7 @@ def _loose_relax_positions(
         Atoms object
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-    **kwargs
+    **calc_kwargs
         Custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely.
 
@@ -327,7 +327,7 @@ def _static(
         Atoms object
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-    **kwargs
+    **calc_kwargs
         Custom kwargs for the calculator. Set a value to `None` to remove
         a pre-existing key entirely.
 

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -83,9 +83,7 @@ def qmof_relax_job(
 
     # 3. Optional: Volume relaxation (loose)
     if relax_cell:
-        summary3 = _loose_relax_cell(
-            atoms, preset, copy_files, **calc_kwargs
-        )
+        summary3 = _loose_relax_cell(atoms, preset, copy_files=copy_files, **calc_kwargs)
         atoms = summary3["atoms"]
         copy_files = {summary3["dir_name"]: ["WAVECAR*"]}
 
@@ -100,9 +98,7 @@ def qmof_relax_job(
     copy_files = {summary4[1]["dir_name"]: ["WAVECAR*"]}
 
     # 5. Static Calculation
-    summary5 = _static(
-        atoms, preset, copy_files=copy_files, **calc_kwargs
-    )
+    summary5 = _static(atoms, preset, copy_files=copy_files, **calc_kwargs)
     summary5["prerelax_lowacc"] = summary1 if run_prerelax else None
     summary5["position_relax_lowacc"] = summary2
     summary5["volume_relax_lowacc"] = summary3 if relax_cell else None

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -7,11 +7,12 @@ Reference: https://doi.org/10.1016/j.matt.2021.02.015
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from ase.optimize import BFGSLineSearch
 
-from quacc import job
+from quacc import SETTINGS, job
 from quacc.recipes.vasp._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from quacc.schemas._aliases.ase import OptSchema
     from quacc.schemas._aliases.vasp import QMOFRelaxSchema, VaspSchema
     from quacc.utils.files import Filenames, SourceDirectory
+
+LOGGER = logging.getLogger(__name__)
 
 
 @job
@@ -68,6 +71,11 @@ def qmof_relax_job(
         Dictionary of results. See the type-hint for the data structure.
     """
     copy_files = None
+    if not SETTINGS.VASP_USE_CUSTODIAN:
+        SETTINGS.VASP_USE_CUSTODIAN = True
+        LOGGER.warning(
+            "Setting VASP_USE_CUSTODIAN to True since it is required for this recipe."
+        )
 
     # 1. Pre-relaxation
     if run_prerelax:

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -504,7 +504,7 @@ def test_qmof(tmp_path, monkeypatch, caplog):
         SETTINGS.VASP_USE_CUSTODIAN = False
         qmof_relax_job(atoms)
 
-        assert "Setting VASP_USE_CUSTODIAN to True'" in caplog.text
+        assert "Setting VASP_USE_CUSTODIAN to True" in caplog.text
         SETTINGS.VASP_USE_CUSTODIAN = DEFAULT_SETTINGS.VASP_USE_CUSTODIAN
 
 

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -502,9 +502,11 @@ def test_qmof(tmp_path, monkeypatch, caplog):
 
 
     with caplog.at_level(logging.WARNING):
+        SETTINGS.VASP_USE_CUSTODIAN = False
         qmof_relax_job(atoms)
 
         assert "Setting VASP_USE_CUSTODIAN to True'" in caplog.text
+        SETTINGS.VASP_USE_CUSTODIAN = DEFAULT_SETTINGS.VASP_USE_CUSTODIAN
 
 def test_mp_metagga_prerelax_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary of Changes

Closes #2117. Fixed passing of the WAVECAR between steps in the QMOF recipe.

There are also a few other minor changes: 1) I removed the `preset` keyword argument because it is not QMOF compatible if "QMOFSet" is not used. 2) I did some cleanup of the internal (`_` prepended) functions for increased robustness. 3) I force `VASP_USE_CUSTODIAN` to be `True` because otherwise WAVECAR issues can occur when going from gamma-point only to standard VASP versions.

@honghuikim: Thank you again for the report. This PR should hopefully fix it. Unfortunately, I do not have very thorough tests set up for WAVECAR passing yet, so please don't hesitate to let me know if the problem persists after this is merged. Thank you!

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [x] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
