### PR TITLE
Bugfix/espresso nscf kspacing

### DIFF
--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -362,7 +362,10 @@ def non_scf_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    calc_defaults = {"input_data": {"control": {"calculation": "nscf"}}, "kspacing": 0.033}
+    calc_defaults = {
+        "input_data": {"control": {"calculation": "nscf"}},
+        "kspacing": 0.033,
+    }
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -13,7 +13,7 @@ from quacc.recipes.espresso._base import run_and_summarize, run_and_summarize_op
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
-    from src.quacc.types import EspressoBaseSet
+    from quacc.types import EspressoBaseSet
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
@@ -362,7 +362,10 @@ def non_scf_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    calc_defaults = {"input_data": {"control": {"calculation": "nscf"}}}
+    is_metal = check_is_metal(atoms)
+
+    calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
+    calc_defaults["input_data"]["control"] = {"calculation": "nscf"}
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -13,7 +13,7 @@ from quacc.recipes.espresso._base import run_and_summarize, run_and_summarize_op
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
-    from quacc.types import EspressoBaseSet
+    from src.quacc.types import EspressoBaseSet
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
 
@@ -362,10 +362,7 @@ def non_scf_job(
         Dictionary of results from [quacc.schemas.ase.summarize_run][].
         See the type-hint for the data structure.
     """
-    is_metal = check_is_metal(atoms)
-
-    calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
-    calc_defaults["input_data"]["control"] = {"calculation": "nscf"}
+    calc_defaults = {"input_data": {"control": {"calculation": "nscf"}}, "kspacing": 0.033}
 
     return run_and_summarize(
         atoms,

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -394,6 +394,7 @@ def test_non_scf_job(tmp_path, monkeypatch):
     new_input_data = results["parameters"]["input_data"]
     assert new_input_data["system"]["ecutwfc"] == 30.0
     assert new_input_data["system"]["ecutrho"] == 240.0
+    assert results["parameters"].get("kspacing") == 0.033
     assert results["parameters"].get("kpts") is None
 
 

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -394,7 +394,6 @@ def test_non_scf_job(tmp_path, monkeypatch):
     new_input_data = results["parameters"]["input_data"]
     assert new_input_data["system"]["ecutwfc"] == 30.0
     assert new_input_data["system"]["ecutrho"] == 240.0
-    assert "kspacing" not in results["parameters"]
     assert results["parameters"].get("kpts") is None
 
 

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -394,7 +394,7 @@ def test_non_scf_job(tmp_path, monkeypatch):
     new_input_data = results["parameters"]["input_data"]
     assert new_input_data["system"]["ecutwfc"] == 30.0
     assert new_input_data["system"]["ecutrho"] == 240.0
-    assert results["parameters"].get("kspacing") == 0.033
+    assert results["parameters"]["kspacing"] == 0.033
     assert results["parameters"].get("kpts") is None
 
 


### PR DESCRIPTION
## Summary of Changes

Added kspacing to espresso `non_scf_job()` `calc_defaults` to prevent crashes. Previously, nscf jobs (with no other k-point specification via `**calc_kwargs`) would fail to start without this addition. 

N.B. An extra unit test failure is recorded by `pytest tests/core/recipes/espresso_recipes/test_core.py` with `assert "kspacing" not in results["parameters"]`. @Andrew-S-Rosen not sure if this should exist in the test in the first place, given that jobs crash without it.

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

### Notes

- Before contributing for the first time, read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines).
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
