### PR TITLE
Clarify usage of `**calc_kwargs` in docs

### DIFF
--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -360,7 +360,7 @@ atoms = bulk("Cu")
 # Run a structure relaxation on the Atoms object
 result = relax_job(
     atoms,
-    asap_cutoff=True,
+    asap_cutoff=True
 )
 print(result)
 ```
@@ -459,7 +459,7 @@ atoms = bulk("Cu")
 # Run a structure relaxation on the Atoms object
 result = relax_job(
     atoms,
-    opt_params={"fmax": 1e-3, "optimizer": LBFGS},
+    opt_params={"fmax": 1e-3, "optimizer": LBFGS}
 )
 print(result)
 ```

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -358,10 +358,7 @@ from quacc.recipes.emt.core import relax_job
 atoms = bulk("Cu")
 
 # Run a structure relaxation on the Atoms object
-result = relax_job(
-    atoms,
-    asap_cutoff=True
-)
+result = relax_job(atoms, asap_cutoff=True)
 print(result)
 ```
 
@@ -457,10 +454,7 @@ from quacc.recipes.emt.core import relax_job
 atoms = bulk("Cu")
 
 # Run a structure relaxation on the Atoms object
-result = relax_job(
-    atoms,
-    opt_params={"fmax": 1e-3, "optimizer": LBFGS}
-)
+result = relax_job(atoms, opt_params={"fmax": 1e-3, "optimizer": LBFGS})
 print(result)
 ```
 

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -239,6 +239,101 @@ print(result2)
 
 As demonstrated in the previous example, each recipe accepts optional keyword arguments to modify the default parameters. To identify the possible parameters a function takes, you'll want to check out the function signature and corresponding documentation, like that for [quacc.recipes.emt.core.relax_job][]. Go ahead; click it! Once you do, you'll see from the docstring that there is one required positional argument for the recipe (the `Atoms` object) and several optional keyword arguments.
 
