### PR TITLE
fix mypy issues for espresso recipes

### DIFF
--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -25,8 +25,6 @@ from quacc.utils.dicts import recursive_dict_merge
 if TYPE_CHECKING:
     from typing import Any
 
-    from ase.calculators.genericfileio import GenericFileIOCalculator
-
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
 
@@ -90,7 +88,7 @@ def run_and_summarize(
         binary=calc.template.binary,
     )
 
-    geom_file = template.outputname if template.binary == "pw" else None
+    geom_file = template.outputname if template and template.binary == "pw" else None
 
     final_atoms = Runner(atoms, calc, copy_files=updated_copy_files).run_calc(
         geom_file=geom_file
@@ -184,7 +182,7 @@ def prepare_calc(
     profile: EspressoProfile | None = None,
     calc_defaults: dict[str, Any] | None = None,
     calc_swaps: dict[str, Any] | None = None,
-) -> GenericFileIOCalculator:
+) -> Espresso:
     """
     Commonly used preparation function to merge parameters
     and create an Espresso calculator accordingly.
@@ -208,7 +206,7 @@ def prepare_calc(
 
     Returns
     -------
-    GenericFileIOCalculator
+    Espresso
         The Espresso calculator.
     """
     calc_defaults = calc_defaults or {}

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
-
 BASE_SET_METAL: BaseSet = {
     "input_data": {
         "system": {"occupations": "smearing", "smearing": "cold", "degauss": 0.01},
@@ -88,7 +87,6 @@ def static_job(
     is_metal = check_is_metal(atoms)
 
     calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
-
     calc_defaults["input_data"]["control"] = {"calculation": "scf"}
 
     return run_and_summarize(

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -13,18 +13,21 @@ from quacc.recipes.espresso._base import run_and_summarize, run_and_summarize_op
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
+    from src.quacc.types import BaseSet
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
-BASE_SET_METAL = {
+
+BASE_SET_METAL: BaseSet = {
     "input_data": {
         "system": {"occupations": "smearing", "smearing": "cold", "degauss": 0.01},
         "electrons": {"conv_thr": 1e-8, "mixing_mode": "local-TF", "mixing_beta": 0.35},
+        "control": {},
     },
     "kspacing": 0.033,
 }
 
-BASE_SET_NON_METAL = {
+BASE_SET_NON_METAL: BaseSet = {
     "input_data": {
         "system": {"occupations": "smearing", "smearing": "gaussian", "degauss": 0.005},
         "electrons": {"conv_thr": 1e-8, "mixing_mode": "local-TF", "mixing_beta": 0.35},
@@ -85,6 +88,7 @@ def static_job(
     is_metal = check_is_metal(atoms)
 
     calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
+
     calc_defaults["input_data"]["control"] = {"calculation": "scf"}
 
     return run_and_summarize(

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -13,11 +13,11 @@ from quacc.recipes.espresso._base import run_and_summarize, run_and_summarize_op
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
-    from src.quacc.types import BaseSet
+    from src.quacc.types import EspressoBaseSet
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
-BASE_SET_METAL: BaseSet = {
+BASE_SET_METAL: EspressoBaseSet = {
     "input_data": {
         "system": {"occupations": "smearing", "smearing": "cold", "degauss": 0.01},
         "electrons": {"conv_thr": 1e-8, "mixing_mode": "local-TF", "mixing_beta": 0.35},
@@ -26,7 +26,7 @@ BASE_SET_METAL: BaseSet = {
     "kspacing": 0.033,
 }
 
-BASE_SET_NON_METAL: BaseSet = {
+BASE_SET_NON_METAL: EspressoBaseSet = {
     "input_data": {
         "system": {"occupations": "smearing", "smearing": "gaussian", "degauss": 0.005},
         "electrons": {"conv_thr": 1e-8, "mixing_mode": "local-TF", "mixing_beta": 0.35},

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -165,6 +165,7 @@ def dos_flow(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
+    job_params = job_params or {}
     default_job_params = {
         "static_job": {
             "kspacing": 0.2,
@@ -241,6 +242,7 @@ def projwfc_flow(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
+    job_params = job_params or {}
     default_job_params = {
         "static_job": {
             "kspacing": 0.2,

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -23,6 +23,7 @@ from quacc.utils.dicts import recursive_dict_merge
 from quacc.wflow_tools.customizers import customize_funcs
 
 if TYPE_CHECKING:
+    from collections import UserDict
     from typing import Any, Callable
 
     from ase.atoms import Atoms
@@ -370,7 +371,7 @@ def grid_phonon_flow(
 
     @subflow
     def _grid_phonon_subflow(
-        ph_input_data: dict | None,
+        ph_input_data: UserDict | None,
         ph_init_job_results: RunSchema,
         ph_job: Job,
         nblocks: int = 1,
@@ -420,6 +421,7 @@ def grid_phonon_flow(
 
         return grid_results
 
+    job_params = job_params or {}
     default_job_params = {
         "relax_job": {
             "input_data": {

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -4,7 +4,7 @@ Custom types used throughout quacc.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING
 
 
 class DefaultSetting:
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from pymatgen.core.structure import Molecule, Structure
     from pymatgen.entries.computed_entries import ComputedEntry
     from pymatgen.io.vasp.inputs import Incar, Kpoints, Poscar, Potcar
+    from typing_extensions import NotRequired, TypedDict
 
     # ----------- File handling -----------
 

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -4,7 +4,7 @@ Custom types used throughout quacc.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 
 class DefaultSetting:
@@ -759,6 +759,24 @@ if TYPE_CHECKING:
         """Type hint associated with VASP relaxations run via ASE"""
 
     # ----------- Recipe (Espresso) type hints -----------
+    class SystemData(TypedDict):
+        occupations: str
+        smearing: str
+        degauss: float
+
+    class ElectronsData(TypedDict):
+        conv_thr: float
+        mixing_mode: str
+        mixing_beta: float
+
+    class InputData(TypedDict):
+        system: SystemData
+        electrons: ElectronsData
+        control: NotRequired[dict[str, Any]]
+
+    class BaseSet(TypedDict):
+        input_data: InputData
+        kspacing: float
 
     class EspressoBandsSchema(TypedDict, total=False):
         bands_pw: RunSchema

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -775,7 +775,7 @@ if TYPE_CHECKING:
         electrons: ElectronsData
         control: NotRequired[dict[str, Any]]
 
-    class BaseSet(TypedDict):
+    class EspressoBaseSet(TypedDict):
         input_data: InputData
         kspacing: float
 


### PR DESCRIPTION
## Summary of Changes

Address MyPy type-checking errors in the espresso recipes module.
Ref: https://github.com/Quantum-Accelerators/quacc/issues/782.
### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [ ] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

### Notes

- Before contributing for the first time, read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines).
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
