### PR TITLE
Support in run_calcs for models that implement arbitrary properties, and support for MLPs that don't have forces

### DIFF
--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -21,7 +21,10 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms, method: Literal["mace-mp-0", "m3gnet", "chgnet"], **calc_kwargs
+    atoms: Atoms,
+    method: Literal["mace-mp-0", "m3gnet", "chgnet"],
+    properties: list[str] | None = None,
+    **calc_kwargs,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -32,6 +35,8 @@ def static_job(
         Atoms object
     method
         Universal ML interatomic potential method to use
+    properties
+        A list of properties to obtain. Defaults to energy/forces
     **calc_kwargs
         Custom kwargs for the underlying calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -45,7 +50,9 @@ def static_job(
         See the type-hint for the data structure.
     """
     atoms.calc = pick_calculator(method, **calc_kwargs)
-    final_atoms = run_calc(atoms, get_forces=True)
+    if properties is None:
+        properties = ["energy", "forces"]
+    final_atoms = run_calc(atoms, properties=properties)
     return summarize_run(
         final_atoms, atoms, additional_fields={"name": f"{method} Static"}
     )

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -36,7 +36,7 @@ def static_job(
     method
         Universal ML interatomic potential method to use
     properties
-        A list of properties to obtain. Defaults to energy/forces
+        A list of properties to obtain. Defaults to ["energy", "forces"]
     **calc_kwargs
         Custom kwargs for the underlying calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -8,13 +8,13 @@ from shutil import copy, copytree
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
+from ase.calculators import calculator
 from ase.filters import FrechetCellFilter
 from ase.io import Trajectory, read
 from ase.optimize import BFGS
 from ase.vibrations import Vibrations
 from monty.dev import requires
 from monty.os.path import zpath
-from ase.calculators import calculator
 
 from quacc import SETTINGS
 from quacc.atoms.core import copy_atoms, get_final_atoms_from_dynamics

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -90,8 +90,8 @@ def run_calc(
         varies between codes.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
-    get_forces
-        Whether to use `atoms.get_forces()` instead of `atoms.get_potential_energy()`.
+    properties
+        List of properties to calculate. Defaults to ["energy"] if `None`.
 
     Returns
     -------

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -14,6 +14,7 @@ from ase.optimize import BFGS
 from ase.vibrations import Vibrations
 from monty.dev import requires
 from monty.os.path import zpath
+from ase.calculators import calculator
 
 from quacc import SETTINGS
 from quacc.atoms.core import copy_atoms, get_final_atoms_from_dynamics
@@ -67,7 +68,7 @@ def run_calc(
     atoms: Atoms,
     geom_file: str | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
-    get_forces: bool = False,
+    properties: list[str] | None = None,
 ) -> Atoms:
     """
     Run a calculation in a scratch directory and copy the results back to the original
@@ -104,11 +105,11 @@ def run_calc(
     tmpdir, job_results_dir = calc_setup(atoms, copy_files=copy_files)
 
     # Run calculation
+    if properties is None:
+        properties = ["energy"]
+
     try:
-        if get_forces:
-            atoms.get_forces()
-        else:
-            atoms.get_potential_energy()
+        atoms.calc.calculate(atoms, properties, calculator.all_changes)
     except Exception as exception:
         terminate(tmpdir, exception)
 


### PR DESCRIPTION
## Summary of Changes

Small change to `run_calc` so that arbitrary properties can be requested (including but not limited to energy/forces), and small change to the mlp.core.static_job so that forces are not already required for those calculators. This is also useful for ML models that predict properties beyond energy/forces. 

Currently, if a MLP calculator does not implement forces, mlp.core.static_job will throw a PropertyNotImplemented error. 