+All recipes in quacc allow you to pass in a custom set of keyword arguments to the underlying ASE calculator so that you have full control over the parameters (as specified via `**calc_kwargs` in the function signature). For instance, ASE's [`EMT` calculator](https://wiki.fysik.dtu.dk/ase/ase/calculators/emt.html#ase.calculators.emt.EMT) can take an optional parameter `asap_cutoff`. We show how to pass this parameter to the `relax_job` recipe in the example below.
+
+```python
+from ase.build import bulk
+from quacc.recipes.emt.core import relax_job
+
+# Make an Atoms object of a bulk Cu structure
+atoms = bulk("Cu")
+
+# Run a structure relaxation on the Atoms object
+result = relax_job(atoms, asap_cutoff=True)
+print(result)
+```
+
+??? Info "Printed Output"
+
+    ```
+    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 231408),
+                    'emmet_version': '0.82.0',
+                    'pymatgen_version': '2024.6.10'},
+    'chemsys': 'Cu',
+    'composition': Composition('Cu1'),
+    'composition_reduced': Composition('Cu1'),
+    'converged': True,
+    'density': 8.971719800606017,
+    'density_atomic': 11.761470249999999,
+    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-20-40-132724-86476',
+    'elements': [Element Cu],
+    'formula_anonymous': 'A',
+    'formula_pretty': 'Cu',
+    'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 229796),
+                                    'emmet_version': '0.82.0',
+                                    'pymatgen_version': '2024.6.10'},
+                    'chemsys': 'Cu',
+                    'composition': Composition('Cu1'),
+                    'composition_reduced': Composition('Cu1'),
+                    'density': 8.971719800606017,
+                    'density_atomic': 11.761470249999999,
+                    'elements': [Element Cu],
+                    'formula_anonymous': 'A',
+                    'formula_pretty': 'Cu',
+                    'nelements': 1,
+                    'nsites': 1,
+                    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
+                    'volume': 11.761470249999999},
+    'name': 'EMT Relax',
+    'nelements': 1,
+    'nid': 'rosen.',
+    'nsites': 1,
+    'parameters': {'asap_cutoff': True},
+    'parameters_opt': {'alpha': 70.0,
+                        'max_steps': 1000,
+                        'maxstep': 0.2,
+                        'optimizer': 'BFGS',
+                        'type': 'optimization'},
+    'quacc_version': '0.8.1',
+    'results': {'energies': array([-0.00060116]),
+                'energy': -0.0006011628239370737,
+                'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
+                'free_energy': -0.0006011628239370737,
+                'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
+        0.        ])},
+    'structure': Structure Summary
+    Lattice
+        abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
+    angles : 60.00000000000001 60.00000000000001 60.00000000000001
+    volume : 11.761470249999999
+        A : 0.0 1.805 1.805
+        B : 1.805 0.0 1.805
+        C : 1.805 1.805 0.0
+        pbc : True True True
+    PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
+    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
+    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])],
+    'trajectory_results': [{'energies': array([-0.00060116]),
+                            'energy': -0.0006011628239370737,
+                            'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
+                            'free_energy': -0.0006011628239370737,
+                            'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
+        0.        ])}],
+    'volume': 11.761470249999999}
+    ```
+
 One of these optional keyword arguments for [quacc.recipes.emt.core.relax_job][] is `relax_cell`, which sets whether the cell should be relaxed. By default, this parameter is set to `False`. We will go ahead and set it to `True` in the example below.
 
 ```python
@@ -346,101 +441,6 @@ print(result)
                             'stress': array([-1.58924696e-04, -1.58924696e-04, -1.58924696e-04,  2.30432437e-16,
             7.68108123e-17,  1.89824193e-17])}],
     'volume': 11.563195249785407}
-    ```
-
-All recipes in quacc allow you to pass in a custom set of keyword arguments to the underlying ASE calculator so that you have full control over the parameters (as specified via `**calc_kwargs` in the function signature). For instance, ASE's [`EMT` calculator](https://wiki.fysik.dtu.dk/ase/ase/calculators/emt.html#ase.calculators.emt.EMT) can take an optional parameter `asap_cutoff`. We show how to pass this parameter to the `relax_job` recipe in the example below.
-
-```python
-from ase.build import bulk
-from quacc.recipes.emt.core import relax_job
-
-# Make an Atoms object of a bulk Cu structure
-atoms = bulk("Cu")
-
-# Run a structure relaxation on the Atoms object
-result = relax_job(atoms, asap_cutoff=True)
-print(result)
-```
-
-??? Info "Printed Output"
-
-    ```
-    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 231408),
-                    'emmet_version': '0.82.0',
-                    'pymatgen_version': '2024.6.10'},
-    'chemsys': 'Cu',
-    'composition': Composition('Cu1'),
-    'composition_reduced': Composition('Cu1'),
-    'converged': True,
-    'density': 8.971719800606017,
-    'density_atomic': 11.761470249999999,
-    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-20-40-132724-86476',
-    'elements': [Element Cu],
-    'formula_anonymous': 'A',
-    'formula_pretty': 'Cu',
-    'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 229796),
-                                    'emmet_version': '0.82.0',
-                                    'pymatgen_version': '2024.6.10'},
-                    'chemsys': 'Cu',
-                    'composition': Composition('Cu1'),
-                    'composition_reduced': Composition('Cu1'),
-                    'density': 8.971719800606017,
-                    'density_atomic': 11.761470249999999,
-                    'elements': [Element Cu],
-                    'formula_anonymous': 'A',
-                    'formula_pretty': 'Cu',
-                    'nelements': 1,
-                    'nsites': 1,
-                    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                                'number': 225,
-                                'point_group': 'm-3m',
-                                'symbol': 'Fm-3m',
-                                'symprec': 0.1,
-                                'version': '2.4.0'},
-                    'volume': 11.761470249999999},
-    'name': 'EMT Relax',
-    'nelements': 1,
-    'nid': 'rosen.',
-    'nsites': 1,
-    'parameters': {'asap_cutoff': True},
-    'parameters_opt': {'alpha': 70.0,
-                        'max_steps': 1000,
-                        'maxstep': 0.2,
-                        'optimizer': 'BFGS',
-                        'type': 'optimization'},
-    'quacc_version': '0.8.1',
-    'results': {'energies': array([-0.00060116]),
-                'energy': -0.0006011628239370737,
-                'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
-                'free_energy': -0.0006011628239370737,
-                'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
-        0.        ])},
-    'structure': Structure Summary
-    Lattice
-        abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
-    angles : 60.00000000000001 60.00000000000001 60.00000000000001
-    volume : 11.761470249999999
-        A : 0.0 1.805 1.805
-        B : 1.805 0.0 1.805
-        C : 1.805 1.805 0.0
-        pbc : True True True
-    PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
-    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                'number': 225,
-                'point_group': 'm-3m',
-                'symbol': 'Fm-3m',
-                'symprec': 0.1,
-                'version': '2.4.0'},
-    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])],
-    'trajectory_results': [{'energies': array([-0.00060116]),
-                            'energy': -0.0006011628239370737,
-                            'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
-                            'free_energy': -0.0006011628239370737,
-                            'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
-        0.        ])}],
-    'volume': 11.761470249999999}
     ```
 
 Finally, you will see that [quacc.recipes.emt.core.relax_job][] takes an `opt_params` keyword argument that allows you to pass in a dictionary of parameters to the optimizer. That may look something like the following.

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -249,10 +249,7 @@ from quacc.recipes.emt.core import relax_job
 atoms = bulk("Cu")
 
 # Run a structure relaxation on the Atoms object
