### PR TITLE
Implement `change_settings_wf`, basically change_settings when using a workflow management

### DIFF
--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import version
 from ase.atoms import Atoms
 from pymatgen.io.ase import MSONAtoms
 
-from quacc.settings import QuaccSettings, change_settings
+from quacc.settings import QuaccSettings, change_settings, change_settings_wf
 from quacc.utils.dicts import Remove
 from quacc.wflow_tools.customizers import redecorate, strip_decorator
 from quacc.wflow_tools.decorators import Flow, Job, Subflow, flow, job, subflow

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -552,3 +552,11 @@ def change_settings(changes: dict[str, Any]) -> QuaccSettings:  # type: ignore
     finally:
         for attr, original_value in original_values.items():
             setattr(SETTINGS, attr, original_value)
+
+def change_settings_wf(func: Callable, changes: Dict, decorator: Callable) -> Callable:
+    from quacc import change_settings, strip_decorator
+    def concatenated(*args, **kwargs):
+        with change_settings(changes):
+            return strip_decorator(func)(*args, **kwargs)
+    
+    return decorator(concatenated)

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -554,6 +554,24 @@ def change_settings(changes: dict[str, Any]) -> QuaccSettings:  # type: ignore
             setattr(SETTINGS, attr, original_value)
 
 def change_settings_wf(func: Callable, changes: Dict, decorator: Callable) -> Callable:
+    """
+    Temporarily change an attribute of an unwrapped object, and return the redecorated object.
+    This is suitable when using workflow management.
+
+    Parameters
+    ----------
+    func
+        The function to update
+    changes
+        Dictionary of changes to make formatted as attribute: value.
+    decorator
+        The decorator associated with `func`.
+
+    Returns
+    -------
+    Callable
+        The updated function.
+    """
     from quacc import change_settings, strip_decorator
     def concatenated(*args, **kwargs):
         with change_settings(changes):

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -553,6 +553,7 @@ def change_settings(changes: dict[str, Any]) -> QuaccSettings:  # type: ignore
         for attr, original_value in original_values.items():
             setattr(SETTINGS, attr, original_value)
 
+
 def change_settings_wf(func: Callable, changes: Dict, decorator: Callable) -> Callable:
     """
     Temporarily change an attribute of an unwrapped object, and return the redecorated object.
@@ -573,8 +574,9 @@ def change_settings_wf(func: Callable, changes: Dict, decorator: Callable) -> Ca
         The updated function.
     """
     from quacc import change_settings, strip_decorator
+
     def concatenated(*args, **kwargs):
         with change_settings(changes):
             return strip_decorator(func)(*args, **kwargs)
-    
+
     return decorator(concatenated)

--- a/tests/parsl/test_syntax.py
+++ b/tests/parsl/test_syntax.py
@@ -4,9 +4,11 @@ import pytest
 
 parsl = pytest.importorskip("parsl")
 
-from quacc import flow, job, subflow, strip_decorator, change_settings_wf, SETTINGS
+import os
 from pathlib import Path
-import os, time
+
+from quacc import SETTINGS, change_settings_wf, flow, job, strip_decorator, subflow
+
 
 def test_parsl_decorators(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -135,9 +137,10 @@ def test_special_params(tmpdir, monkeypatch):
     assert add(1, 2).result() == 3
     assert add2(1, 2).result() == [4, 6, 8, 10, 12, 14]
 
+
 def test_change_settings_wf(tmp_path_factory):
     @job
-    def write_file(name='job'):
+    def write_file(name="job"):
         with open(Path(f"{SETTINGS.RESULTS_DIR}/{name}.txt"), "w") as f:
             f.write("test file")
 
@@ -148,20 +151,22 @@ def test_change_settings_wf(tmp_path_factory):
 
     @subflow
     def write_file3():
-        return [write_file(name='subflow')]
-    
+        return [write_file(name="subflow")]
+
     tmp_dir = tmp_path_factory.mktemp("dir1")
     tmp_dir2 = tmp_path_factory.mktemp("dir2")
     tmp_dir3 = tmp_path_factory.mktemp("dir3")
 
     write_file_new = change_settings_wf(write_file, {"RESULTS_DIR": tmp_dir}, job)
     write_file2_new = change_settings_wf(write_file2, {"RESULTS_DIR": tmp_dir2}, flow)
-    write_file3_new = change_settings_wf(write_file3, {"RESULTS_DIR": tmp_dir3}, subflow)
+    write_file3_new = change_settings_wf(
+        write_file3, {"RESULTS_DIR": tmp_dir3}, subflow
+    )
 
     write_file_new().result()
     write_file2_new()
     write_file3_new().result()
 
-    assert os.path.exists(tmp_dir/"job.txt")
-    assert os.path.exists(tmp_dir2/"flow.txt")
-    assert os.path.exists(tmp_dir3/"subflow.txt")
+    assert os.path.exists(tmp_dir / "job.txt")
+    assert os.path.exists(tmp_dir2 / "flow.txt")
+    assert os.path.exists(tmp_dir3 / "subflow.txt")

--- a/tests/parsl/test_syntax.py
+++ b/tests/parsl/test_syntax.py
@@ -4,8 +4,9 @@ import pytest
 
 parsl = pytest.importorskip("parsl")
 
-from quacc import flow, job, strip_decorator, subflow
-
+from quacc import flow, job, subflow, strip_decorator, change_settings_wf, SETTINGS
+from pathlib import Path
+import os, time
 
 def test_parsl_decorators(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -133,3 +134,34 @@ def test_special_params(tmpdir, monkeypatch):
 
     assert add(1, 2).result() == 3
     assert add2(1, 2).result() == [4, 6, 8, 10, 12, 14]
+
+def test_change_settings_wf(tmp_path_factory):
+    @job
+    def write_file(name='job'):
+        with open(Path(f"{SETTINGS.RESULTS_DIR}/{name}.txt"), "w") as f:
+            f.write("test file")
+
+    @flow
+    def write_file2():
+        with open(Path(f"{SETTINGS.RESULTS_DIR}/flow.txt"), "w") as f:
+            f.write("test file")
+
+    @subflow
+    def write_file3():
+        return [write_file(name='subflow')]
+    
+    tmp_dir = tmp_path_factory.mktemp("dir1")
+    tmp_dir2 = tmp_path_factory.mktemp("dir2")
+    tmp_dir3 = tmp_path_factory.mktemp("dir3")
+
+    write_file_new = change_settings_wf(write_file, {"RESULTS_DIR": tmp_dir}, job)
+    write_file2_new = change_settings_wf(write_file2, {"RESULTS_DIR": tmp_dir2}, flow)
+    write_file3_new = change_settings_wf(write_file3, {"RESULTS_DIR": tmp_dir3}, subflow)
+
+    write_file_new().result()
+    write_file2_new()
+    write_file3_new().result()
+
+    assert os.path.exists(tmp_dir/"job.txt")
+    assert os.path.exists(tmp_dir2/"flow.txt")
+    assert os.path.exists(tmp_dir3/"subflow.txt")


### PR DESCRIPTION
## Summary of Changes

\>> Describe your changes here. Make sure to reference any associated issues. <<

Refer to #2147, a new function named `change_settings_wf` is implemented to change settings when using a workflow management.

### Checklist

- [x] I have read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines) of the contributing guide. Don't lie! 😉
- [x] My PR is on a custom branch and is _not_ named `main`.
- [x] I have added relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).

### Notes

- Your PR will likely not be merged without proper and thorough tests.
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
