### PR TITLE
Tag the original function with the decorator type

### DIFF
--- a/src/quacc/wflow_tools/customizers.py
+++ b/src/quacc/wflow_tools/customizers.py
@@ -34,33 +34,33 @@ def strip_decorator(func: Callable) -> Callable:
 
     if SETTINGS.WORKFLOW_ENGINE == "covalent":
         if decorator in ("job", "subflow"):
-            func = func.electron_object.function
+            func_ = func.electron_object.function
 
         if decorator in ("flow", "subflow"):
-            func = func.workflow_function.get_deserialized()
+            func_ = func.workflow_function.get_deserialized()
 
     elif SETTINGS.WORKFLOW_ENGINE == "dask":
         if decorator == "job":
             func = func.func
-        func = func.__wrapped__
+        func_ = func.__wrapped__
         if decorator == "subflow":
-            func = func.__wrapped__
+            func_ = func.__wrapped__
 
     elif SETTINGS.WORKFLOW_ENGINE == "jobflow":
-        func = func.original
+        func_ = func.original
 
     elif SETTINGS.WORKFLOW_ENGINE == "parsl":
-        func = func.func
+        func_ = func.func
 
     elif SETTINGS.WORKFLOW_ENGINE == "prefect":
         if SETTINGS.PREFECT_AUTO_SUBMIT:
             func = func.__wrapped__
-        func = func.fn
+        func_ = func.fn
 
     elif SETTINGS.WORKFLOW_ENGINE == "redun":
-        func = func.func
+        func_ = func.func
 
-    return func
+    return func_
 
 
 def redecorate(func: Callable, decorator: Callable) -> Callable:

--- a/tests/dask/test_syntax.py
+++ b/tests/dask/test_syntax.py
@@ -162,12 +162,12 @@ def test_customize_funcs(monkeypatch, tmp_path):
     def test_dynamic_workflow(a, b, c=3):
         result1 = add(a, b)
         result2 = make_more(result1)
-        return update_parameters(add_distributed, {"d": 1}, decorator="subflow")(
+        return update_parameters(add_distributed, {"d": 1})(
             result2, c
         )
 
-    add_ = update_parameters(add, {"b": 3}, decorator="job")
-    dynamic_workflow_ = update_parameters(dynamic_workflow, {"c": 4}, decorator="flow")
+    add_ = update_parameters(add, {"b": 3})
+    dynamic_workflow_ = update_parameters(dynamic_workflow, {"c": 4})
     assert client.compute(add_(1)).result() == 4
     assert client.compute(dynamic_workflow_(1, 2)).result() == [7, 7, 7]
     assert client.compute(test_dynamic_workflow(1, 2)).result() == [7, 7, 7]

--- a/tests/prefect/test_syntax.py
+++ b/tests/prefect/test_syntax.py
@@ -4,6 +4,9 @@ import pytest
 
 prefect = pytest.importorskip("prefect")
 
+from prefect import Flow as PrefectFlow
+from prefect import Task
+
 from quacc import change_settings, flow, job, strip_decorator, subflow
 
 
@@ -178,9 +181,12 @@ def test_strip_decorators():
 
     stripped_add = strip_decorator(add)
     assert stripped_add(1, 2) == 3
+    assert not isinstance(stripped_add, Task)
 
     stripped_add2 = strip_decorator(add2)
     assert stripped_add2(1, 2) == 3
+    assert not isinstance(stripped_add2,PrefectFlow)
 
     stripped_add3 = strip_decorator(add3)
     assert stripped_add3(1, 2) == 3
+    assert not isinstance(stripped_add3,PrefectFlow)


### PR DESCRIPTION
## Summary of Changes

Closes #1865 by adding a `.quacc_decorator` attribute on the decorated function so we can intelligently redecorate behind-the-scenes. This may, in the future, allow for advanced logic with redecoration.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