-result = relax_job(
-    atoms,
-    relax_cell=True
-)
+result = relax_job(atoms, relax_cell=True)
 print(result)
 ```
 

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -41,26 +41,23 @@ print(result)
 
     ```
     {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-    'atoms_info': {'_id': 'd4859270a1a67083343bec0ab783f774'},
-    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 55, 25, 799465),
-                      'emmet_version': '0.78.7',
-                      'pymatgen_version': '2024.3.1'},
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 22, 22, 334535),
+                    'emmet_version': '0.82.0',
+                    'pymatgen_version': '2024.6.10'},
     'chemsys': 'Cu',
     'composition': Composition('Cu1'),
     'composition_reduced': Composition('Cu1'),
     'converged': True,
     'density': 8.971719800606017,
     'density_atomic': 11.761470249999999,
-    'dir_name': '/home/rosen/test/quacc-2024-03-08-17-55-25-774290-64642',
+    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-22-22-249452-41421',
     'elements': [Element Cu],
-    'fmax': 0.01,
     'formula_anonymous': 'A',
     'formula_pretty': 'Cu',
     'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-                    'atoms_info': {},
-                    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 55, 25, 797148),
-                                      'emmet_version': '0.78.7',
-                                      'pymatgen_version': '2024.3.1'},
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 22, 22, 333682),
+                                    'emmet_version': '0.82.0',
+                                    'pymatgen_version': '2024.6.10'},
                     'chemsys': 'Cu',
                     'composition': Composition('Cu1'),
                     'composition_reduced': Composition('Cu1'),
@@ -72,53 +69,52 @@ print(result)
                     'nelements': 1,
                     'nsites': 1,
                     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                                  'number': 225,
-                                  'point_group': 'm-3m',
-                                  'symbol': 'Fm-3m',
-                                  'symprec': 0.1,
-                                  'version': '2.3.1'},
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
                     'volume': 11.761470249999999},
     'name': 'EMT Relax',
     'nelements': 1,
     'nid': 'rosen.',
     'nsites': 1,
-    'nsteps': 0,
     'parameters': {'asap_cutoff': False},
     'parameters_opt': {'alpha': 70.0,
                         'max_steps': 1000,
                         'maxstep': 0.2,
                         'optimizer': 'BFGS',
                         'type': 'optimization'},
-    'quacc_version': '0.6.10',
+    'quacc_version': '0.8.1',
     'results': {'energies': array([-0.00568151]),
                 'energy': -0.005681511358581304,
                 'forces': array([[-3.14977672e-16,  1.01949224e-15,  3.66995236e-16]]),
                 'free_energy': -0.005681511358581304,
                 'stress': array([1.36192652e-02, 1.36192652e-02, 1.36192652e-02, 0.00000000e+00,
-          7.55159347e-17, 1.47492060e-19])},
+        7.55159347e-17, 1.47492060e-19])},
     'structure': Structure Summary
     Lattice
         abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
     angles : 60.00000000000001 60.00000000000001 60.00000000000001
     volume : 11.761470249999999
-          A : 0.0 1.805 1.805
-          B : 1.805 0.0 1.805
-          C : 1.805 1.805 0.0
+        A : 0.0 1.805 1.805
+        B : 1.805 0.0 1.805
+        C : 1.805 1.805 0.0
         pbc : True True True
     PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                  'number': 225,
-                  'point_group': 'm-3m',
-                  'symbol': 'Fm-3m',
-                  'symprec': 0.1,
-                  'version': '2.3.1'},
-    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]], calculator=SinglePointCalculator(...))],
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
+    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])],
     'trajectory_results': [{'energies': array([-0.00568151]),
                             'energy': -0.005681511358581304,
                             'forces': array([[-3.14977672e-16,  1.01949224e-15,  3.66995236e-16]]),
                             'free_energy': -0.005681511358581304,
                             'stress': array([1.36192652e-02, 1.36192652e-02, 1.36192652e-02, 0.00000000e+00,
-          7.55159347e-17, 1.47492060e-19])}],
+        7.55159347e-17, 1.47492060e-19])}],
     'volume': 11.761470249999999}
     ```
 
@@ -169,25 +165,22 @@ print(result2)
 
     ```
     {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-    'atoms_info': {'_id': 'd4859270a1a67083343bec0ab783f774',
-                    '_old_ids': ['d4859270a1a67083343bec0ab783f774']},
-    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 56, 18, 773772),
-                      'emmet_version': '0.78.7',
-                      'pymatgen_version': '2024.3.1'},
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 25, 25, 853559),
+                    'emmet_version': '0.83.6',
+                    'pymatgen_version': '2024.6.10'},
     'chemsys': 'Cu',
     'composition': Composition('Cu1'),
     'composition_reduced': Composition('Cu1'),
     'density': 8.971719800606017,
     'density_atomic': 11.761470249999999,
