### PR TITLE
Remove restriction on absolute paths for RESULTS and SCRATCH directories

### DIFF
--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -431,8 +431,8 @@ class QuaccSettings(BaseSettings):
     @classmethod
     def make_directories(cls, v: Optional[Path]) -> Optional[Path]:
         """Make directories."""
-        if v and not v.exists():
-            v.mkdir(parents=True)
+        if v:
+            v.mkdir(exist_ok=True, parents=True)
         return v
 
     @field_validator("STORE")

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -65,7 +65,7 @@ class QuaccSettings(BaseSettings):
     # ---------------------------
 
     RESULTS_DIR: Path = Field(
-        Path.cwd(),
+        Path(),
         description=(
             """
             Directory to permanently store I/O-based calculation results in.
@@ -432,8 +432,6 @@ class QuaccSettings(BaseSettings):
     def make_directories(cls, v: Optional[Path]) -> Optional[Path]:
         """Make directories."""
         if v:
-            if not v.is_absolute():
-                raise ValueError(f"{v} must be an absolute path.")
             if not v.exists():
                 v.mkdir(parents=True)
         return v

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -431,9 +431,8 @@ class QuaccSettings(BaseSettings):
     @classmethod
     def make_directories(cls, v: Optional[Path]) -> Optional[Path]:
         """Make directories."""
-        if v:
-            if not v.exists():
-                v.mkdir(parents=True)
+        if v and not v.exists():
+            v.mkdir(parents=True)
         return v
 
     @field_validator("STORE")

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import pytest
 from ase.build import bulk
 from maggma.stores import MemoryStore
 
-from quacc import SETTINGS, change_settings
+from quacc import change_settings
 from quacc.recipes.emt.core import relax_job, static_job
 from quacc.settings import QuaccSettings
 

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -45,13 +45,6 @@ def test_results_dir(tmp_path, monkeypatch):
         assert "opt.traj" in os.listdir(output["dir_name"])
 
 
-def test_bad_dir():
-    with pytest.raises(ValueError, match="must be an absolute path"):
-        SETTINGS.RESULTS_DIR = "bad_dir"
-    with pytest.raises(ValueError, match="must be an absolute path"):
-        SETTINGS.SCRATCH_DIR = "bad_dir"
-
-
 def test_env_var(monkeypatch, tmp_path):
     p = tmp_path / "my/scratch/dir"
     monkeypatch.setenv("QUACC_SCRATCH_DIR", p)


### PR DESCRIPTION
## Summary of Changes

As the title states. There is no need for absolute paths anymore if we don't have `chdir` calls.

### Checklist

- [X] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [X] My PR is on a custom branch and is _not_ named `main`.
- [X] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
