### PR TITLE
Fix ValueError when checking kpts in Espresso module

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -473,5 +473,5 @@ class Espresso(GenericFileIOCalculator):
         else:
             self.user_calc_params = self.kwargs
 
-        if self.user_calc_params.get("kpts") and self.user_calc_params.get("kspacing"):
+        if self.user_calc_params.get("kpts") is not None and self.user_calc_params.get("kspacing"):
             raise ValueError("Cannot specify both kpts and kspacing.")

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -473,5 +473,7 @@ class Espresso(GenericFileIOCalculator):
         else:
             self.user_calc_params = self.kwargs
 
-        if self.user_calc_params.get("kpts") is not None and self.user_calc_params.get("kspacing"):
+        if self.user_calc_params.get("kpts") is not None and self.user_calc_params.get(
+            "kspacing"
+        ):
             raise ValueError("Cannot specify both kpts and kspacing.")


### PR DESCRIPTION
## Summary of Changes

This pull request fixes a `ValueError` that occurs when checking the `kpts` parameters in `_cleanup_params()` of the Espresso module. Previously, using a numpy array for `kpts` resulted in an ambiguous truth value error. Numpy array input is accepted as a form of manual kpoint specification per [ASE documentation](https://wiki.fysik.dtu.dk/ase/ase/calculators/espresso.html).
@Andrew-S-Rosen please kindly review.

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [N/A] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

### Notes

- Before contributing for the first time, read the ["Guidelines" section](https://quantum-accelerators.github.io/quacc/dev/contributing.html#guidelines).
- If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
- When your code is ready for review, ping one of the [active maintainers](https://quantum-accelerators.github.io/quacc/about/contributors.html#active-maintainers).