-    'dir_name': '/home/rosen/test/quacc-2024-03-08-17-56-17-983251-36940',
+    'dir_name': '/mnt/c/Users/asros/github/quacc/quacc-2024-06-17-18-25-25-482739-76656',
     'elements': [Element Cu],
     'formula_anonymous': 'A',
     'formula_pretty': 'Cu',
     'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-                    'atoms_info': {'_id': 'd4859270a1a67083343bec0ab783f774'},
-                    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 56, 18, 772151),
-                                      'emmet_version': '0.78.7',
-                                      'pymatgen_version': '2024.3.1'},
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 25, 25, 852522),
+                                    'emmet_version': '0.83.6',
+                                    'pymatgen_version': '2024.6.10'},
                     'chemsys': 'Cu',
                     'composition': Composition('Cu1'),
                     'composition_reduced': Composition('Cu1'),
@@ -199,11 +192,11 @@ print(result2)
                     'nelements': 1,
                     'nsites': 1,
                     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                                  'number': 225,
-                                  'point_group': 'm-3m',
-                                  'symbol': 'Fm-3m',
-                                  'symprec': 0.1,
-                                  'version': '2.3.1'},
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
                     'volume': 11.761470249999999},
     'name': 'TBLite Static',
     'nelements': 1,
@@ -215,12 +208,12 @@ print(result2)
                     'max_iterations': 250,
                     'method': 'GFN2-xTB',
                     'verbosity': 1},
