### PR TITLE
Change `VASP_MAG_CUTOFF` from 0.05 to 0.02

### DIFF
--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -282,7 +282,7 @@ class QuaccSettings(BaseSettings):
         ),
     )
     VASP_MAG_CUTOFF: float = Field(
-        0.05,
+        0.02,
         description=(
             """
             If the absolute value of all magnetic moments are below this value,


### PR DESCRIPTION
This PR changes `VASP_MAG_CUTOFF` from 0.05 to 0.02 to more closely match the protocol used by MP.