### PR TITLE
Use `Structure.from_ase_atoms()` shorthand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "psutil", # for getting compute architecture details
     "pydantic>=2.0.1", # for settings management
     "pydantic-settings>=2.2.0", # for settings management
-    "pymatgen>=2024.4.13", # for structure manipulation
+    "pymatgen>2024.5.1", # for structure manipulation
     "ruamel.yaml>=0.17.40", # for YAML
     "typer>=0.12.1", # for the CLI
 ]

--- a/src/quacc/atoms/defects.py
+++ b/src/quacc/atoms/defects.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 from monty.dev import requires
 from pymatgen.core.periodic_table import DummySpecies
+from pymatgen.core.structure import Structure
 from pymatgen.entries.computed_entries import ComputedStructureEntry
-from pymatgen.io.ase import AseAtomsAdaptor
 
 try:
     from pymatgen.analysis.defects.generators import VacancyGenerator
@@ -20,7 +20,6 @@ except ImportError:
 if TYPE_CHECKING:
     from ase.atoms import Atoms
     from numpy.typing import NDArray
-    from pymatgen.core.structure import Structure
 
     if has_deps:
         from pymatgen.analysis.defects.core import Defect
@@ -86,7 +85,7 @@ def make_defects_from_bulk(
         All generated defects
     """
     # Use pymatgen-analysis-defects and ShakeNBreak to generate defects
-    struct = AseAtomsAdaptor.get_structure(atoms)
+    struct = Structure.from_ase_atoms(atoms)
 
     # Make all the defects
     defects = defect_gen().get_defects(struct, **defect_gen_kwargs)

--- a/src/quacc/atoms/deformation.py
+++ b/src/quacc/atoms/deformation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pymatgen.analysis.elasticity.strain import DeformedStructureSet
-from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core import Structure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -38,7 +38,7 @@ def make_deformations_from_bulk(
     list[Atoms]
         All generated deformed structures
     """
-    struct = AseAtomsAdaptor.get_structure(atoms)
+    struct = Structure.from_ase_atoms(atoms)
 
     deformed_set = DeformedStructureSet(
         struct,

--- a/src/quacc/atoms/phonons.py
+++ b/src/quacc/atoms/phonons.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
-from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core import Structure
 from pymatgen.io.phonopy import get_phonopy_structure, get_pmg_structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
@@ -61,7 +61,7 @@ def get_phonopy(
     phonopy_kwargs = phonopy_kwargs or {}
 
     symmetrized_structure = SpacegroupAnalyzer(
-        AseAtomsAdaptor().get_structure(atoms), symprec=symprec
+        Structure.from_ase_atoms(atoms), symprec=symprec
     ).get_symmetrized_structure()
 
     if supercell_matrix is None and min_lengths is not None:

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from ase.calculators.vasp import Vasp as Vasp_
 from monty.dev import requires
-from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core import Structure
 
 from quacc.atoms.core import check_is_metal
 from quacc.utils.kpts import convert_pmg_kpts
@@ -402,7 +402,7 @@ class MPtoASEConverter:
             raise ValueError("Either atoms or prev_dir must be provided.")
         self.atoms = atoms
         self.prev_dir = prev_dir
-        self.structure = AseAtomsAdaptor.get_structure(atoms)
+        self.structure = Structure.from_ase_atoms(atoms)
 
     def convert_dict_set(self, dict_set: DictSet) -> dict:
         """

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ase.dft.kpoints import bandpath
-from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from quacc import flow, job
@@ -101,7 +101,7 @@ def bands_pw_job(
         "input_data": {"control": {"calculation": "bands", "verbosity": "high"}}
     }
     if make_bandpath:
-        structure = AseAtomsAdaptor.get_structure(atoms)
+        structure = Structure.from_ase_atoms(atoms)
         primitive = SpacegroupAnalyzer(structure).get_primitive_standard_structure()
         atoms = primitive.to_ase_atoms()
         calc_defaults["kpts"] = bandpath(

--- a/src/quacc/utils/kpts.py
+++ b/src/quacc/utils/kpts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core import Structure
 from pymatgen.io.vasp.inputs import Kpoints
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 
@@ -67,7 +67,7 @@ def convert_pmg_kpts(
     gamma
         Whether the k-points are gamma-centered.
     """
-    struct = AseAtomsAdaptor.get_structure(input_atoms)
+    struct = Structure.from_ase_atoms(input_atoms)
 
     if pmg_kpts.get("line_density"):
         kpath = HighSymmKpath(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,6 +8,6 @@ numpy==1.26.4
 psutil==5.9.8
 pydantic==2.7.1
 pydantic-settings==2.2.1
-pymatgen==2024.5.1
+pymatgen @ https://github.com/materialsproject/pymatgen.git
 ruamel.yaml==0.18.6
 typer==0.12.3


### PR DESCRIPTION
## Summary of Changes

Closes #2122 by using the new `Structure.from_ase_atoms()` shorthand.

### Checklist

- [ ] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [ ] My PR is on a custom branch and is _not_ named `main`.
- [ ] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
