### PR TITLE
Breaking: Don't try to auto-detect the workflow engine

### DIFF
--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from importlib import util
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, Literal, Optional, Union

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -16,15 +16,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 if TYPE_CHECKING:
     from typing import Any
 
-
-installed_engine = next(
-    (
-        wflow_engine
-        for wflow_engine in ["parsl", "covalent", "prefect", "dask", "redun", "jobflow"]
-        if util.find_spec(wflow_engine)
-    ),
-    None,
-)
 _DEFAULT_CONFIG_FILE_PATH = Path("~", ".quacc.yaml").expanduser().resolve()
 
 
@@ -67,7 +58,7 @@ class QuaccSettings(BaseSettings):
 
     WORKFLOW_ENGINE: Optional[
         Literal["covalent", "dask", "parsl", "prefect", "redun", "jobflow"]
-    ] = Field(installed_engine, description=("The workflow manager to use, if any."))
+    ] = Field(None, description=("The workflow manager to use, if any."))
 
     # ---------------------------
     # General Settings


### PR DESCRIPTION
## Summary of Changes

Previously, `quacc` would try to auto-detect which workflow engine you had installed and then set that as the default. This, however, is too smart for its own good. It often leads to user confusion because if you install (say) atomate2 and get jobflow installed as a side-effect, it will auto-change to jobflow without the user knowing. This behavior has been disabled. As noted in the docs, the user should specific explicitly which workflow engine to use.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