-    'quacc_version': '0.6.10',
-    'results': {'charges': array([-4.63897809e-11]),
-                'dipole': array([-7.99968228e-08,  1.96246646e-07, -5.12600360e-08]),
-                'energy': -318.8584605831397,
+    'quacc_version': '0.9.6',
+    'results': {'charges': array([-4.66053862e-11]),
+                'dipole': array([-8.02234177e-08,  1.96331282e-07, -5.14078572e-08]),
+                'energy': -318.8584605831615,
                 'forces': array([[5.44452313e-20, 5.39007790e-19, 2.45003541e-19]]),
-                'free_energy': -318.8584605831397,
+                'free_energy': -318.8584605831615,
                 'stress': array([14.65181119, 14.65181119, 14.65181119,  1.40704868,  1.01943286,
             0.63181703])},
     'structure': Structure Summary
@@ -228,23 +221,235 @@ print(result2)
         abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
     angles : 60.00000000000001 60.00000000000001 60.00000000000001
     volume : 11.761470249999999
-          A : 0.0 1.805 1.805
-          B : 1.805 0.0 1.805
-          C : 1.805 1.805 0.0
+        A : 0.0 1.805 1.805
+        B : 1.805 0.0 1.805
+        C : 1.805 1.805 0.0
         pbc : True True True
     PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                  'number': 225,
-                  'point_group': 'm-3m',
-                  'symbol': 'Fm-3m',
-                  'symprec': 0.1,
-                  'version': '2.3.1'},
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
     'volume': 11.761470249999999}
     ```
 
 ### Modifying Parameters of a Job
 
-As demonstrated in the previous example, each recipe accepts optional keyword arguments to modify the default parameters. To identify the possible parameters a function takes, you'll want to check out the function signature and corresponding documentation, like that for [quacc.recipes.emt.core.relax_job][]. Go ahead; click it! Once you do, you'll see from the docstring that there is one required positional argument for the recipe (the `Atoms` object) and several optional keyword arguments, including those related to the underlying ASE calculator (`**calc_kwargs`), the optimization settings, and more. You can modify these parameters like in the example below:
+As demonstrated in the previous example, each recipe accepts optional keyword arguments to modify the default parameters. To identify the possible parameters a function takes, you'll want to check out the function signature and corresponding documentation, like that for [quacc.recipes.emt.core.relax_job][]. Go ahead; click it! Once you do, you'll see from the docstring that there is one required positional argument for the recipe (the `Atoms` object) and several optional keyword arguments.
+
+One of these optional keyword arguments for [quacc.recipes.emt.core.relax_job][] is `relax_cell`, which sets whether the cell should be relaxed. By default, this parameter is set to `False`. We will go ahead and set it to `True` in the example below.
+
+```python
+from ase.build import bulk
+from quacc.recipes.emt.core import relax_job
+
+# Make an Atoms object of a bulk Cu structure
+atoms = bulk("Cu")
+
+# Run a structure relaxation on the Atoms object
+result = relax_job(
+    atoms,
+    relax_cell=True
+)
+print(result)
+```
+
+??? Info "Printed Output"
+
+    ```text
+    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[3.237103763481748e-17, 1.7947995601681468, 1.794799560168147], [1.7947995601681463, 1.6830370083537554e-16, 1.7947995601681468], [1.7947995601681463, 1.7947995601681466, 2.5911916198566743e-16]]),
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 18, 43, 595725),
+                    'emmet_version': '0.82.0',
+                    'pymatgen_version': '2024.6.10'},
+    'chemsys': 'Cu',
+    'composition': Composition('Cu1'),
+    'composition_reduced': Composition('Cu1'),
+    'converged': True,
+    'density': 9.125558571548108,
+    'density_atomic': 11.563195249785407,
+    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-18-43-397414-52347',
+    'elements': [Element Cu],
+    'formula_anonymous': 'A',
+    'formula_pretty': 'Cu',
+    'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 18, 43, 588430),
+                                    'emmet_version': '0.82.0',
+                                    'pymatgen_version': '2024.6.10'},
+                    'chemsys': 'Cu',
+                    'composition': Composition('Cu1'),
+                    'composition_reduced': Composition('Cu1'),
+                    'density': 8.971719800606017,
+                    'density_atomic': 11.761470249999999,
+                    'elements': [Element Cu],
+                    'formula_anonymous': 'A',
+                    'formula_pretty': 'Cu',
+                    'nelements': 1,
+                    'nsites': 1,
+                    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
+                    'volume': 11.761470249999999},
+    'name': 'EMT Relax',
+    'nelements': 1,
+    'nid': 'rosen.',
+    'nsites': 1,
+    'parameters': {'asap_cutoff': False},
+    'parameters_opt': {'alpha': 70.0,
+                        'max_steps': 1000,
+                        'maxstep': 0.2,
+                        'optimizer': 'BFGS',
+                        'type': 'optimization'},
+    'quacc_version': '0.8.1',
+    'results': {'energies': array([-0.00703632]),
+                'energy': -0.007036318158828436,
+                'forces': array([[-1.59440590e-15,  2.41710031e-15,  8.65930422e-15]]),
+                'free_energy': -0.007036318158828436,
+                'stress': array([-1.58924696e-04, -1.58924696e-04, -1.58924696e-04,  2.30432437e-16,
+            7.68108123e-17,  1.89824193e-17])},
+    'structure': Structure Summary
+    Lattice
+        abc : 2.538229879731059 2.538229879731059 2.5382298797310585
+    angles : 59.99999999999999 59.99999999999999 59.99999999999999
+    volume : 11.563195249785407
+        A : 3.237103763481748e-17 1.7947995601681468 1.794799560168147
+        B : 1.7947995601681463 1.6830370083537554e-16 1.7947995601681468
+        C : 1.7947995601681463 1.7947995601681466 2.5911916198566743e-16
+        pbc : True True True
+    PeriodicSite: Cu (1.426e-17, 4.785e-18, 2.908e-17) [5.462e-18, 1.074e-17, -2.796e-18],
+    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
+    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+                    Atoms(symbols='Cu', pbc=True, cell=[[-2.2894595839080307e-17, 1.800874299952309, 1.800874299952309], [1.8008742999523093, -4.462884179157955e-20, 1.800874299952309], [1.8008742999523093, 1.800874299952309, -2.2849966997288728e-17]]),
+                    Atoms(symbols='Cu', pbc=True, cell=[[3.237103763481748e-17, 1.7947995601681468, 1.794799560168147], [1.7947995601681463, 1.6830370083537554e-16, 1.7947995601681468], [1.7947995601681463, 1.7947995601681466, 2.5911916198566743e-16]])],
+    'trajectory_results': [{'energies': array([-0.00568151]),
+                            'energy': -0.005681511358581304,
+                            'forces': array([[-3.14977672e-16,  1.01949224e-15,  3.66995236e-16]]),
+                            'free_energy': -0.005681511358581304,
+                            'stress': array([1.36192652e-02, 1.36192652e-02, 1.36192652e-02, 0.00000000e+00,
+        7.55159347e-17, 1.47492060e-19])},
+                            {'energies': array([-0.00655972]),
+                            'energy': -0.006559723374008897,
+                            'forces': array([[ 5.33690684e-16, -2.55246602e-16,  6.79425456e-16]]),
+                            'free_energy': -0.006559723374008897,
+                            'stress': array([ 8.17600510e-03,  8.17600510e-03,  8.17600510e-03, -2.28108398e-16,
+        -7.60361327e-17,  1.22198354e-18])},
+                            {'energies': array([-0.00703632]),
+                            'energy': -0.007036318158828436,
+                            'forces': array([[-1.59440590e-15,  2.41710031e-15,  8.65930422e-15]]),
+                            'free_energy': -0.007036318158828436,
+                            'stress': array([-1.58924696e-04, -1.58924696e-04, -1.58924696e-04,  2.30432437e-16,
+            7.68108123e-17,  1.89824193e-17])}],
+    'volume': 11.563195249785407}
+    ```
+
+All recipes in quacc allow you to pass in a custom set of keyword arguments to the underlying ASE calculator so that you have full control over the parameters (as specified via `**calc_kwargs` in the function signature). For instance, ASE's [`EMT` calculator](https://wiki.fysik.dtu.dk/ase/ase/calculators/emt.html#ase.calculators.emt.EMT) can take an optional parameter `asap_cutoff`. We show how to pass this parameter to the `relax_job` recipe in the example below.
+
+```python
+from ase.build import bulk
+from quacc.recipes.emt.core import relax_job
+
+# Make an Atoms object of a bulk Cu structure
+atoms = bulk("Cu")
+
+# Run a structure relaxation on the Atoms object
+result = relax_job(
+    atoms,
+    asap_cutoff=True,
+)
+print(result)
+```
+
+??? Info "Printed Output"
+
+    ```
+    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 231408),
+                    'emmet_version': '0.82.0',
+                    'pymatgen_version': '2024.6.10'},
+    'chemsys': 'Cu',
+    'composition': Composition('Cu1'),
+    'composition_reduced': Composition('Cu1'),
+    'converged': True,
+    'density': 8.971719800606017,
+    'density_atomic': 11.761470249999999,
+    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-20-40-132724-86476',
+    'elements': [Element Cu],
+    'formula_anonymous': 'A',
+    'formula_pretty': 'Cu',
+    'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 20, 40, 229796),
+                                    'emmet_version': '0.82.0',
+                                    'pymatgen_version': '2024.6.10'},
+                    'chemsys': 'Cu',
+                    'composition': Composition('Cu1'),
+                    'composition_reduced': Composition('Cu1'),
+                    'density': 8.971719800606017,
+                    'density_atomic': 11.761470249999999,
+                    'elements': [Element Cu],
+                    'formula_anonymous': 'A',
+                    'formula_pretty': 'Cu',
+                    'nelements': 1,
+                    'nsites': 1,
+                    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
+                    'volume': 11.761470249999999},
+    'name': 'EMT Relax',
+    'nelements': 1,
+    'nid': 'rosen.',
+    'nsites': 1,
+    'parameters': {'asap_cutoff': True},
+    'parameters_opt': {'alpha': 70.0,
+                        'max_steps': 1000,
+                        'maxstep': 0.2,
+                        'optimizer': 'BFGS',
+                        'type': 'optimization'},
+    'quacc_version': '0.8.1',
+    'results': {'energies': array([-0.00060116]),
+                'energy': -0.0006011628239370737,
+                'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
+                'free_energy': -0.0006011628239370737,
+                'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
+        0.        ])},
+    'structure': Structure Summary
+    Lattice
+        abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
+    angles : 60.00000000000001 60.00000000000001 60.00000000000001
+    volume : 11.761470249999999
+        A : 0.0 1.805 1.805
+        B : 1.805 0.0 1.805
+        C : 1.805 1.805 0.0
+        pbc : True True True
+    PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
+    'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
+    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])],
+    'trajectory_results': [{'energies': array([-0.00060116]),
+                            'energy': -0.0006011628239370737,
+                            'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
+                            'free_energy': -0.0006011628239370737,
+                            'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
+        0.        ])}],
+    'volume': 11.761470249999999}
+    ```
+
+Finally, you will see that [quacc.recipes.emt.core.relax_job][] takes an `opt_params` keyword argument that allows you to pass in a dictionary of parameters to the optimizer. That may look something like the following.
 
 ```python
 from ase.build import bulk
