### PR TITLE
Provider a proper output schema for `grid_phonon_flow`

### DIFF
--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
 
     from quacc.types import (
+        EspressoGridPhononSchema,
         EspressoPhononDosSchema,
         Filenames,
         RunSchema,
@@ -290,7 +291,7 @@ def grid_phonon_flow(
     nblocks: int = 1,
     job_params: dict[str, Any] | None = None,
     job_decorators: dict[str, Callable | None] | None = None,
-) -> RunSchema:
+) -> EspressoGridPhononSchema:
     """
     This function performs grid parallelization of a ph.x calculation. Each
     representation of each q-point is calculated in a separate job, allowing for
@@ -351,9 +352,8 @@ def grid_phonon_flow(
 
     Returns
     -------
-    RunSchema
-        Dictionary of results from [quacc.schemas.ase.Summarize.run][].
-        See the type-hint for the data structure.
+    EspressoGridPhononSchema
+        Dictionary of results.
     """
 
     @subflow
@@ -459,7 +459,14 @@ def grid_phonon_flow(
         job_params["ph_job"]["input_data"], ph_init_job_results, ph_job, nblocks=nblocks
     )
 
-    return _ph_recover_subflow(grid_results)
+    ph_recover_subflow_results = _ph_recover_subflow(grid_results)
+
+    return {
+        "relax_job": pw_job_results,
+        "ph_init_job": ph_init_job_results,
+        "grid_phonon_subflow": grid_results,
+        "ph_recover_subflow": ph_recover_subflow_results,
+    }
 
 
 @job

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -813,6 +813,12 @@ if TYPE_CHECKING:
         q2r_job: RunSchema
         matdyn_job: RunSchema
 
+    class EspressoGridPhononSchema(TypedDict):
+        relax_job: RunSchema
+        ph_init_job: RunSchema
+        grid_phonon_subflow: list[RunSchema]
+        ph_recover_subflow: RunSchema
+
     # ----------- Recipe (NewtonNet) type hints -----------
 
     class NewtonNetTSSchema(OptSchema):

--- a/tests/dask/test_espresso_recipes.py
+++ b/tests/dask/test_espresso_recipes.py
@@ -64,7 +64,7 @@ def test_phonon_grid_single(tmp_path, monkeypatch):
     }
 
     future = grid_phonon_flow(atoms, job_params=job_params)
-    grid_results = client.compute(future).result()
+    grid_results = client.compute(future).result()[-1]
     sections = [
         "atoms",
         "eqpoints",
@@ -116,7 +116,7 @@ def test_phonon_grid_single_gamma(tmp_path, monkeypatch):
     }
 
     future = grid_phonon_flow(atoms, job_params=job_params)
-    grid_results = client.compute(future).result()
+    grid_results = client.compute(future).result()[-1]
     sections = [
         "atoms",
         "eqpoints",
@@ -159,7 +159,7 @@ def test_phonon_grid_qplot(tmp_path, monkeypatch):
     }
 
     future = grid_phonon_flow(atoms, job_params=job_params)
-    grid_results = client.compute(future).result()
+    grid_results = client.compute(future).result()[-1]
 
     sections = [
         "atoms",
@@ -212,7 +212,7 @@ def test_phonon_grid_disp(tmp_path, monkeypatch):
     }
 
     future = grid_phonon_flow(atoms, job_params=job_params)
-    grid_results = client.compute(future).result()
+    grid_results = client.compute(future).result()[-1]
 
     sections = [
         "atoms",
@@ -254,7 +254,7 @@ def test_phonon_grid_v2(tmp_path, monkeypatch):
     }
 
     future = grid_phonon_flow(atoms, job_params=job_params, nblocks=3)
-    grid_results = client.compute(future).result()
+    grid_results = client.compute(future).result()[-1]
 
     sections = [
         "atoms",


### PR DESCRIPTION
## Summary of Changes

This PR seeks to standardize the Espresso `grid_phonon_flow` by returning a dictionary of results where each key is each job (or subflow) rather than just the results from the final step.