### PR TITLE
job patterns for partitioning lists and mapping onto them

### DIFF
--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from quacc.wflow_tools.decorators import job
+from quacc.wflow_tools.customizers import strip_decorator
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@job
+def partition(a, n) -> list[Any]:
+    """
+    Given a list, partition it into n roughly equal lists
+
+    Parameters
+    ----------
+    a
+        the list to partition
+    n
+        the number of partitions to output
+
+    Returns
+    -------
+    list[Any]
+        n lists constructed from a
+    """
+    k, m = divmod(len(a), n)
+    return [a[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
+
+
+def map_partitioned_lists(
+    func: callable,
+    num_partitions: int,
+    unmapped_kwargs: dict[str, Any] | None = None,
+    **mapped_kwargs: dict[str, list[list[Any]]],
+):
+    """
+    Given list-of-lists parameters (say a list of batches that we want to map over),
+    apply func to each element of each list
+
+    For example:
+    @job
+    def testjob(**kwargs):
+        print(kwargs)
+
+    @flow
+    def testflow():
+        num_partitions = 2
+        result = map_partitioned_lists(
+            testjob,
+            num_partitions=num_partitions,
+            test_arg_1=partition([1,2,3,4,5], num_partitions),
+            test_arg_2=partition(["a", "b", "c","d","e"], num_partitions),
+        )
+
+    testflow()
+
+    should yield:
+    {'test_arg_1': 1, 'test_arg_2': 'a'}
+    {'test_arg_1': 2, 'test_arg_2': 'b'}
+    {'test_arg_1': 3, 'test_arg_2': 'c'}
+    {'test_arg_1': 4, 'test_arg_2': 'd'}
+    {'test_arg_1': 5, 'test_arg_2': 'e'}
+
+    regardless of the number of partitions
+
+
+    Parameters
+    ----------
+    func
+        The function to map.
+    num_partitions
+        the length of each kwarg in mapped_kwargs
+    unmapped_kwargs
+        Dictionary of kwargs to pass to func that shouldn't be mapped
+    mapped_kwargs
+        kwargs of the form key=list[] that should be mapped over
+
+    Returns
+    -------
+    list[results]
+        list of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
+        kwargs in mapped_kwargs
+    """
+
+    return [
+        map_partition(
+            strip_decorator(func),
+            unmapped_kwargs=unmapped_kwargs,
+            **{k: mapped_kwargs[k][i] for k in mapped_kwargs},
+        )
+        for i in range(num_partitions)
+    ]
+
+
+@job
+def map_partition(
+    func: callable, unmapped_kwargs: dict[str, Any] | None = None, **mapped_kwargs
+) -> list[Any]:
+    """
+    Wrap a function to handle special Parsl arguments.
+
+    Parameters
+    ----------
+    func
+        The function to map.
+    unmapped_kwargs
+        Dictionary of kwargs to pass to func that shouldn't be mapped
+    mapped_kwargs
+        kwargs of the form key=list[] that should be mapped over
+
+    Returns
+    -------
+    list[results]
+        list of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
+        kwargs in mapped_kwargs
+    """
+    return kwarg_map(func, unmapped_kwargs=unmapped_kwargs, **mapped_kwargs)
+
+
+def kwarg_map(func: callable, unmapped_kwargs: None = None, **mapped_kwargs):
+    """
+    A helper function for when you want to construct a chain of objects with individual arguments for each one.  Can
+    be easier to read than a list expansion.
+
+    Parameters
+    ----------
+    func
+        The function to map.
+    unmapped_kwargs
+        Dictionary of kwargs to pass to func that shouldn't be mapped
+    mapped_kwargs
+        kwargs of the form key=list[] that should be mapped over
+
+    Returns
+    -------
+    list[results]
+        list of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
+        kwargs in mapped_kwargs
+
+    Adapted from https://stackoverflow.com/a/36575917 (CC-by-SA 3.0)
+
+    """
+    if unmapped_kwargs is None:
+        unmapped_kwargs = {}
+
+    all_lens = [len(v) for v in mapped_kwargs.values()]
+    n_elements = all_lens[0]
+    assert all(n_elements == le for le in all_lens), "Inconsistent lengths: %s" % (
+        all_lens,
+    )
+    return [
+        func(**{k: v[i] for k, v in iter(mapped_kwargs.items())}, **unmapped_kwargs)
+        for i in range(n_elements)
+    ]

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -65,7 +65,7 @@ def map_partitioned_lists(
     testflow()
     ```
 
-    should yield:
+    should yield
 
     ```python
     {"test_arg_1": 1, "test_arg_2": "a"}
@@ -92,7 +92,7 @@ def map_partitioned_lists(
     Returns
     -------
     list[Any]
-        list of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
+        list of results from calling func(**(mapped_kwargs | unmapped_kwargs)) for each
         kwargs in mapped_kwargs
     """
 
@@ -159,7 +159,8 @@ def kwarg_map(
 
     all_lens = [len(v) for v in mapped_kwargs.values()]
     n_elements = all_lens[0]
-    assert all(n_elements == le for le in all_lens), f"Inconsistent lengths: {all_lens}"
+    if not all(n_elements == le for le in all_lens):
+        raise AssertionError(f"Inconsistent lengths: {all_lens}")
     return [
         func(**{k: v[i] for k, v in iter(mapped_kwargs.items())}, **unmapped_kwargs)
         for i in range(n_elements)

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -44,6 +44,8 @@ def map_partitioned_lists(
     apply func to each element of each list
 
     For example:
+
+    ```python
     @job
     def testjob(**kwargs):
         print(kwargs)
@@ -59,15 +61,19 @@ def map_partitioned_lists(
         )
 
     testflow()
+    ```
 
     should yield:
+
+    ```python
     {'test_arg_1': 1, 'test_arg_2': 'a'}
     {'test_arg_1': 2, 'test_arg_2': 'b'}
     {'test_arg_1': 3, 'test_arg_2': 'c'}
     {'test_arg_1': 4, 'test_arg_2': 'd'}
     {'test_arg_1': 5, 'test_arg_2': 'e'}
+    ```
 
-    regardless of the number of partitions
+    regardless of the number of partitions.
 
 
     Parameters
@@ -79,7 +85,7 @@ def map_partitioned_lists(
     unmapped_kwargs
         Dictionary of kwargs to pass to func that shouldn't be mapped
     mapped_kwargs
-        kwargs of the form key=list[] that should be mapped over
+        kwargs of the form key=list[...] that should be mapped over
 
     Returns
     -------

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -156,8 +156,7 @@ def kwarg_map(
     Adapted from https://stackoverflow.com/a/36575917 (CC-by-SA 3.0)
 
     """
-    if unmapped_kwargs is None:
-        unmapped_kwargs = {}
+    unmapped_kwargs = unmapped_kwargs or {}
 
     all_lens = [len(v) for v in mapped_kwargs.values()]
     n_elements = all_lens[0]

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -120,7 +120,7 @@ def map_partition(
     unmapped_kwargs
         Dictionary of kwargs to pass to func that shouldn't be mapped
     mapped_kwargs
-        kwargs of the form key=list[] that should be mapped over
+        kwargs of the form key=list[...] that should be mapped over
 
     Returns
     -------
@@ -138,6 +138,8 @@ def kwarg_map(
     A helper function for when you want to construct a chain of objects with individual arguments for each one.  Can
     be easier to read than a list expansion.
 
+    Adapted from https://stackoverflow.com/a/36575917 (CC-by-SA 3.0)
+
     Parameters
     ----------
     func
@@ -145,16 +147,13 @@ def kwarg_map(
     unmapped_kwargs
         Dictionary of kwargs to pass to func that shouldn't be mapped
     mapped_kwargs
-        kwargs of the form key=list[] that should be mapped over
+        kwargs of the form key=list[...] that should be mapped over
 
     Returns
     -------
     list[Any]
-        list of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
+        List of results from calling func(**mapped_kwargs, **unmapped_kwargs) for each
         kwargs in mapped_kwargs
-
-    Adapted from https://stackoverflow.com/a/36575917 (CC-by-SA 3.0)
-
     """
     unmapped_kwargs = unmapped_kwargs or {}
 

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from quacc.wflow_tools.decorators import job
 from quacc.wflow_tools.customizers import strip_decorator
+from quacc.wflow_tools.decorators import job
 
 if TYPE_CHECKING:
     from typing import Any
@@ -148,9 +148,7 @@ def kwarg_map(func: callable, unmapped_kwargs: None = None, **mapped_kwargs):
 
     all_lens = [len(v) for v in mapped_kwargs.values()]
     n_elements = all_lens[0]
-    assert all(n_elements == le for le in all_lens), "Inconsistent lengths: %s" % (
-        all_lens,
-    )
+    assert all(n_elements == le for le in all_lens), f"Inconsistent lengths: {all_lens}"
     return [
         func(**{k: v[i] for k, v in iter(mapped_kwargs.items())}, **unmapped_kwargs)
         for i in range(n_elements)

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -50,15 +50,17 @@ def map_partitioned_lists(
     def testjob(**kwargs):
         print(kwargs)
 
+
     @flow
     def testflow():
         num_partitions = 2
         result = map_partitioned_lists(
             testjob,
             num_partitions,
-            test_arg_1=partition([1,2,3,4,5], num_partitions),
-            test_arg_2=partition(["a", "b", "c","d","e"], num_partitions),
+            test_arg_1=partition([1, 2, 3, 4, 5], num_partitions),
+            test_arg_2=partition(["a", "b", "c", "d", "e"], num_partitions),
         )
+
 
     testflow()
     ```
@@ -66,11 +68,11 @@ def map_partitioned_lists(
     should yield:
 
     ```python
-    {'test_arg_1': 1, 'test_arg_2': 'a'}
-    {'test_arg_1': 2, 'test_arg_2': 'b'}
-    {'test_arg_1': 3, 'test_arg_2': 'c'}
-    {'test_arg_1': 4, 'test_arg_2': 'd'}
-    {'test_arg_1': 5, 'test_arg_2': 'e'}
+    {"test_arg_1": 1, "test_arg_2": "a"}
+    {"test_arg_1": 2, "test_arg_2": "b"}
+    {"test_arg_1": 3, "test_arg_2": "c"}
+    {"test_arg_1": 4, "test_arg_2": "d"}
+    {"test_arg_1": 5, "test_arg_2": "e"}
     ```
 
     regardless of the number of partitions.

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -19,9 +19,7 @@ def test_partition():
 
     partitioned_list = partition(simple_list(), 3)
     assert len(partitioned_list) == 3
-    assert np.allclose(partitioned_list[0], [0, 1, 2, 3])
-
-    return
+    np.testing.assert_allclose(partitioned_list[0], [0, 1, 2, 3])
 
 
 def test_kwarg_map():
@@ -38,7 +36,6 @@ def test_kwarg_map():
     ]
     with pytest.raises(AssertionError):
         kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
-    return
 
 
 def test_map_partitioned_lists():
@@ -73,7 +70,6 @@ def test_map_partitioned_lists():
         a=partition(simple_list(), num_partitions),
         num_partitions=num_partitions,
     )[1] == [15, 18, 21, 24, 27]
-    return
 
 
 def test_map_partition():
@@ -90,4 +86,3 @@ def test_map_partition():
     ]
     with pytest.raises(AssertionError):
         kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
-    return

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from quacc import job
+from quacc.wflow_tools.job_patterns import (
+    partition,
+    kwarg_map,
+    map_partition,
+    map_partitioned_lists,
+)
+import numpy as np
+
+
+def test_partition():
+
+    @job
+    def simple_list():
+        return list(range(10))
+
+    partitioned_list = partition(simple_list(), 3)
+    assert len(partitioned_list) == 3
+    assert np.allclose(partitioned_list[0], [0, 1, 2, 3])
+
+    return
+
+
+def test_kwarg_map():
+
+    def test_fun(a, b):
+        return {"a": a, "b": b}
+
+    assert kwarg_map(test_fun, a=[1, 2], b=["c", "d"]) == [
+        {"a": 1, "b": "c"},
+        {"a": 2, "b": "d"},
+    ]
+    assert kwarg_map(test_fun, unmapped_kwargs={"b": 1}, a=[1, 2]) == [
+        {"a": 1, "b": 1},
+        {"a": 2, "b": 1},
+    ]
+    with pytest.raises(AssertionError):
+        kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
+    return
+
+
+def test_map_partitioned_lists():
+
+    @job
+    def simple_list():
+        return list(range(10))
+
+    def testfun(a, const=2):
+        return a * const
+
+    num_partitions = 4
+    assert map_partitioned_lists(
+        testfun,
+        a=partition(simple_list(), num_partitions),
+        num_partitions=num_partitions,
+    )[0] == [0, 2, 4]
+    assert map_partitioned_lists(
+        testfun,
+        unmapped_kwargs={"const": 3},
+        a=partition(simple_list(), num_partitions),
+        num_partitions=num_partitions,
+    )[0] == [0, 3, 6]
+    num_partitions = 2
+    assert map_partitioned_lists(
+        testfun,
+        a=partition(simple_list(), num_partitions),
+        num_partitions=num_partitions,
+    )[0] == [0, 2, 4, 6, 8]
+    assert map_partitioned_lists(
+        testfun,
+        unmapped_kwargs={"const": 3},
+        a=partition(simple_list(), num_partitions),
+        num_partitions=num_partitions,
+    )[1] == [15, 18, 21, 24, 27]
+    return
+
+
+def test_map_partition():
+
+    def test_fun(a, b):
+        return {"a": a, "b": b}
+
+    assert map_partition(test_fun, a=[1, 2], b=["c", "d"]) == [
+        {"a": 1, "b": "c"},
+        {"a": 2, "b": "d"},
+    ]
+    assert map_partition(test_fun, unmapped_kwargs={"b": 1}, a=[1, 2]) == [
+        {"a": 1, "b": 1},
+        {"a": 2, "b": 1},
+    ]
+    with pytest.raises(AssertionError):
+        kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
+    return

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -34,7 +34,7 @@ def test_kwarg_map():
         {"a": 1, "b": 1},
         {"a": 2, "b": 1},
     ]
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Inconsistent lengths"):
         kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
 
 

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from quacc import job
 from quacc.wflow_tools.job_patterns import (
-    partition,
     kwarg_map,
     map_partition,
     map_partitioned_lists,
+    partition,
 )
-import numpy as np
 
 
 def test_partition():
-
     @job
     def simple_list():
         return list(range(10))
@@ -26,7 +25,6 @@ def test_partition():
 
 
 def test_kwarg_map():
-
     def test_fun(a, b):
         return {"a": a, "b": b}
 
@@ -44,7 +42,6 @@ def test_kwarg_map():
 
 
 def test_map_partitioned_lists():
-
     @job
     def simple_list():
         return list(range(10))
@@ -80,7 +77,6 @@ def test_map_partitioned_lists():
 
 
 def test_map_partition():
-
     def test_fun(a, b):
         return {"a": a, "b": b}
 

--- a/tests/prefect/test_map_partitions.py
+++ b/tests/prefect/test_map_partitions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from quacc import job, flow
+from quacc import flow, job
 from quacc.wflow_tools.job_patterns import (
     kwarg_map,
     map_partition,

--- a/tests/prefect/test_map_partitions.py
+++ b/tests/prefect/test_map_partitions.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quacc import job, flow
+from quacc.wflow_tools.job_patterns import (
+    kwarg_map,
+    map_partition,
+    map_partitioned_lists,
+    partition,
+)
+
+
+def test_partition():
+    @job
+    def simple_list():
+        return list(range(10))
+
+    @flow
+    def test_flow():
+        return partition(simple_list(), 3)
+
+    partitioned_list = test_flow().result()
+    assert len(partitioned_list) == 3
+    np.testing.assert_allclose(partitioned_list[0], [0, 1, 2, 3])
+
+
+def test_kwarg_map():
+    def test_fun(a, b):
+        return {"a": a, "b": b}
+
+    assert kwarg_map(test_fun, a=[1, 2], b=["c", "d"]) == [
+        {"a": 1, "b": "c"},
+        {"a": 2, "b": "d"},
+    ]
+    assert kwarg_map(test_fun, unmapped_kwargs={"b": 1}, a=[1, 2]) == [
+        {"a": 1, "b": 1},
+        {"a": 2, "b": 1},
+    ]
+    with pytest.raises(AssertionError):
+        kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
+
+
+def test_map_partitioned_lists():
+    @job
+    def simple_list():
+        return list(range(10))
+
+    def testfun(a, const=2):
+        return a * const
+
+    @flow
+    def test_flow(func, num_partitions, unmapped_kwargs=None):
+        return map_partitioned_lists(
+            func,
+            unmapped_kwargs=unmapped_kwargs,
+            a=partition(simple_list(), num_partitions),
+            num_partitions=num_partitions,
+        )
+
+    num_partitions = 4
+    assert test_flow(testfun, num_partitions)[0].result() == [0, 2, 4]
+    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[
+        0
+    ].result() == [0, 3, 6]
+    num_partitions = 2
+    assert test_flow(testfun, num_partitions)[0].result() == [0, 2, 4, 6, 8]
+    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[
+        1
+    ].result() == [15, 18, 21, 24, 27]
+
+
+def test_map_partition():
+    def test_fun(a, b):
+        return {"a": a, "b": b}
+
+    @flow
+    def test_flow1():
+        return map_partition(test_fun, a=[1, 2], b=["c", "d"])
+
+    assert test_flow1().result() == [{"a": 1, "b": "c"}, {"a": 2, "b": "d"}]
+
+    @flow
+    def test_flow2():
+        return map_partition(test_fun, unmapped_kwargs={"b": 1}, a=[1, 2])
+
+    assert test_flow2().result() == [{"a": 1, "b": 1}, {"a": 2, "b": 1}]

--- a/tests/prefect/test_map_partitions.py
+++ b/tests/prefect/test_map_partitions.py
@@ -38,7 +38,7 @@ def test_kwarg_map():
         {"a": 1, "b": 1},
         {"a": 2, "b": 1},
     ]
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Inconsistent lengths"):
         kwarg_map(test_fun, a=[1, 2, 3], b=[1, 2])
 
 


### PR DESCRIPTION
## Summary of Changes

This draft PR adds job patterns that are common in high-throughput workflows. When running many jobs on the same flow (say `result = map(my_job, range(1000))`) , many workflow managers will get sad (network/db/load issues) with too many jobs. This PR is inspired by the dask bag partitions and map operator. 

For example:
```
@job
def testjob(**kwargs):
    print(kwargs)

@flow
def testflow():
    num_partitions = 2
    result = map_partitioned_lists(
        testjob,
        num_partitions=num_partitions,
        test_arg_1=partition([1,2,3,4,5], num_partitions),
        test_arg_2=partition(["a", "b", "c","d","e"], num_partitions),
    )

testflow()
```

should yield:
```
{'test_arg_1': 1, 'test_arg_2': 'a'}
{'test_arg_1': 2, 'test_arg_2': 'b'}
{'test_arg_1': 3, 'test_arg_2': 'c'}
{'test_arg_1': 4, 'test_arg_2': 'd'}
{'test_arg_1': 5, 'test_arg_2': 'e'}
```
but run in only two jobs (instead of 5). 

In addition, by using a specified number of partitions, logic flows can quickly move from one step to the next without waiting for any intermediate results.
```
many_results = generate_many_objects()

# Cannot continue until many_results is generated as the number of jobs to be generated is unknown
final_results = [analysis_job(result) for result in results]
```
while 
```
many_results = generate_many_objects()
partitions_results = partition(many_results, num_partitions=10)
final_results = mapped_partitioned_lists(analysis_job, result=partitioned_results, num_partitions=10)
```
is fine since it is clear there is a first job, a second partition job that yields 10 tasks, and a final mapping job that has 10 jobs (one per partition). 