### PR TITLE
Fix a small typo in elastic

### DIFF
--- a/src/quacc/atoms/deformation.py
+++ b/src/quacc/atoms/deformation.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def make_deformations_from_bulk(
     atoms: Atoms,
     norm_strains: Sequence[float] = (-0.01, -0.005, 0.005, 0.01),
-    shear_strains: Sequence[float] = (-0.06, -0.03, 0.03, 0.0),
+    shear_strains: Sequence[float] = (-0.06, -0.03, 0.03, 0.06),
     symmetry: bool = False,
 ) -> list[Atoms]:
     """


### PR DESCRIPTION
The default [value](https://github.com/materialsproject/pymatgen/blob/163cc01e0251525f5ab8f48776511411754012a9/pymatgen/analysis/elasticity/strain.py#L110) from pymatgen is `0.06`.