### PR TITLE
Raise a custom `JobFailure` error when a job fails

### DIFF
--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -108,22 +108,30 @@ class JobFailure(Exception):
         The directory where the calculations can be found.
     """
 
-    def __init__(self, message: str, directory: Path | str) -> None:
+    def __init__(
+        self,
+        directory: Path | str,
+        parent_error: Exception | None = None,
+        message: str = "Calculation failed!",
+    ) -> None:
         """
         Initialize the JobFailure exception.
 
         Parameters
         ----------
-        message
-            The message to display when the exception is raised.
         directory
             The directory where the calculations can be found.
+        parent_error
+            The Exception that caused the job to fail.
+        message
+            The message to display when the exception is raised.
 
         Returns
         -------
         None
         """
         self.directory = Path(directory)
+        self.parent_error = parent_error
         super().__init__(message)
 
 

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 from importlib.metadata import version
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ase.atoms import Atoms
@@ -33,6 +34,7 @@ __all__ = [
     "Remove",
     "get_settings",
     "QuaccDefault",
+    "JobFailure",
 ]
 
 
@@ -93,6 +95,37 @@ QuaccDefault = DefaultSetting()
 
 # Set logging info
 logging.basicConfig(level=logging.DEBUG if _settings.DEBUG else logging.INFO)
+
+
+# Custom exceptions
+class JobFailure(Exception):
+    """
+    A custom exception for handling/catching job failures.
+
+    Attributes
+    ----------
+    directory
+        The directory where the calculations can be found.
+    """
+
+    def __init__(self, message: str, directory: Path | str) -> None:
+        """
+        Initialize the JobFailure exception.
+
+        Parameters
+        ----------
+        message
+            The message to display when the exception is raised.
+        directory
+            The directory where the calculations can be found.
+
+        Returns
+        -------
+        None
+        """
+        self.directory = Path(directory)
+        super().__init__(message)
+
 
 # Monkeypatching for Prefect
 if _settings.WORKFLOW_ENGINE == "prefect":

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -106,6 +106,8 @@ class JobFailure(Exception):
     ----------
     directory
         The directory where the calculations can be found.
+    parent_error
+        The Exception that caused the job to fail.
     """
 
     def __init__(

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from monty.shutil import gzip_dir
 
-from quacc import get_settings
+from quacc import JobFailure, get_settings
 from quacc.utils.files import copy_decompress_files, make_unique_dir
 
 if TYPE_CHECKING:
@@ -155,8 +155,9 @@ def terminate(tmpdir: Path | str, exception: Exception) -> None:
 
     Raises
     -------
-    Exception
-        The exception that caused the calculation to fail.
+    JobFailure
+        The exception that caused the calculation to fail plus additional
+        metadata.
     """
     tmpdir = Path(tmpdir)
     settings = get_settings()
@@ -172,4 +173,4 @@ def terminate(tmpdir: Path | str, exception: Exception) -> None:
         old_symlink_path.unlink(missing_ok=True)
         symlink_path.symlink_to(job_failed_dir, target_is_directory=True)
 
-    raise exception
+    raise JobFailure(str(exception), job_failed_dir) from exception

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -173,4 +173,4 @@ def terminate(tmpdir: Path | str, exception: Exception) -> None:
         old_symlink_path.unlink(missing_ok=True)
         symlink_path.symlink_to(job_failed_dir, target_is_directory=True)
 
-    raise JobFailure(str(exception), job_failed_dir) from exception
+    raise JobFailure(job_failed_dir, message=msg, parent_error=exception) from exception

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -21,6 +21,7 @@ from ase.optimize import BFGS
 from monty.io import zopen
 from numpy.testing import assert_allclose, assert_array_equal
 
+from quacc import JobFailure
 from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso.core import (
     ase_relax_job,
@@ -220,13 +221,15 @@ def test_static_job_test_run(tmp_path, monkeypatch):
 
     assert Path("test.EXIT").exists()
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         static_job(
             atoms,
             pseudopotentials=pseudopotentials,
             input_data={"pseudo_dir": tmp_path},
             test_run=True,
         )
+    with pytest.raises(CalledProcessError) as err:
+        raise err.value.parent_error
 
 
 def test_relax_job(tmp_path, monkeypatch):

--- a/tests/core/recipes/espresso_recipes/test_core.py
+++ b/tests/core/recipes/espresso_recipes/test_core.py
@@ -228,7 +228,7 @@ def test_static_job_test_run(tmp_path, monkeypatch):
             input_data={"pseudo_dir": tmp_path},
             test_run=True,
         )
-    with pytest.raises(CalledProcessError) as err:
+    with pytest.raises(CalledProcessError):
         raise err.value.parent_error
 
 

--- a/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
+++ b/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
@@ -213,7 +213,8 @@ def test_static_job_v5(tmp_path, monkeypatch, test_atoms):
             qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
         )
     with pytest.raises(
-        ValueError, match="Only Sella should be used for static optimization"
+        ValueError,
+        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
     ):
         raise err.value.parent_error
 

--- a/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
+++ b/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
@@ -441,25 +441,15 @@ def test_ts_job_v3(monkeypatch, tmp_path, test_atoms):
 def test_ts_job_v4(tmp_path, monkeypatch, test_atoms):
     monkeypatch.chdir(tmp_path)
     with pytest.raises(JobFailure, match="Calculation failed!") as err:
-        ts_job(
-            test_atoms,
-            charge=0,
-            spin_multiplicity=1,
-            qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
-        )
+        ts_job(test_atoms, charge=0, spin_multiplicity=1)
     with pytest.raises(
-        ValueError,
-        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
+        ValueError, match="Only Sella should be used for TS optimization"
     ):
         raise err.value.parent_error
 
     with pytest.raises(JobFailure, match="Calculation failed!") as err:
         ts_job(
-            test_atoms,
-            charge=0,
-            spin_multiplicity=1,
-            qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
-            opt_params={"optimizer": FIRE},
+            test_atoms, charge=0, spin_multiplicity=1, opt_params={"optimizer": FIRE}
         )
     with pytest.raises(
         ValueError, match="Only Sella should be used for TS optimization"
@@ -538,34 +528,39 @@ def test_irc_job_v1(monkeypatch, tmp_path, test_atoms):
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
 def test_irc_job_v2(tmp_path, monkeypatch, test_atoms):
     monkeypatch.chdir(tmp_path)
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
+        irc_job(test_atoms, charge=0, spin_multiplicity=1, direction="straight")
     with pytest.raises(
         ValueError, match='direction must be one of "forward" or "reverse"!'
     ):
-        irc_job(test_atoms, charge=0, spin_multiplicity=1, direction="straight")
+        raise err.value.parent_error
 
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
+        irc_job(
+            test_atoms,
+            charge=0,
+            spin_multiplicity=1,
+            direction="forward",
+            qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
+        )
     with pytest.raises(
         ValueError,
         match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
     ):
+        raise err.value.parent_error
+
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         irc_job(
             test_atoms,
             charge=0,
             spin_multiplicity=1,
             direction="forward",
-            qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
+            opt_params={"optimizer": FIRE},
         )
-
     with pytest.raises(
         ValueError, match="Only Sella's IRC should be used for IRC optimization"
     ):
-        irc_job(
-            test_atoms,
-            charge=0,
-            spin_multiplicity=1,
-            direction="forward",
-            qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
-            opt_params={"optimizer": FIRE},
-        )
+        raise err.value.parent_error
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")

--- a/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
+++ b/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
@@ -18,6 +18,7 @@ from quacc.recipes.qchem.core import freq_job, relax_job, static_job
 from quacc.recipes.qchem.ts import irc_job, quasi_irc_job, ts_job
 
 has_sella = bool(find_spec("sella"))
+has_obabel = bool(find_spec("openbabel"))
 
 
 FILE_DIR = Path(__file__).parent
@@ -437,21 +438,16 @@ def test_ts_job_v3(monkeypatch, tmp_path, test_atoms):
     assert output["results"]["forces"][0][0] == pytest.approx(-1.3826311086011256)
 
 
-def test_ts_job_v4(test_atoms):
+@pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
+@pytest.mark.skipif(has_obabel is False, reason="Does not have openbabel")
+def test_ts_job_v4(monkeypatch, tmp_path, test_atoms):
+    monkeypatch.chdir(tmp_path)
     with pytest.raises(
         ValueError, match="Only Sella should be used for TS optimization"
     ):
         ts_job(
             test_atoms, charge=0, spin_multiplicity=1, opt_params={"optimizer": FIRE}
         )
-
-
-@pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
-def test_ts_job_v5(test_atoms):
-    with pytest.raises(
-        ValueError, match="Only Sella should be used for TS optimization"
-    ):
-        ts_job(test_atoms, charge=0, spin_multiplicity=1)
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")

--- a/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
+++ b/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
@@ -11,7 +11,7 @@ from ase.io import read
 from ase.optimize import FIRE
 from pymatgen.io.qchem.inputs import QCInput
 
-from quacc import _internally_set_settings
+from quacc import JobFailure, _internally_set_settings
 from quacc.atoms.core import check_charge_and_spin
 from quacc.calculators.qchem import QChem
 from quacc.recipes.qchem.core import freq_job, relax_job, static_job
@@ -205,16 +205,17 @@ def test_static_job_v4(monkeypatch, tmp_path, os_atoms):
 def test_static_job_v5(tmp_path, monkeypatch, test_atoms):
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(
-        ValueError,
-        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
-    ):
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         static_job(
             test_atoms,
             charge=0,
             spin_multiplicity=1,
             qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
         )
+    with pytest.raises(
+        ValueError, match="Only Sella should be used for static optimization"
+    ):
+        raise err.value.parent_error
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
@@ -308,16 +309,18 @@ def test_relax_job_v3(monkeypatch, tmp_path, test_atoms):
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
 def test_relax_job_v4(tmp_path, monkeypatch, test_atoms):
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(
-        ValueError,
-        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
-    ):
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         relax_job(
             test_atoms,
             charge=0,
             spin_multiplicity=1,
             qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
         )
+    with pytest.raises(
+        ValueError,
+        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
+    ):
+        raise err.value.parent_error
 
 
 def test_freq_job_v1(monkeypatch, tmp_path, test_atoms):
@@ -436,20 +439,20 @@ def test_ts_job_v3(monkeypatch, tmp_path, test_atoms):
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
 def test_ts_job_v4(tmp_path, monkeypatch, test_atoms):
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(
-        ValueError,
-        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
-    ):
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         ts_job(
             test_atoms,
             charge=0,
             spin_multiplicity=1,
             qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
         )
-
     with pytest.raises(
-        ValueError, match="Only Sella should be used for TS optimization"
+        ValueError,
+        match="Only one of PCM, ISOSVP, SMD, and CMIRSmay be used for solvation",
     ):
+        raise err.value.parent_error
+
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         ts_job(
             test_atoms,
             charge=0,
@@ -457,6 +460,10 @@ def test_ts_job_v4(tmp_path, monkeypatch, test_atoms):
             qchem_dict_set_params={"pcm_dielectric": "3.0", "smd_solvent": "water"},
             opt_params={"optimizer": FIRE},
         )
+    with pytest.raises(
+        ValueError, match="Only Sella should be used for TS optimization"
+    ):
+        raise err.value.parent_error
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")

--- a/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
+++ b/tests/core/recipes/qchem_recipes/mocked/test_qchem_recipes.py
@@ -437,24 +437,21 @@ def test_ts_job_v3(monkeypatch, tmp_path, test_atoms):
     assert output["results"]["forces"][0][0] == pytest.approx(-1.3826311086011256)
 
 
-@pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
-def test_ts_job_v4(tmp_path, monkeypatch, test_atoms):
-    monkeypatch.chdir(tmp_path)
-    with pytest.raises(JobFailure, match="Calculation failed!") as err:
-        ts_job(test_atoms, charge=0, spin_multiplicity=1)
+def test_ts_job_v4(test_atoms):
     with pytest.raises(
         ValueError, match="Only Sella should be used for TS optimization"
     ):
-        raise err.value.parent_error
-
-    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         ts_job(
             test_atoms, charge=0, spin_multiplicity=1, opt_params={"optimizer": FIRE}
         )
+
+
+@pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
+def test_ts_job_v5(test_atoms):
     with pytest.raises(
         ValueError, match="Only Sella should be used for TS optimization"
     ):
-        raise err.value.parent_error
+        ts_job(test_atoms, charge=0, spin_multiplicity=1)
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")
@@ -549,7 +546,9 @@ def test_irc_job_v2(tmp_path, monkeypatch, test_atoms):
     ):
         raise err.value.parent_error
 
-    with pytest.raises(JobFailure, match="Calculation failed!") as err:
+    with pytest.raises(
+        ValueError, match="Only Sella's IRC should be used for IRC optimization"
+    ):
         irc_job(
             test_atoms,
             charge=0,
@@ -557,10 +556,6 @@ def test_irc_job_v2(tmp_path, monkeypatch, test_atoms):
             direction="forward",
             opt_params={"optimizer": FIRE},
         )
-    with pytest.raises(
-        ValueError, match="Only Sella's IRC should be used for IRC optimization"
-    ):
-        raise err.value.parent_error
 
 
 @pytest.mark.skipif(has_sella is False, reason="Does not have Sella")

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -247,5 +247,5 @@ def test_fn_hook(tmp_path, monkeypatch):
 
     with pytest.raises(JobFailure, match="Calculation failed!") as err:
         Runner(bulk("Cu"), EMT()).run_opt(fn_hook=fn_hook)
-    with pytest.raises(RuntimeError, match="Test error"):
+    with pytest.raises(ValueError, match="Test error"):
         raise err.value.parent_error

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -15,7 +15,7 @@ from ase.io import read
 from ase.optimize import BFGS, BFGSLineSearch
 from ase.optimize.sciopt import SciPyFminBFGS
 
-from quacc import change_settings, get_settings
+from quacc import JobFailure, change_settings, get_settings
 from quacc.runners._base import BaseRunner
 from quacc.runners.ase import Runner
 
@@ -245,5 +245,7 @@ def test_fn_hook(tmp_path, monkeypatch):
         if dyn.atoms:
             raise ValueError("Test error")
 
-    with pytest.raises(ValueError, match="Test error"):
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         Runner(bulk("Cu"), EMT()).run_opt(fn_hook=fn_hook)
+    with pytest.raises(RuntimeError, match="Test error"):
+        raise err.value.parent_error

--- a/tests/core/runners/test_prep.py
+++ b/tests/core/runners/test_prep.py
@@ -7,7 +7,7 @@ import pytest
 from ase.build import bulk
 from ase.calculators.emt import EMT
 
-from quacc import change_settings, get_settings
+from quacc import JobFailure, change_settings, get_settings
 from quacc.runners.prep import calc_cleanup, calc_setup, terminate
 
 
@@ -177,7 +177,8 @@ def test_calc_cleanup(tmp_path, monkeypatch):
 def test_terminate(tmp_path):
     p = tmp_path / "tmp-quacc-1234"
     os.mkdir(p)
-    with pytest.raises(ValueError, match="moo"):
+    with pytest.raises(JobFailure, match="moo") as err:
         terminate(p, ValueError("moo"))
+    assert err.value.directory == tmp_path / "failed-quacc-1234"
     assert not p.exists()
     assert Path(tmp_path, "failed-quacc-1234").exists()

--- a/tests/core/runners/test_prep.py
+++ b/tests/core/runners/test_prep.py
@@ -179,8 +179,8 @@ def test_terminate(tmp_path):
     os.mkdir(p)
     with pytest.raises(JobFailure, match="Calculation failed!") as err:
         terminate(p, ValueError("moo"))
-    assert isinstance(err.value.parent_error, ValueError)
-    assert str(err.value.parent_error) == "moo"
+    with pytest.raises(ValueError, match="moo"):
+        raise err.value.parent_error
     assert err.value.directory == tmp_path / "failed-quacc-1234"
     assert not p.exists()
     assert Path(tmp_path, "failed-quacc-1234").exists()

--- a/tests/core/runners/test_prep.py
+++ b/tests/core/runners/test_prep.py
@@ -177,8 +177,10 @@ def test_calc_cleanup(tmp_path, monkeypatch):
 def test_terminate(tmp_path):
     p = tmp_path / "tmp-quacc-1234"
     os.mkdir(p)
-    with pytest.raises(JobFailure, match="moo") as err:
+    with pytest.raises(JobFailure, match="Calculation failed!") as err:
         terminate(p, ValueError("moo"))
+    assert isinstance(err.value.parent_error, ValueError)
+    assert str(err.value.parent_error) == "moo"
     assert err.value.directory == tmp_path / "failed-quacc-1234"
     assert not p.exists()
     assert Path(tmp_path, "failed-quacc-1234").exists()


### PR DESCRIPTION
## Summary of Changes

This PR seeks to close #2407 by raising a custom `JobFailure` exception when a job fails, which can be used to `try`/`except` calculations more easily. The `JobFailure` raises the parent ASE error but also has a `directory` attribute that can be easily accessed by the user without any need to sift through the log file. The directory info was already being logged, but now it's also present in the traceback. There is also a `parent_error` attribute to ensure the original exception is still accessible by the end user.

Pinging @tomdemeyere for review.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
