### PR TITLE
Update fmax in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Failed calculations are now stored in a `failed-quacc-12345-` directory to distinguish these tasks from the running tasks in `tmp-quacc-12345-`
 - The output schema is now written to a serialized JSON file instead of pickle for security and ease-of-use reasons. It can be rehydrated via `loadfn("quacc_results.json.gz")` where `loadfn` is from `monty.serialization import loadfn`
+- The `fmax` attribute was move from the base level to the `parameters_opt` section since it is an input parameter
 
 ### Fixed
 

--- a/src/quacc/schemas/_aliases/ase.py
+++ b/src/quacc/schemas/_aliases/ase.py
@@ -20,8 +20,8 @@ class Parameters(TypedDict):
 
 
 class ParametersOpt(TypedDict):
-    """Dictionary of parameters from Optimizer.todict()"""
-
+    """Dictionary of parameters from Optimizer.todict() and fmax"""
+    fmax: float | None
 
 class RunSchema(AtomsSchema):
     """Schema for [quacc.schemas.ase.summarize_run][]"""

--- a/src/quacc/schemas/_aliases/ase.py
+++ b/src/quacc/schemas/_aliases/ase.py
@@ -21,7 +21,9 @@ class Parameters(TypedDict):
 
 class ParametersOpt(TypedDict):
     """Dictionary of parameters from Optimizer.todict() and fmax"""
+
     fmax: float | None
+
 
 class RunSchema(AtomsSchema):
     """Schema for [quacc.schemas.ase.summarize_run][]"""

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -193,12 +193,11 @@ def summarize_opt_run(
     )
 
     # Clean up the opt parameters
-    parameters_opt = dyn.todict()
+    parameters_opt = dyn.todict() | {"fmax": getattr(dyn, "fmax", None)}
     parameters_opt.pop("logfile", None)
     parameters_opt.pop("restart", None)
 
     opt_fields = {
-        "fmax": getattr(dyn, "fmax", None),
         "parameters_opt": parameters_opt,
         "converged": is_converged,
         "nsteps": dyn.get_number_of_steps(),

--- a/tests/core/recipes/orca_recipes/test_orca_recipes.py
+++ b/tests/core/recipes/orca_recipes/test_orca_recipes.py
@@ -133,7 +133,7 @@ def test_ase_relax_job(tmp_path, monkeypatch):
         output["parameters"]["orcasimpleinput"]
         == "def2-tzvp engrad normalprint wb97x-d3bj xyzfile"
     )
-    assert output["fmax"] == 0.1
+    assert output["parameters_opt"]["fmax"] == 0.1
     assert output.get("trajectory")
     assert output.get("trajectory_results")
     assert output.get("attributes")

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -173,7 +173,7 @@ def test_ase_relax_job(patch_metallic_taskdoc):
     assert output["parameters"]["lwave"] is False
     assert output["parameters"]["lcharg"] is False
     assert output["parameters"]["encut"] == 520
-    assert output["fmax"] == 0.01
+    assert output["parameters_opt"]["fmax"] == 0.01
     assert len(output["trajectory_results"]) > 1
 
 
@@ -186,7 +186,7 @@ def test_ase_relax_job2(patch_metallic_taskdoc):
     assert output["parameters"]["lwave"] is False
     assert output["parameters"]["lcharg"] is False
     assert output["parameters"]["encut"] == 520
-    assert output["fmax"] == 0.01
+    assert output["parameters_opt"]["fmax"] == 0.01
     assert len(output["trajectory_results"]) > 1
     assert len(output["steps"]) == len(output["trajectory_results"])
 

--- a/tests/core/schemas/test_ase.py
+++ b/tests/core/schemas/test_ase.py
@@ -131,7 +131,7 @@ def test_summarize_opt_run(tmp_path, monkeypatch):
     assert "nid" in results
     assert "dir_name" in results
     assert "pymatgen_version" in results["builder_meta"]
-    assert results["fmax"] == dyn.fmax
+    assert results["parameters_opt"]["fmax"] == dyn.fmax
     assert results["parameters_opt"]["max_steps"] == 100
 
     json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))

--- a/tests/covalent/test_emt_recipes.py
+++ b/tests/covalent/test_emt_recipes.py
@@ -25,7 +25,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     assert output.status == "COMPLETED"
     assert len(output.result) == 4
     assert "atoms" in output.result[-1]
-    assert output.result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
+    assert output.result[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/covalent/test_emt_recipes.py
+++ b/tests/covalent/test_emt_recipes.py
@@ -25,7 +25,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     assert output.status == "COMPLETED"
     assert len(output.result) == 4
     assert "atoms" in output.result[-1]
-    assert output.result[-1]["fmax"] == 0.1
+    assert output.result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/dask/test_emt_recipes.py
+++ b/tests/dask/test_emt_recipes.py
@@ -28,7 +28,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     result = client.compute(delayed).result()
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/dask/test_emt_recipes.py
+++ b/tests/dask/test_emt_recipes.py
@@ -28,7 +28,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     result = client.compute(delayed).result()
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/parsl/test_emt_recipes.py
+++ b/tests/parsl/test_emt_recipes.py
@@ -24,7 +24,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     ).result()
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
 
 
 # def test_copy_files(tmp_path, monkeypatch):

--- a/tests/parsl/test_emt_recipes.py
+++ b/tests/parsl/test_emt_recipes.py
@@ -24,7 +24,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     ).result()
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 # def test_copy_files(tmp_path, monkeypatch):

--- a/tests/prefect/test_emt_recipes.py
+++ b/tests/prefect/test_emt_recipes.py
@@ -24,7 +24,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     result = [future.result() for future in output]
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/prefect/test_emt_recipes.py
+++ b/tests/prefect/test_emt_recipes.py
@@ -24,7 +24,7 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
     result = [future.result() for future in output]
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):

--- a/tests/redun/test_emt_recipes.py
+++ b/tests/redun/test_emt_recipes.py
@@ -30,7 +30,7 @@ def test_functools(tmp_path, monkeypatch, scheduler, job_decorators):
     )
     assert len(result) == 4
     assert "atoms" in result[-1]
-    assert result[-1]["fmax"] == 0.1
+    assert result[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch, scheduler):


### PR DESCRIPTION
## Summary of Changes

Put `fmax` in `parameters_opt` within the schema instead of the base level. Closes #1970.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
