### PR TITLE
Warn users about a future breaking change to `relax_cell` in VASP recipes

### DIFF
--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
+from warnings import warn
 
 import numpy as np
 from monty.os.path import zpath
@@ -107,6 +108,12 @@ def relax_job(
         Dictionary of results from [quacc.schemas.vasp.vasp_summarize_run][].
         See the type-hint for the data structure.
     """
+    if relax_cell:
+        warn(
+            "The `relax_cell` parameter will default to `False` by default in a future version for internal consistency throughout quacc.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
     calc_defaults = {
         "ediffg": -0.02,
         "isif": 3 if relax_cell else 2,
@@ -219,6 +226,12 @@ def ase_relax_job(
     VaspASEOptSchema
         Dictionary of results. See the type-hint for the data structure.
     """
+    if relax_cell:
+        warn(
+            "The `relax_cell` parameter will default to `False` by default in a future version for internal consistency throughout quacc.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
     calc_defaults = {"lcharg": False, "lwave": False, "nsw": 0}
     opt_defaults = {"relax_cell": relax_cell}
     return run_and_summarize_opt(


### PR DESCRIPTION
## Summary of Changes

As noted in https://github.com/Quantum-Accelerators/quacc/issues/1887, the VASP recipes are the only ones throughout quacc with `relax_cell = True` by default (namely: `relax_job` and `ase_relax_job`). This can lead to unexpected behavior for users that run multiple codes in quacc. To streamline things, eventually we will make `relax_cell = False` by default. This would be a notable breaking change, so we will not do so for some time. The warning may be perceived as annoying, but it is perhaps worthwhile.

### Requirements

- Your PR should be focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- Your PR should have relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- Your PR should be on a custom branch and _not_ be named `main`.

### Notes

- Before contributing for the first time, read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines).
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
