### PR TITLE
Organize outputs directory as nested folders

### DIFF
--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -149,9 +149,6 @@ def job(_func: Callable | None = None, **kwargs) -> Job:
     if changes := kwargs.pop("settings_swap", {}):
         return job(change_settings_wrap(_func, changes), **kwargs)
 
-    # if settings.NESTED_RESULTS_DIR:
-    #     _func = nest_results_dir_wrap(_func)
-
     if settings.WORKFLOW_ENGINE == "covalent":
         import covalent as ct
 


### PR DESCRIPTION
## Summary of Changes

This is a draft PR to organize the RESULTS_DIR as a nested directory based on the DAG of the calling functions. For example, running the EMT example in the docs:
```
from ase.build import bulk
from quacc.recipes.emt.slabs import bulk_to_slabs_flow

# Define the Atoms object
atoms = bulk("Cu")

# Define the workflow
result = bulk_to_slabs_flow(atoms)
```
with the new setting `QUACC_NESTED_RESULTS_DIR=True` will lead to a RESULTS_DIR with layout:
* RESULTS_DIR
  * quacc.recipes.emt.slabs.bulk_to_slabs_flow-d0451dd0-843b-4f45-a6d9-f2de6e79e187
    * quacc.recipes.common.slabs.bulk_to_slabs_subflow-13292e70-7fe9-4dc4-9d01-34088b61cae4
      * quacc.recipes.emt.core.relax_job-b0a60c45-d0e6-4a11-bd42-4f396d3b9b76
      * quacc.recipes.emt.core.static_job-a72fe906-9d19-4bd3-a739-d0433f2eb3fe
      * quacc.recipes.emt.core.relax_job-ab3c836a-66b0-4bc6-a000-1996349d776d
      * quacc.recipes.emt.core.static_job-23df0c5a-5606-454c-8f1a-02861cfb9f2d
      * quacc.recipes.emt.core.relax_job-02717538-3d4b-421d-80ed-ee0f61ffc091
      * quacc.recipes.emt.core.static_job-d7e1d0b5-830b-481a-94c2-2785cbb5b126
      * quacc.recipes.emt.core.relax_job-b6d62a53-0550-445a-b817-5c6c14976bd3
      * quacc.recipes.emt.core.static_job-7302e8cd-5815-4892-a7df-8a3ed5d42a92

This is only a demo to inspire discussion, and is only implemented for prefect right now (though others would be easy to add!).

A couple of potential downsides:
* Passing around wrapped functions increases complexity
* You can only define the task/flow/etc at runtime in the flow, which could lead to some downstream weird logic issues
* Prefect throws some warnings that different functions with the same name are being used (it still works)