@@ -257,39 +462,32 @@ atoms = bulk("Cu")
 # Run a structure relaxation on the Atoms object
 result = relax_job(
     atoms,
-    relax_cell=True,
     opt_params={"fmax": 1e-3, "optimizer": LBFGS},
-    asap_cutoff=True,  # (1)!
 )
 print(result)
 ```
 
-1. All recipes in quacc allow you to pass in a custom set of keyword arguments corresponding to the ASE calculator.
-
 ??? Info "Printed Output"
 
     ```text
-    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[1.6657488637835028e-19, 1.7963940854299556, 1.7963940854299547], [1.7963940854299552, 2.3931154361445102e-17, 1.7963940854299547], [1.7963940854299552, 1.7963940854299556, -8.132837144101245e-16]]),
-    'atoms_info': {'_id': '6915f7a4e111b833dcca453da6d0d694'},
-    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 54, 26, 361990),
-                      'emmet_version': '0.78.7',
-                      'pymatgen_version': '2024.3.1'},
+    {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
+    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 21, 41, 211864),
+                    'emmet_version': '0.82.0',
+                    'pymatgen_version': '2024.6.10'},
     'chemsys': 'Cu',
     'composition': Composition('Cu1'),
     'composition_reduced': Composition('Cu1'),
     'converged': True,
