### PR TITLE
Update `Optimizer.todict()` call in ASE opt schema

### DIFF
--- a/src/quacc/schemas/_aliases/ase.py
+++ b/src/quacc/schemas/_aliases/ase.py
@@ -20,9 +20,7 @@ class Parameters(TypedDict):
 
 
 class ParametersOpt(TypedDict):
-    """Dictionary of parameters from Optimizer.todict() and fmax"""
-
-    fmax: float | None
+    """Dictionary of parameters from Optimizer.todict()"""
 
 
 class RunSchema(AtomsSchema):

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -193,14 +193,13 @@ def summarize_opt_run(
     )
 
     # Clean up the opt parameters
-    parameters_opt = dyn.todict() | {"fmax": getattr(dyn, "fmax", None)}
+    parameters_opt = dyn.todict()
     parameters_opt.pop("logfile", None)
     parameters_opt.pop("restart", None)
 
     opt_fields = {
         "parameters_opt": parameters_opt,
         "converged": is_converged,
-        "nsteps": dyn.get_number_of_steps(),
         "trajectory": trajectory,
         "trajectory_results": [atoms.calc.results for atoms in trajectory],
     }


### PR DESCRIPTION
This mainly updates a schema to reflect changes in https://gitlab.com/ase/ase/-/merge_requests/3360. The only user-facing change is that `nsteps` is moved slightly.