### PR TITLE
Store failed calculations with a dedicated naming scheme

### DIFF
--- a/docs/user/settings/file_management.md
+++ b/docs/user/settings/file_management.md
@@ -90,7 +90,7 @@ SCRATCH_DIR
 
 ### Job Failure
 
-If the job fails or does not complete, then the file structure look slike:
+If the job fails or does not complete, then the file structure looks like:
 
 ```text
 RESULTS_DIR

--- a/docs/user/settings/file_management.md
+++ b/docs/user/settings/file_management.md
@@ -38,7 +38,14 @@ RESULTS_DIR
 
 ### Job Failure
 
-If the job fails or does not complete, then the `tmp-quacc-2023-12-08-67890` directory will remain in `RESULTS_DIR` so you can inspect the files.
+If the job fails or does not complete, then the file structure looks like:
+
+```text
+RESULTS_DIR
+├── failed-quacc-2023-12-08-67890
+│   ├── INPUT
+    └── OUTPUT
+```
 
 ## Scenario 2: Specifying a `SCRATCH_DIR`
 
@@ -83,4 +90,17 @@ SCRATCH_DIR
 
 ### Job Failure
 
-If the job fails or does not complete, then the `tmp-quacc-2023-12-08-67890` directory will remain in `SCRATCH_DIR` so you can inspect the files. The symbolic link in `RESULTS_DIR` will also remain.
+If the job fails or does not complete, then the file structure look slike:
+
+```text
+RESULTS_DIR
+├── symlink-failed-quacc-2023-12-08-67890
+│
+```
+
+```text
+SCRATCH_DIR
+├── failed-quacc-2023-12-08-67890
+│   ├── INPUT
+    └── OUTPUT
+```

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -258,6 +258,7 @@ def run_opt(
                     if fn_hook:
                         fn_hook(dyn)
         except Exception as exception:
+            traj.close()
             terminate(tmpdir, exception)
 
     # Store the trajectory atoms

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -236,8 +236,8 @@ def run_opt(
         atoms = FrechetCellFilter(atoms)
 
     # Run optimization
-    with traj, optimizer(atoms, **optimizer_kwargs) as dyn:
-        try:
+    try:
+        with traj, optimizer(atoms, **optimizer_kwargs) as dyn:
             if optimizer.__name__.startswith("SciPy"):
                 # https://gitlab.com/ase/ase/-/issues/1475
                 dyn.run(fmax=fmax, steps=max_steps, **run_kwargs)
@@ -258,7 +258,6 @@ def run_opt(
                     if fn_hook:
                         fn_hook(dyn)
         except Exception as exception:
-            traj.close()
             terminate(tmpdir, exception)
 
     # Store the trajectory atoms

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -257,8 +257,8 @@ def run_opt(
                         )
                     if fn_hook:
                         fn_hook(dyn)
-        except Exception as exception:
-            terminate(tmpdir, exception)
+    except Exception as exception:
+        terminate(tmpdir, exception)
 
     # Store the trajectory atoms
     dyn.traj_atoms = read(traj_file, index=":")

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -112,7 +112,7 @@ def run_calc(
         else:
             atoms.get_potential_energy()
     except Exception as exception:
-        terminate(tmpdir,exception)
+        terminate(tmpdir, exception)
 
     # Most ASE calculators do not update the atoms object in-place with a call
     # to .get_potential_energy(), which is important if an internal optimizer is
@@ -242,7 +242,9 @@ def run_opt(
                 # https://gitlab.com/ase/ase/-/issues/1475
                 dyn.run(fmax=fmax, steps=max_steps, **run_kwargs)
             else:
-                for i, _ in enumerate(dyn.irun(fmax=fmax, steps=max_steps, **run_kwargs)):
+                for i, _ in enumerate(
+                    dyn.irun(fmax=fmax, steps=max_steps, **run_kwargs)
+                ):
                     if store_intermediate_results:
                         _copy_intermediate_files(
                             tmpdir,
@@ -256,7 +258,7 @@ def run_opt(
                     if fn_hook:
                         fn_hook(dyn)
         except Exception as exception:
-            terminate(tmpdir,exception)
+            terminate(tmpdir, exception)
 
     # Store the trajectory atoms
     dyn.traj_atoms = read(traj_file, index=":")
@@ -308,7 +310,7 @@ def run_vib(
     try:
         vib.run()
     except Exception as exception:
-        terminate(tmpdir,exception)
+        terminate(tmpdir, exception)
 
     # Summarize run
     vib.summary(log=sys.stdout if SETTINGS.DEBUG else str(tmpdir / "vib_summary.log"))

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -69,9 +69,8 @@ def calc_setup(
 
     # Create a symlink to the tmpdir
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
-        symlink = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
-        symlink.unlink(missing_ok=True)
-        symlink.symlink_to(tmpdir, target_is_directory=True)
+        symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
+        symlink_path.symlink_to(tmpdir, target_is_directory=True)
 
     # Copy files to tmpdir and decompress them if needed
     if copy_files:
@@ -141,7 +140,23 @@ def calc_cleanup(
 
     logger.info(f"Calculation results stored at {job_results_dir}")
 
-def terminate(tmpdir: Path | str, exception: Exception)->RuntimeError:
+
+def terminate(tmpdir: Path | str, exception: Exception) -> RuntimeError:
+    """
+    Terminate a calculation and move files to a failed directory.
+
+    Parameters
+    ----------
+    tmpdir
+        The path to the tmpdir, where the calculation was run.
+    exception
+        The exception that caused the calculation to fail.
+
+    Returns
+    -------
+    RuntimeError
+        An exception with a message about the failed calculation.
+    """
     job_failed_dir = Path(str(tmpdir).replace("tmp-", "failed-"))
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
     logging.info(msg)
@@ -152,7 +167,7 @@ def terminate(tmpdir: Path | str, exception: Exception)->RuntimeError:
 
     # Remove symlink to tmpdir
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
-        symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
-        symlink_path.unlink(missing_ok=True)
+        symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{job_failed_dir.name}"
+        symlink_path.symlink_to(job_failed_dir, target_is_directory=True)
 
     raise RuntimeError(msg) from exception

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -150,7 +150,7 @@ def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
     Exception
         The exception that caused the calculation to fail.
     """
-    job_failed_dir = Path(str(tmpdir).replace("tmp-", "failed-"))
+    job_failed_dir = tmpdir.with_name(tmpdir.name.replace("tmp-", "failed-"))
     tmpdir.rename(job_failed_dir)
 
     msg = f"Calculation failed! Files stored at {job_failed_dir}"

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -157,18 +157,16 @@ def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
         The exception that caused the calculation to fail.
     """
     job_failed_dir = Path(str(tmpdir).replace("tmp-", "failed-"))
-    job_failed_dir.mkdir(parents=True)
-
-    # Move files from tmpdir to job_failed_dir
-    for file_name in os.listdir(tmpdir):
-        move(tmpdir / file_name, job_failed_dir / file_name)
+    os.rename(tmpdir, job_failed_dir)
 
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
     logging.info(msg)
 
     # Remove symlink to tmpdir
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
+        old_symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
         symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{job_failed_dir.name}"
+        old_symlink_path.unlink(missing_ok=True)
         symlink_path.symlink_to(job_failed_dir, target_is_directory=True)
 
     raise exception

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -126,19 +126,13 @@ def calc_cleanup(
         gzip_dir(tmpdir)
 
     # Move files from tmpdir to job_results_dir
-    for file_name in os.listdir(tmpdir):
-        move(tmpdir / file_name, job_results_dir / file_name)
+    os.rename(tmpdir, job_results_dir)
+    logger.info(f"Calculation results stored at {job_results_dir}")
 
     # Remove symlink to tmpdir
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
         symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
         symlink_path.unlink(missing_ok=True)
-
-    # Remove the tmpdir
-    rmtree(tmpdir, ignore_errors=True)
-
-    logger.info(f"Calculation results stored at {job_results_dir}")
-
 
 def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
     """

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -125,7 +125,7 @@ def calc_cleanup(
         gzip_dir(tmpdir)
 
     # Move files from tmpdir to job_results_dir
-    os.rename(tmpdir, job_results_dir)
+    tmpdir.rename(job_results_dir)
     logger.info(f"Calculation results stored at {job_results_dir}")
 
     # Remove symlink to tmpdir
@@ -151,7 +151,7 @@ def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
         The exception that caused the calculation to fail.
     """
     job_failed_dir = Path(str(tmpdir).replace("tmp-", "failed-"))
-    os.rename(tmpdir, job_failed_dir)
+    tmpdir.rename(job_failed_dir)
 
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
     logging.info(msg)

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from shutil import move, rmtree
 from typing import TYPE_CHECKING
 
 from monty.shutil import gzip_dir
@@ -133,6 +132,7 @@ def calc_cleanup(
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
         symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
         symlink_path.unlink(missing_ok=True)
+
 
 def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
     """

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from shutil import move
+from shutil import move, rmtree
 from typing import TYPE_CHECKING
 
 from monty.shutil import gzip_dir
@@ -127,6 +127,7 @@ def calc_cleanup(
     else:
         for file_name in os.listdir(tmpdir):
             move(tmpdir / file_name, job_results_dir / file_name)
+        rmtree(tmpdir)
     logger.info(f"Calculation results stored at {job_results_dir}")
 
     # Remove symlink to tmpdir
@@ -157,7 +158,6 @@ def terminate(tmpdir: Path | str, exception: Exception) -> Exception:
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
     logging.info(msg)
 
-    # Remove symlink to tmpdir
     if os.name != "nt" and SETTINGS.SCRATCH_DIR:
         old_symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{tmpdir.name}"
         symlink_path = SETTINGS.RESULTS_DIR / f"symlink-{job_failed_dir.name}"

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -172,13 +172,12 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
     atoms = bulk("Cu")
     with (
         caplog.at_level(logging.INFO),
-        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
+        change_settings({"SCRATCH_DIR": tmp_path / "scratch", "RESULTS_DIR"}),
     ):
         with pytest.raises(RuntimeError, match="failed with command"):
             static_job(atoms)
         assert "Calculation failed" in caplog.text
         assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "results"))
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlinking not possible on Windows")
@@ -193,4 +192,3 @@ def test_child_errors2(tmp_path, monkeypatch, caplog):
             relax_job(atoms)
         assert "Calculation failed" in caplog.text
         assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "results"))

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -13,6 +13,7 @@ import os
 import numpy as np
 from ase.build import bulk, molecule
 
+from quacc import change_settings
 from quacc.recipes.dftb.core import relax_job, static_job
 
 LOGGER = logging.getLogger(__name__)
@@ -165,20 +166,25 @@ def test_relax_job_cu_supercell_errors(tmp_path, monkeypatch):
         relax_job(atoms, kpts=(3, 3, 3), MaxSteps=1, Hamiltonian_MaxSccIterations=100)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlinking not possible on Windows")
 def test_child_errors(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INFO), change_settings({"SCRATCH_DIR": tmp_path/"scratch"}):
         with pytest.raises(RuntimeError, match="failed with command"):
             static_job(atoms)
         assert "Calculation failed" in caplog.text
-        assert "quacc-failed" in " ".join(os.listdir(tmp_path))
+        assert "quacc-failed" in " ".join(os.listdir( tmp_path/"scratch"))
+        assert "symlink-quacc-failed" in " ".join(os.listdir( tmp_path/"scratch"))
 
+
+@pytest.mark.skipif(os.name == "nt", reason="symlinking not possible on Windows")
 def test_child_errors2(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INFO), change_settings({"SCRATCH_DIR": tmp_path/"scratch"}):
         with pytest.raises(RuntimeError, match="failed with command"):
             relax_job(atoms)
         assert "Calculation failed" in caplog.text
-        assert "quacc-failed" in " ".join(os.listdir(tmp_path))
+        assert "quacc-failed" in " ".join(os.listdir( tmp_path/"scratch"))
+        assert "symlink-quacc-failed" in " ".join(os.listdir( tmp_path/"scratch"))

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -178,7 +178,7 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
             static_job(atoms)
         assert "Calculation failed" in caplog.text
         assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
+        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "results"))
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlinking not possible on Windows")
@@ -193,4 +193,4 @@ def test_child_errors2(tmp_path, monkeypatch, caplog):
             relax_job(atoms)
         assert "Calculation failed" in caplog.text
         assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
+        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "results"))

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -170,21 +170,27 @@ def test_relax_job_cu_supercell_errors(tmp_path, monkeypatch):
 def test_child_errors(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with caplog.at_level(logging.INFO), change_settings({"SCRATCH_DIR": tmp_path/"scratch"}):
+    with (
+        caplog.at_level(logging.INFO),
+        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
+    ):
         with pytest.raises(RuntimeError, match="failed with command"):
             static_job(atoms)
         assert "Calculation failed" in caplog.text
-        assert "failed-quacc-" in " ".join(os.listdir( tmp_path/"scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir( tmp_path/"scratch"))
+        assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
+        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlinking not possible on Windows")
 def test_child_errors2(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with caplog.at_level(logging.INFO), change_settings({"SCRATCH_DIR": tmp_path/"scratch"}):
+    with (
+        caplog.at_level(logging.INFO),
+        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
+    ):
         with pytest.raises(RuntimeError, match="failed with command"):
             relax_job(atoms)
         assert "Calculation failed" in caplog.text
-        assert "failed-quacc-" in " ".join(os.listdir( tmp_path/"scratch"))
-        assert "symlink-failed-quacc-" in " ".join(os.listdir( tmp_path/"scratch"))
+        assert "failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))
+        assert "symlink-failed-quacc-" in " ".join(os.listdir(tmp_path / "scratch"))

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -8,6 +8,7 @@ DFTBPLUS_EXISTS = bool(which("dftb+"))
 
 pytestmark = pytest.mark.skipif(not DFTBPLUS_EXISTS, reason="Needs DFTB+")
 import logging
+import os
 
 import numpy as np
 from ase.build import bulk, molecule
@@ -171,8 +172,13 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
         with pytest.raises(RuntimeError, match="failed with command"):
             static_job(atoms)
         assert "Calculation failed" in caplog.text
+        assert "quacc-failed" in " ".join(os.listdir(tmp_path))
 
+def test_child_errors2(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    atoms = bulk("Cu")
     with caplog.at_level(logging.INFO):
         with pytest.raises(RuntimeError, match="failed with command"):
             relax_job(atoms)
         assert "Calculation failed" in caplog.text
+        assert "quacc-failed" in " ".join(os.listdir(tmp_path))

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -172,7 +172,7 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
     atoms = bulk("Cu")
     with (
         caplog.at_level(logging.INFO),
-        change_settings({"SCRATCH_DIR": tmp_path / "scratch", "RESULTS_DIR"}),
+        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
     ):
         with pytest.raises(RuntimeError, match="failed with command"):
             static_job(atoms)

--- a/tests/core/runners/test_prep.py
+++ b/tests/core/runners/test_prep.py
@@ -8,7 +8,7 @@ from ase.build import bulk
 from ase.calculators.emt import EMT
 
 from quacc import change_settings
-from quacc.runners.prep import calc_cleanup, calc_setup
+from quacc.runners.prep import calc_cleanup, calc_setup, terminate
 
 
 def make_files():
@@ -176,3 +176,12 @@ def test_calc_cleanup(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         calc_cleanup(atoms, "quacc", SETTINGS.RESULTS_DIR)
+
+
+def test_terminate(tmp_path):
+    p = tmp_path / "tmp-quacc-1234"
+    os.mkdir(p)
+    with pytest.raises(ValueError, match="moo"):
+        terminate(p, ValueError("moo"))
+    assert not p.exists()
+    assert Path(tmp_path, "failed-quacc-1234").exists()

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -28,9 +28,9 @@ def test_file(tmp_path, monkeypatch):
 
 def test_store(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    SETTINGS.STORE = MemoryStore()
-    atoms = bulk("Cu")
-    static_job(atoms)
+    with change_settings({"STORE": MemoryStore()}):
+        atoms = bulk("Cu")
+        static_job(atoms)
 
 
 def test_results_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary of Changes

Closes #2016 by storing failed calculations in a renamed `failed-quacc-...` directory. The only user-facing change here is the `tmp-quacc-12345` becomes `failed-quacc-12345` upon failure.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