-    'density': 9.10127989823884,
-    'density_atomic': 11.594041355280432,
-    'dir_name': '/home/rosen/test/quacc-2024-03-08-17-54-26-278865-61885',
+    'density': 8.971719800606017,
+    'density_atomic': 11.761470249999999,
+    'dir_name': '/mnt/c/Users/asros/Desktop/quacc-2024-06-17-18-21-41-136784-41483',
     'elements': [Element Cu],
-    'fmax': 0.001,
     'formula_anonymous': 'A',
     'formula_pretty': 'Cu',
     'input_atoms': {'atoms': Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]]),
-                    'atoms_info': {},
-                    'builder_meta': {'build_date': datetime.datetime(2024, 3, 8, 17, 54, 26, 350899),
-                                      'emmet_version': '0.78.7',
-                                      'pymatgen_version': '2024.3.1'},
+                    'builder_meta': {'build_date': datetime.datetime(2024, 6, 17, 18, 21, 41, 211034),
+                                    'emmet_version': '0.82.0',
+                                    'pymatgen_version': '2024.6.10'},
                     'chemsys': 'Cu',
                     'composition': Composition('Cu1'),
                     'composition_reduced': Composition('Cu1'),
@@ -301,72 +499,50 @@ print(result)
                     'nelements': 1,
                     'nsites': 1,
                     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                                  'number': 225,
-                                  'point_group': 'm-3m',
-                                  'symbol': 'Fm-3m',
-                                  'symprec': 0.1,
-                                  'version': '2.3.1'},
+                                'number': 225,
+                                'point_group': 'm-3m',
+                                'symbol': 'Fm-3m',
+                                'symprec': 0.1,
+                                'version': '2.4.0'},
                     'volume': 11.761470249999999},
     'name': 'EMT Relax',
     'nelements': 1,
     'nid': 'rosen.',
     'nsites': 1,
-    'nsteps': 3,
-    'parameters': {'asap_cutoff': True},
+    'parameters': {'asap_cutoff': False},
     'parameters_opt': {'max_steps': 1000,
                         'maxstep': 0.2,
                         'optimizer': 'LBFGS',
                         'type': 'optimization'},
-    'quacc_version': '0.6.10',
-    'results': {'energies': array([-0.00159299]),
-                'energy': -0.0015929904219369462,
-                'forces': array([[-1.64798730e-16,  3.27862737e-16,  3.78169718e-15]]),
-                'free_energy': -0.0015929904219369462,
-                'stress': array([ 1.12813866e-06,  1.12813866e-06,  1.12813866e-06, -1.53212912e-16,
-          -2.29819368e-16, -4.92256329e-17])},
+    'quacc_version': '0.8.1',
+    'results': {'energies': array([-0.00568151]),
+                'energy': -0.005681511358581304,
+                'forces': array([[-3.14977672e-16,  1.01949224e-15,  3.66995236e-16]]),
+                'free_energy': -0.005681511358581304,
+                'stress': array([1.36192652e-02, 1.36192652e-02, 1.36192652e-02, 0.00000000e+00,
+        7.55159347e-17, 1.47492060e-19])},
     'structure': Structure Summary
     Lattice
-        abc : 2.540484878981855 2.5404848789818546 2.540484878981855
-    angles : 60.00000000000002 60.00000000000001 60.00000000000002
-    volume : 11.594041355280432
-          A : 1.6657488637835028e-19 1.7963940854299556 1.7963940854299547
-          B : 1.7963940854299552 2.3931154361445102e-17 1.7963940854299547
-          C : 1.7963940854299552 1.7963940854299556 -8.132837144101245e-16
+        abc : 2.5526554800834367 2.5526554800834367 2.5526554800834367
+    angles : 60.00000000000001 60.00000000000001 60.00000000000001
+    volume : 11.761470249999999
+        A : 0.0 1.805 1.805
+        B : 1.805 0.0 1.805
+        C : 1.805 1.805 0.0
         pbc : True True True
