### PR TITLE
Remove deprecated `mace` method

### DIFF
--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from warnings import warn
 
 if TYPE_CHECKING:
     from typing import Literal

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -22,11 +22,6 @@ def pick_calculator(
     """
     Adapted from `matcalc.util.get_universal_calculator`.
 
-    .. deprecated:: 0.7.6
-            method `mace` will be removed in a later version, it is replaced by 'mace-mp-0'
-            which more accurately reflects the nature of the model and allows for versioning
-            in the future.
-
     Parameters
     ----------
     method
@@ -62,16 +57,9 @@ def pick_calculator(
 
         calc = CHGNetCalculator(**kwargs)
 
-    elif method.lower() in ["mace-mp-0", "mace"]:
+    elif method.lower() == "mace-mp-0":
         from mace import __version__
         from mace.calculators import mace_mp
-
-        if method.lower() == "mace":
-            warn(
-                "'mace' is deprecated and support will be removed. Use 'mace-mp-0' instead!",
-                DeprecationWarning,
-                stacklevel=3,
-            )
 
         if "default_dtype" not in kwargs:
             kwargs["default_dtype"] = "float64"


### PR DESCRIPTION
This PR removes an old deprecated keyword argument `mace` in the MLP recipes. The keyword argument in the docstring is `mace-mp-0`.