### PR TITLE
Add `additional_fields` to all `@job`s

### DIFF
--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -8,7 +8,7 @@ from quacc import job
 from quacc.recipes.dftb._base import run_and_summarize
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Any, Literal
 
     from ase.atoms import Atoms
 
@@ -21,6 +21,7 @@ def static_job(
     method: Literal["GFN1-xTB", "GFN2-xTB", "DFTB"] = "GFN2-xTB",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     kpts: tuple | list[tuple] | dict | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -36,6 +37,8 @@ def static_job(
         k-point grid to use.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator that would override the
         calculator defaults. Set a value to `quacc.Remove` to remove a pre-existing key
@@ -60,7 +63,7 @@ def static_job(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "DFTB+ Static"},
+        additional_fields={"name": "DFTB+ Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -72,6 +75,7 @@ def relax_job(
     kpts: tuple | list[tuple] | dict | None = None,
     relax_cell: bool = False,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -90,6 +94,8 @@ def relax_job(
         positions.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator that would override the
         calculator defaults. Set a value to `quacc.Remove` to remove a pre-existing key
@@ -118,6 +124,6 @@ def relax_job(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "DFTB+ Relax"},
+        additional_fields={"name": "DFTB+ Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -15,6 +15,8 @@ from quacc.runners.ase import Runner
 from quacc.schemas.ase import Summarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, OptParams, OptSchema, RunSchema, SourceDirectory
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -35,6 +38,8 @@ def static_job(
         Atoms object
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the EMT calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -49,7 +54,9 @@ def static_job(
     calc = EMT(**calc_kwargs)
     final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
 
-    return Summarize(additional_fields={"name": "EMT Static"}).run(final_atoms, atoms)
+    return Summarize(
+        additional_fields={"name": "EMT Static"} | (additional_fields or {})
+    ).run(final_atoms, atoms)
 
 
 @job
@@ -58,6 +65,7 @@ def relax_job(
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -74,6 +82,8 @@ def relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the EMT calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -92,4 +102,6 @@ def relax_job(
         relax_cell=relax_cell, **opt_params
     )
 
-    return Summarize(additional_fields={"name": "EMT Relax"}).opt(dyn)
+    return Summarize(
+        additional_fields={"name": "EMT Relax"} | (additional_fields or {})
+    ).opt(dyn)

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -16,6 +16,8 @@ from quacc.schemas.ase import Summarize
 from quacc.utils.dicts import recursive_dict_merge
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
@@ -32,6 +34,7 @@ def md_job(
     pressure_bar: float | None = None,
     md_params: MDParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> DynSchema:
     """
@@ -56,6 +59,8 @@ def md_job(
         keys, refer to [quacc.runners.ase.Runner.run_md][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the EMT calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -80,4 +85,6 @@ def md_job(
     calc = EMT(**calc_kwargs)
     dyn = Runner(atoms, calc, copy_files=copy_files).run_md(dynamics, **md_params)
 
-    return Summarize(additional_fields={"name": "EMT MD"}).md(dyn)
+    return Summarize(
+        additional_fields={"name": "EMT MD"} | (additional_fields or {})
+    ).md(dyn)

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -39,6 +39,7 @@ def bands_pw_job(
     line_density: float = 20,
     force_gamma: bool = True,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -78,6 +79,8 @@ def bands_pw_job(
     test_run
         If True, a test run is performed to check that the calculation input_data is correct or
         to generate some files/info if needed.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -108,7 +111,7 @@ def bands_pw_job(
         template=EspressoTemplate("pw", test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "pw.x bands"},
+        additional_fields={"name": "pw.x bands"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -123,6 +126,7 @@ def bands_pp_job(
     ) = None,
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -148,6 +152,8 @@ def bands_pp_job(
     test_run
         If True, a test run is performed to check that the calculation input_data is correct or
         to generate some files/info if needed.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -163,7 +169,8 @@ def bands_pp_job(
         template=EspressoTemplate("bands", test_run=test_run, outdir=prev_outdir),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "bands.x post-processing"},
+        additional_fields={"name": "bands.x post-processing"}
+        | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -178,6 +185,7 @@ def fermi_surface_job(
     ) = None,
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -202,6 +210,8 @@ def fermi_surface_job(
     test_run
         If True, a test run is performed to check that the calculation input_data is correct or
         to generate some files/info if needed.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -217,7 +227,7 @@ def fermi_surface_job(
         template=EspressoTemplate("fs", test_run=test_run, outdir=prev_outdir),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "fs.x fermi_surface"},
+        additional_fields={"name": "fs.x fermi_surface"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -12,6 +12,8 @@ from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
     from src.quacc.types import EspressoBaseSet
 
@@ -47,6 +49,7 @@ def static_job(
         | None
     ) = None,
     prev_outdir: SourceDirectory | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -73,6 +76,8 @@ def static_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -84,9 +89,7 @@ def static_job(
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
-    is_metal = check_is_metal(atoms)
-
-    calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
+    calc_defaults = BASE_SET_METAL if check_is_metal(atoms) else BASE_SET_NON_METAL
     calc_defaults["input_data"]["control"] = {"calculation": "scf"}
 
     return run_and_summarize(
@@ -95,7 +98,7 @@ def static_job(
         template=EspressoTemplate("pw", test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "pw.x Static"},
+        additional_fields={"name": "pw.x Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -113,6 +116,7 @@ def relax_job(
         | None
     ) = None,
     prev_outdir: SourceDirectory | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -141,6 +145,8 @@ def relax_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -152,9 +158,7 @@ def relax_job(
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
-    is_metal = check_is_metal(atoms)
-
-    calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
+    calc_defaults = BASE_SET_METAL if check_is_metal(atoms) else BASE_SET_NON_METAL
     calc_defaults["input_data"]["control"] = {
         "calculation": "vc-relax" if relax_cell else "relax"
     }
@@ -165,7 +169,7 @@ def relax_job(
         template=EspressoTemplate("pw", test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "pw.x Relax"},
+        additional_fields={"name": "pw.x Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -184,6 +188,7 @@ def ase_relax_job(
         | None
     ) = None,
     prev_outdir: SourceDirectory | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -217,6 +222,8 @@ def ase_relax_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -228,9 +235,7 @@ def ase_relax_job(
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
-    is_metal = check_is_metal(atoms)
-
-    calc_defaults = BASE_SET_METAL if is_metal else BASE_SET_NON_METAL
+    calc_defaults = BASE_SET_METAL if check_is_metal(atoms) else BASE_SET_NON_METAL
     calc_defaults["input_data"]["control"] = {
         "calculation": "scf",
         "tstress": relax_cell,
@@ -247,7 +252,7 @@ def ase_relax_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "pw.x ExternalRelax"},
+        additional_fields={"name": "pw.x ExternalRelax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -262,6 +267,7 @@ def post_processing_job(
     ) = None,
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -282,6 +288,11 @@ def post_processing_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    test_run
+        If True, a test run is performed to check that the calculation input_data is correct or
+        to generate some files/info if needed.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -308,7 +319,7 @@ def post_processing_job(
         template=EspressoTemplate("pp", test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "pp.x post-processing"},
+        additional_fields={"name": "pp.x post-processing"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -325,6 +336,7 @@ def non_scf_job(
     prev_outdir: SourceDirectory | None = None,
     preset: str | None = "sssp_1.3.0_pbe_efficiency",
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -351,6 +363,8 @@ def non_scf_job(
     test_run
         If True, a test run is performed to check that the calculation input_data is correct or
         to generate some files/info if needed.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -373,6 +387,6 @@ def non_scf_job(
         template=EspressoTemplate("pw", test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "pw.x Non SCF"},
+        additional_fields={"name": "pw.x Non SCF"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -35,6 +35,7 @@ def dos_job(
     ) = None,
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -55,6 +56,11 @@ def dos_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    test_run
+        If True, the calculation will be run in test mode. This is useful for quickly
+        checking if the calculation will run without errors.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -70,7 +76,8 @@ def dos_job(
         template=EspressoTemplate("dos", test_run=test_run, outdir=prev_outdir),
         calc_defaults=None,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "dos.x Density-of-States"},
+        additional_fields={"name": "dos.x Density-of-States"}
+        | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -85,6 +92,7 @@ def projwfc_job(
     ) = None,
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -105,6 +113,11 @@ def projwfc_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    test_run
+        If True, the calculation will be run in test mode. This is useful for quickly
+        checking if the calculation will run without errors.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -120,7 +133,8 @@ def projwfc_job(
         template=EspressoTemplate("projwfc", test_run=test_run, outdir=prev_outdir),
         calc_defaults=None,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "projwfc.x Projects-wavefunctions"},
+        additional_fields={"name": "projwfc.x Projects-wavefunctions"}
+        | (additional_fields or {}),
         copy_files=copy_files,
     )
 

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -44,6 +44,7 @@ def phonon_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     use_phcg: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -85,6 +86,8 @@ def phonon_job(
         If True, the calculation is performed using the `phcg.x` code which uses a faster algorithm.
         It can be used only if you sample the Brillouin Zone at Gamma and you only need the phonon
         modes at Gamma (molecules typically). It cannot be used with spin-polarization, USPP and PAW.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -96,6 +99,7 @@ def phonon_job(
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
+    binary = "phcg" if use_phcg else "ph"
     calc_defaults = {
         "input_data": {
             "inputph": {"tr2_ph": 1e-12, "alpha_mix(1)": 0.1, "verbosity": "high"}
@@ -103,13 +107,11 @@ def phonon_job(
         "qpts": (0, 0, 0),
     }
 
-    binary = "phcg" if use_phcg else "ph"
-
     return run_and_summarize(
         template=EspressoTemplate(binary, test_run=test_run, outdir=prev_outdir),
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": f"{binary}.x Phonon"},
+        additional_fields={"name": f"{binary}.x Phonon"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -119,6 +121,7 @@ def q2r_job(
     copy_files: (
         SourceDirectory | list[SourceDirectory] | dict[SourceDirectory, Filenames]
     ),
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -137,6 +140,8 @@ def q2r_job(
         which files have to be copied over by looking at the binary and `input_data`.
         If a dict is provided, the mode is manual, keys are source directories and values
         are relative path to files or directories to copy. Glob patterns are supported.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -152,7 +157,7 @@ def q2r_job(
         template=EspressoTemplate("q2r"),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "q2r.x Phonon"},
+        additional_fields={"name": "q2r.x Phonon"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -162,6 +167,7 @@ def matdyn_job(
     copy_files: (
         SourceDirectory | list[SourceDirectory] | dict[SourceDirectory, Filenames]
     ),
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -181,6 +187,8 @@ def matdyn_job(
         which files have to be copied over by looking at the binary and `input_data`.
         If a dict is provided, the mode is manual, keys are source directories and values
         are relative path to files or directories to copy. Glob patterns are supported.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -196,7 +204,7 @@ def matdyn_job(
         template=EspressoTemplate("matdyn"),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "matdyn Phonon"},
+        additional_fields={"name": "matdyn.x Phonon"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -503,6 +511,7 @@ def dvscf_q2r_job(
         | None
     ) = None,
     prev_outdir: SourceDirectory | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -548,6 +557,8 @@ def dvscf_q2r_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -563,7 +574,7 @@ def dvscf_q2r_job(
         template=EspressoTemplate("dvscf_q2r", outdir=prev_outdir),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "dvscf_q2r Phonon"},
+        additional_fields={"name": "dvscf_q2r Phonon"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -577,6 +588,7 @@ def postahc_job(
         | None
     ) = None,
     prev_outdir: SourceDirectory | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -607,6 +619,8 @@ def postahc_job(
         The output directory of a previous calculation. If provided, Quantum Espresso
         will directly read the necessary files from this directory, eliminating the need
         to manually copy files. The directory will be ungzipped if necessary.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the Espresso calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. See the docstring of
@@ -622,6 +636,6 @@ def postahc_job(
         template=EspressoTemplate("postahc", outdir=prev_outdir),
         calc_defaults={},
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "postahc Phonon"},
+        additional_fields={"name": "postahc Phonon"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -10,6 +10,8 @@ from quacc import job
 from quacc.recipes.gaussian._base import run_and_summarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
@@ -23,6 +25,7 @@ def static_job(
     xc: str = "wb97xd",
     basis: str = "def2tzvp",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -42,6 +45,8 @@ def static_job(
         Basis set
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Gaussian calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -74,7 +79,7 @@ def static_job(
         spin_multiplicity=spin_multiplicity,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "Gaussian Static"},
+        additional_fields={"name": "Gaussian Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -88,6 +93,7 @@ def relax_job(
     basis: str = "def2tzvp",
     freq: bool = False,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -109,6 +115,8 @@ def relax_job(
         If a frequency calculation should be carried out.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results
     **calc_kwargs
         Custom kwargs for the Gaussian calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -143,6 +151,6 @@ def relax_job(
         spin_multiplicity=spin_multiplicity,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "Gaussian Relax"},
+        additional_fields={"name": "Gaussian Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/gulp/core.py
+++ b/src/quacc/recipes/gulp/core.py
@@ -8,6 +8,8 @@ from quacc import job
 from quacc.recipes.gulp._base import run_and_summarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
@@ -21,6 +23,7 @@ def static_job(
     options: list[str] | None = None,
     library: str | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -43,6 +46,8 @@ def static_job(
         Filename of the potential library file, if required.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -60,7 +65,7 @@ def static_job(
         option_defaults=option_defaults,
         keyword_swaps=keywords,
         option_swaps=options,
-        additional_fields={"name": "GULP Static"},
+        additional_fields={"name": "GULP Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -74,6 +79,7 @@ def relax_job(
     options: list[str] | None = None,
     library: str | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> RunSchema:
     """
     Carry out a structure relaxation.
@@ -98,6 +104,8 @@ def relax_job(
         Filename of the potential library file, if required.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -118,6 +126,6 @@ def relax_job(
         option_defaults=option_defaults,
         keyword_swaps=keywords,
         option_swaps=options,
-        additional_fields={"name": "GULP Relax"},
+        additional_fields={"name": "GULP Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -15,6 +15,8 @@ from quacc.runners.ase import Runner
 from quacc.schemas.ase import Summarize, VibSummarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import (
@@ -32,6 +34,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -57,7 +60,9 @@ def static_job(
     calc = LennardJones(**calc_kwargs)
     final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
 
-    return Summarize(additional_fields={"name": "LJ Static"}).run(final_atoms, atoms)
+    return Summarize(
+        additional_fields={"name": "LJ Static"} | (additional_fields or {})
+    ).run(final_atoms, atoms)
 
 
 @job
@@ -65,6 +70,7 @@ def relax_job(
     atoms: Atoms,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -79,6 +85,8 @@ def relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the LJ calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -95,7 +103,9 @@ def relax_job(
     calc = LennardJones(**calc_kwargs)
     dyn = Runner(atoms, calc, copy_files=copy_files).run_opt(**opt_params)
 
-    return Summarize(additional_fields={"name": "LJ Relax"}).opt(dyn)
+    return Summarize(
+        additional_fields={"name": "LJ Relax"} | (additional_fields or {})
+    ).opt(dyn)
 
 
 @job
@@ -106,6 +116,7 @@ def freq_job(
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VibThermoSchema:
     """
@@ -125,6 +136,8 @@ def freq_job(
         Dictionary of kwargs for the [ase.vibrations.Vibrations][] class.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Dictionary of custom kwargs for the LJ calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -141,7 +154,9 @@ def freq_job(
     vib = Runner(atoms, calc, copy_files=copy_files).run_vib(vib_kwargs=vib_kwargs)
 
     return VibSummarize(
-        vib, additional_fields={"name": "LJ Frequency and Thermo"}
+        vib,
+        additional_fields={"name": "LJ Frequency and Thermo"}
+        | (additional_fields or {}),
     ).vib_and_thermo(
         "ideal_gas", energy=energy, temperature=temperature, pressure=pressure
     )

--- a/src/quacc/recipes/newtonnet/core.py
+++ b/src/quacc/recipes/newtonnet/core.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -54,6 +55,8 @@ def static_job(
         Atoms object
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the NewtonNet calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -75,9 +78,9 @@ def static_job(
     calc = NewtonNet(**calc_flags)
     final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
 
-    return Summarize(additional_fields={"name": "NewtonNet Static"}).run(
-        final_atoms, atoms
-    )
+    return Summarize(
+        additional_fields={"name": "NewtonNet Static"} | (additional_fields or {})
+    ).run(final_atoms, atoms)
 
 
 @job
@@ -88,6 +91,7 @@ def relax_job(
     atoms: Atoms,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -102,6 +106,8 @@ def relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Dictionary of custom kwargs for the NewtonNet calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -127,7 +133,9 @@ def relax_job(
     dyn = Runner(atoms, calc, copy_files=copy_files).run_opt(**opt_flags)
 
     return _add_stdev_and_hess(
-        Summarize(additional_fields={"name": "NewtonNet Relax"}).opt(dyn)
+        Summarize(
+            additional_fields={"name": "NewtonNet Relax"} | (additional_fields or {})
+        ).opt(dyn)
     )
 
 
@@ -140,6 +148,7 @@ def freq_job(
     temperature: float = 298.15,
     pressure: float = 1.0,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VibThermoSchema:
     """
@@ -155,6 +164,8 @@ def freq_job(
         The pressure for the thermodynamic analysis.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the NewtonNet calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -176,9 +187,9 @@ def freq_job(
     calc = NewtonNet(**calc_flags)
     final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
 
-    summary = Summarize(additional_fields={"name": "NewtonNet Hessian"}).run(
-        final_atoms, atoms
-    )
+    summary = Summarize(
+        additional_fields={"name": "NewtonNet Frequency"} | (additional_fields or {})
+    ).run(final_atoms, atoms)
 
     vib = VibrationsData(final_atoms, summary["results"]["hessian"])
     return VibSummarize(

--- a/src/quacc/recipes/newtonnet/ts.py
+++ b/src/quacc/recipes/newtonnet/ts.py
@@ -47,6 +47,7 @@ def ts_job(
     run_freq: bool = True,
     freq_job_kwargs: dict[str, Any] | None = None,
     opt_params: OptParams | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> NewtonNetTSSchema:
     """
@@ -65,6 +66,8 @@ def ts_job(
     opt_params
         Dictionary of custom kwargs for the optimization process. For a list
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Dictionary of custom kwargs for the NewtonNet calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -75,6 +78,7 @@ def ts_job(
     TSSchema
         Dictionary of results. See the type-hint for the data structure.
     """
+    additional_fields = additional_fields or {}
     freq_job_kwargs = freq_job_kwargs or {}
     settings = get_settings()
 
@@ -126,6 +130,7 @@ def irc_job(
     run_freq: bool = True,
     freq_job_kwargs: dict[str, Any] | None = None,
     opt_params: OptParams | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> NewtonNetIRCSchema:
     """
@@ -144,6 +149,8 @@ def irc_job(
     opt_params
         Dictionary of custom kwargs for the optimization process. For a list
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the NewtonNet calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -178,9 +185,10 @@ def irc_job(
     with change_settings({"CHECK_CONVERGENCE": False}):
         dyn = Runner(atoms, calc).run_opt(**opt_flags)
         opt_irc_summary = _add_stdev_and_hess(
-            Summarize(additional_fields={"name": f"NewtonNet IRC: {direction}"}).opt(
-                dyn
-            )
+            Summarize(
+                additional_fields={"name": f"NewtonNet IRC: {direction}"}
+                | (additional_fields or {})
+            ).opt(dyn)
         )
 
     # Run frequency job

--- a/src/quacc/recipes/onetep/core.py
+++ b/src/quacc/recipes/onetep/core.py
@@ -11,6 +11,8 @@ from quacc.recipes.onetep._base import run_and_summarize, run_and_summarize_opt
 from quacc.utils.dicts import recursive_dict_merge
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, OptParams, RunSchema, SourceDirectory
@@ -29,6 +31,7 @@ BASE_SET = {
 def static_job(
     atoms: Atoms,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -40,6 +43,8 @@ def static_job(
         The Atoms object.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the ONETEP calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -51,13 +56,11 @@ def static_job(
         Dictionary of results, specified in [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
-    calc_defaults = BASE_SET
-
     return run_and_summarize(
         atoms,
-        calc_defaults=calc_defaults,
+        calc_defaults=BASE_SET,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "ONETEP Static"},
+        additional_fields={"name": "ONETEP Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -68,6 +71,7 @@ def ase_relax_job(
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -86,6 +90,8 @@ def ase_relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Additional keyword arguments to pass to the ONETEP calculator.
 
@@ -108,6 +114,6 @@ def ase_relax_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "ONETEP ASE Relax"},
+        additional_fields={"name": "ONETEP ASE Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/orca/core.py
+++ b/src/quacc/recipes/orca/core.py
@@ -11,7 +11,7 @@ from quacc.atoms.core import perturb
 from quacc.recipes.orca._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Any, Literal
 
     from ase.atoms import Atoms
     from numpy.typing import NDArray
@@ -30,6 +30,7 @@ def static_job(
     orcablocks: list[str] | None = None,
     nprocs: int | Literal["max"] = "max",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -58,12 +59,15 @@ def static_job(
         Number of processors to use. Defaults to the number of physical cores.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
     RunSchema
         Dictionary of results
     """
+    additional_fields = {"name": "ORCA Static"} | (additional_fields or {})
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
     default_inputs = [xc, basis, "engrad", "normalprint"]
     default_blocks = [f"%pal nprocs {nprocs} end"]
@@ -76,7 +80,7 @@ def static_job(
         default_blocks=default_blocks,
         input_swaps=orcasimpleinput,
         block_swaps=orcablocks,
-        additional_fields={"name": "ORCA Static"},
+        additional_fields=additional_fields,
         copy_files=copy_files,
     )
 
@@ -93,6 +97,7 @@ def relax_job(
     orcablocks: list[str] | None = None,
     nprocs: int | Literal["max"] = "max",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> RunSchema:
     """
     Carry out a geometry optimization.
@@ -123,12 +128,15 @@ def relax_job(
         Number of processors to use. Defaults to the number of physical cores.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
     RunSchema
         Dictionary of results
     """
+    additional_fields = {"name": "ORCA Relax"} | (additional_fields or {})
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
 
     default_inputs = [xc, basis, "normalprint", "opt"]
@@ -145,7 +153,7 @@ def relax_job(
         default_blocks=default_blocks,
         input_swaps=orcasimpleinput,
         block_swaps=orcablocks,
-        additional_fields={"name": "ORCA Relax"},
+        additional_fields=additional_fields,
         copy_files=copy_files,
     )
 
@@ -162,6 +170,7 @@ def freq_job(
     orcablocks: list[str] | None = None,
     nprocs: int | Literal["max"] = "max",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> RunSchema:
     """
     Carry out a vibrational frequency analysis calculation.
@@ -192,6 +201,8 @@ def freq_job(
         Number of processors to use. Defaults to the number of physical cores.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -199,9 +210,7 @@ def freq_job(
         Dictionary of results
     """
     nprocs = psutil.cpu_count(logical=False) if nprocs == "max" else nprocs
-
     default_inputs = [xc, basis, "normalprint", "numfreq" if numerical else "freq"]
-
     default_blocks = [f"%pal nprocs {nprocs} end"]
 
     return run_and_summarize(
@@ -212,7 +221,8 @@ def freq_job(
         default_blocks=default_blocks,
         input_swaps=orcasimpleinput,
         block_swaps=orcablocks,
-        additional_fields={"name": "ORCA vibrational frequency analysis"},
+        additional_fields={"name": "ORCA Vibrational Frequency Analysis"}
+        | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -229,6 +239,7 @@ def ase_relax_job(
     opt_params: OptParams | None = None,
     nprocs: int | Literal["max"] = "max",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> OptSchema:
     """
     Carry out a geometry optimization.
@@ -253,10 +264,14 @@ def ase_relax_job(
         List of `orcablocks` swaps for the calculator. To remove entries
         from the defaults, put a `#` in front of the name. Refer to the
         [ase.calculators.orca.ORCA][] calculator for details on `orcablocks`.
+    opt_params
+        Dictionary of optimization parameters.
     nprocs
         Number of processors to use. Defaults to the number of physical cores.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -276,7 +291,7 @@ def ase_relax_job(
         input_swaps=orcasimpleinput,
         block_swaps=orcablocks,
         opt_params=opt_params,
-        additional_fields={"name": "ORCA ASE Relax"},
+        additional_fields={"name": "ORCA ASE Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -296,6 +311,7 @@ def ase_quasi_irc_job(
     opt_params: OptParams | None = None,
     nprocs: int | Literal["max"] = "max",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
 ) -> OptSchema:
     """
     Quasi-IRC to optimize a reaction endpoint from a transition-state with known vibrational frequency modes.
@@ -330,10 +346,14 @@ def ase_quasi_irc_job(
         List of `orcablocks` swaps for the calculator. To remove entries
         from the defaults, put a `#` in front of the name. Refer to the
         [ase.calculators.orca.ORCA][] calculator for details on `orcablocks`.
+    opt_params
+        Dictionary of optimization parameters.
     nprocs
         Number of processors to use. Defaults to the number of physical cores.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -355,6 +375,6 @@ def ase_quasi_irc_job(
         input_swaps=orcasimpleinput,
         block_swaps=orcablocks,
         opt_params=opt_params,
-        additional_fields={"name": "ORCA ASE Quasi-IRC optimization"},
+        additional_fields={"name": "ORCA ASE Quasi-IRC"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -13,6 +13,8 @@ from quacc.recipes.psi4._base import run_and_summarize
 has_psi4 = bool(find_spec("psi4"))
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
@@ -27,6 +29,7 @@ def static_job(
     method: str = "wb97x-v",
     basis: str = "def2-tzvp",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -46,6 +49,8 @@ def static_job(
         Basis set
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Psi4 calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -72,6 +77,6 @@ def static_job(
         spin_multiplicity=spin_multiplicity,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "Psi4 Static"},
+        additional_fields={"name": "Psi4 Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -15,6 +15,8 @@ if has_sella:
     from sella import Sella
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import Filenames, OptParams, OptSchema, RunSchema, SourceDirectory
@@ -41,6 +43,7 @@ def static_job(
     method: str | None = "wb97mv",
     basis: str | None = "def2-tzvpd",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -61,6 +64,8 @@ def static_job(
         Basis set.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator. Set a value to `quacc.Remove` to remove
         a pre-existing key entirely. See [quacc.calculators.qchem.qchem.QChem][] for more
@@ -82,7 +87,7 @@ def static_job(
         spin_multiplicity=spin_multiplicity,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "Q-Chem Static"},
+        additional_fields={"name": "Q-Chem Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -96,6 +101,7 @@ def relax_job(
     basis: str = "def2-svpd",
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -119,6 +125,8 @@ def relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator. Set a value to `quacc.Remove` to remove
         a pre-existing key entirely. See [quacc.calculators.qchem.qchem.QChem][] for more
@@ -143,7 +151,7 @@ def relax_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "Q-Chem Optimization"},
+        additional_fields={"name": "Q-Chem Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -156,6 +164,7 @@ def freq_job(
     method: str = "wb97mv",
     basis: str = "def2-svpd",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
     """
@@ -179,6 +188,8 @@ def freq_job(
         Custom kwargs for the calculator. Set a value to `quacc.Remove` to remove
         a pre-existing key entirely. See [quacc.calculators.qchem.qchem.QChem][] for more
         details.
+    additional_fields
+        Additional fields to add to the results dictionary.
 
     Returns
     -------
@@ -196,5 +207,5 @@ def freq_job(
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
         copy_files=copy_files,
-        additional_fields={"name": "Q-Chem Frequency"},
+        additional_fields={"name": "Q-Chem Frequency"} | (additional_fields or {}),
     )

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -18,7 +18,7 @@ if has_sella:
     from sella import IRC, Sella
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Any, Literal
 
     from ase.atoms import Atoms
     from numpy.typing import NDArray
@@ -36,6 +36,7 @@ def ts_job(
     basis: str = "def2-svpd",
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -86,7 +87,7 @@ def ts_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "Q-Chem TS"},
+        additional_fields={"name": "Q-Chem TS"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -102,6 +103,7 @@ def irc_job(
     basis: str = "def2-svpd",
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -127,6 +129,8 @@ def irc_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator. Set a value to `quacc.Remove` to remove
         a pre-existing key entirely. See [quacc.calculators.qchem.qchem.QChem][] for more
@@ -156,7 +160,7 @@ def irc_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "Q-Chem IRC"},
+        additional_fields={"name": "Q-Chem IRC"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -174,6 +178,7 @@ def quasi_irc_job(
     basis: str = "def2-svpd",
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
     """
@@ -207,6 +212,8 @@ def quasi_irc_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the calculator. Set a value to `quacc.Remove` to remove
         a pre-existing key entirely. See [quacc.calculators.qchem.qchem.QChem][] for more
@@ -218,7 +225,6 @@ def quasi_irc_job(
     OptSchema
         Dictionary of results from [quacc.schemas.ase.Summarize.opt][]
     """
-
     calc_defaults = recursive_dict_merge(
         _BASE_SET, {"rem": {"job_type": "force", "method": method, "basis": basis}}
     )
@@ -234,6 +240,6 @@ def quasi_irc_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "Q-Chem Quasi-IRC perturbed optimization"},
+        additional_fields={"name": "Q-Chem Quasi-IRC"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -39,6 +39,7 @@ def static_job(
     atoms: Atoms,
     preset: str | None = "BulkSet",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
@@ -52,6 +53,8 @@ def static_job(
         Preset to use from `quacc.calculators.vasp.presets`.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -77,7 +80,7 @@ def static_job(
         preset=preset,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "VASP Static"},
+        additional_fields={"name": "VASP Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -88,6 +91,7 @@ def relax_job(
     preset: str | None = "BulkSet",
     relax_cell: bool = True,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
@@ -104,6 +108,8 @@ def relax_job(
         only the positions (ISIF = 2) should be updated.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -136,7 +142,7 @@ def relax_job(
         preset=preset,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "VASP Relax"},
+        additional_fields={"name": "VASP Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -204,6 +210,7 @@ def ase_relax_job(
     relax_cell: bool = True,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspASEOptSchema:
     """
@@ -223,6 +230,8 @@ def ase_relax_job(
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -248,7 +257,7 @@ def ase_relax_job(
         calc_swaps=calc_kwargs,
         opt_defaults=opt_defaults,
         opt_params=opt_params,
-        additional_fields={"name": "VASP ASE Relax"},
+        additional_fields={"name": "VASP ASE Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -263,6 +272,7 @@ def non_scf_job(
     uniform_kppvol: float = 100,
     line_kpt_density: float = 20,
     calculate_optics: bool = False,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
@@ -287,6 +297,8 @@ def non_scf_job(
         The k-point density for the line k-point mode.
     calculate_optics
         Whether to calculate optical properties.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -338,7 +350,7 @@ def non_scf_job(
         preset=preset,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "VASP Non-SCF"},
+        additional_fields={"name": "VASP Non-SCF"} | (additional_fields or {}),
         copy_files={prev_dir: ["CHGCAR*", "WAVECAR*"]},
     )
 

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -16,8 +16,6 @@ from quacc import change_settings, job
 from quacc.recipes.vasp._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from ase.atoms import Atoms
 
     from quacc.types import (
@@ -37,7 +35,6 @@ def qmof_relax_job(
     relax_cell: bool = True,
     run_prerelax: bool = True,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
-    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> QMOFRelaxSchema:
     """

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -16,6 +16,8 @@ from quacc import change_settings, job
 from quacc.recipes.vasp._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import (
@@ -35,6 +37,7 @@ def qmof_relax_job(
     relax_cell: bool = True,
     run_prerelax: bool = True,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> QMOFRelaxSchema:
     """

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -22,6 +22,7 @@ def static_job(
     atoms: Atoms,
     preset: str | None = "SlabSet",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
@@ -35,6 +36,8 @@ def static_job(
         Preset to use from `quacc.calculators.vasp.presets`.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -62,7 +65,7 @@ def static_job(
         preset=preset,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "VASP Slab Static"},
+        additional_fields={"name": "VASP Slab Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 
@@ -72,6 +75,7 @@ def relax_job(
     atoms: Atoms,
     preset: str | None = "SlabSet",
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+    additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
@@ -85,6 +89,8 @@ def relax_job(
         Preset to use from `quacc.calculators.vasp.presets`.
     copy_files
         Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to
         `None` to remove a pre-existing key entirely. For a list of available
@@ -112,7 +118,7 @@ def relax_job(
         preset=preset,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "VASP Slab Relax"},
+        additional_fields={"name": "VASP Slab Relax"} | (additional_fields or {}),
         copy_files=copy_files,
     )
 


### PR DESCRIPTION
## Summary of Changes

This PR addresses the request in https://github.com/Quantum-Accelerators/quacc/issues/2399 to have an `additional_fields` keyword argument for all `@job`s in quacc. Will not merge without input from @tomdemeyere.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