-    PeriodicSite: Cu (-6.919e-18, 9.514e-17, 1.138e-16) [6.008e-17, 3.264e-18, -7.116e-18],
+    PeriodicSite: Cu (0.0, 0.0, 0.0) [0.0, 0.0, 0.0],
     'symmetry': {'crystal_system': <CrystalSystem.cubic: 'Cubic'>,
-                  'number': 225,
-                  'point_group': 'm-3m',
-                  'symbol': 'Fm-3m',
-                  'symprec': 0.1,
-                  'version': '2.3.1'},
-    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]], calculator=SinglePointCalculator(...)),
-                    Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.8014556448273662, 1.8014556448273664], [1.8014556448273662, 0.0, 1.8014556448273664], [1.8014556448273662, 1.8014556448273662, 0.0]], calculator=SinglePointCalculator(...)),
-                    Atoms(symbols='Cu', pbc=True, cell=[[5.771123678574472e-17, 1.7963098069799175, 1.7963098069799164], [1.796309806979917, 1.7488253571435684e-18, 1.7963098069799164], [1.796309806979917, 1.7963098069799175, -1.031316315430271e-15]], calculator=SinglePointCalculator(...)),
-                    Atoms(symbols='Cu', pbc=True, cell=[[1.6657488637835028e-19, 1.7963940854299556, 1.7963940854299547], [1.7963940854299552, 2.3931154361445102e-17, 1.7963940854299547], [1.7963940854299552, 1.7963940854299556, -8.132837144101245e-16]], calculator=SinglePointCalculator(...))],
-    'trajectory_results': [{'energies': array([-0.00060116]),
-                            'energy': -0.0006011628239370737,
-                            'forces': array([[1.18655086e-15, 1.15706056e-15, 3.16066617e-15]]),
-                            'free_energy': -0.0006011628239370737,
-                            'stress': array([0.01169831, 0.01169831, 0.01169831, 0.        , 0.        ,
-          0.        ])},
-                            {'energies': array([-0.00124764]),
-                            'energy': -0.0012476410887956035,
-                            'forces': array([[-9.64506253e-16,  1.88737914e-15, -8.84708973e-16]]),
-                            'free_energy': -0.0012476410887956035,
-                            'stress': array([ 6.97489804e-03,  6.97489804e-03,  6.97489804e-03,  0.00000000e+00,
-          -7.59625440e-17, -2.37382950e-18])},
-                            {'energies': array([-0.0015929]),
-                            'energy': -0.0015928956483097778,
-                            'forces': array([[6.81746326e-16, 9.74914593e-16, 7.14012183e-15]]),
-                            'free_energy': -0.0015928956483097778,
-                            'stress': array([-1.17305499e-04, -1.17305499e-04, -1.17305499e-04, -1.53234478e-16,
-          -7.66172391e-17,  7.73654544e-17])},
-                            {'energies': array([-0.00159299]),
-                            'energy': -0.0015929904219369462,
-                            'forces': array([[-1.64798730e-16,  3.27862737e-16,  3.78169718e-15]]),
-                            'free_energy': -0.0015929904219369462,
-                            'stress': array([ 1.12813866e-06,  1.12813866e-06,  1.12813866e-06, -1.53212912e-16,
-          -2.29819368e-16, -4.92256329e-17])}],
-    'volume': 11.594041355280432}
+                'number': 225,
+                'point_group': 'm-3m',
+                'symbol': 'Fm-3m',
+                'symprec': 0.1,
+                'version': '2.4.0'},
+    'trajectory': [Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])],
+    'trajectory_results': [{'energies': array([-0.00568151]),
+                            'energy': -0.005681511358581304,
+                            'forces': array([[-3.14977672e-16,  1.01949224e-15,  3.66995236e-16]]),
+                            'free_energy': -0.005681511358581304,
+                            'stress': array([1.36192652e-02, 1.36192652e-02, 1.36192652e-02, 0.00000000e+00,
+        7.55159347e-17, 1.47492060e-19])}],
+    'volume': 11.761470249999999}
     ```


### PR DESCRIPTION
## Summary of Changes

Closes #2267.

This PR seeks to further clarify what `**calc_kwargs` means in the function signature, providing more detailed guidance for users in the introductory documentation. This is based on @wladerer's initial point of confusion in https://github.com/Quantum-Accelerators/quacc/discussions/2265.