### PR TITLE
PARSL_MPI_PREFIX moved to the espresso calculator

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -419,9 +419,13 @@ class Espresso(GenericFileIOCalculator):
             .get("pseudo_dir", str(self._settings.ESPRESSO_PSEUDO))
         )
 
+        cmd_prefix = os.environ.get(
+            "PARSL_MPI_PREFIX", self._settings.ESPRESSO_PARALLEL_CMD[0]
+        )
+        cmd_suffix = self._settings.ESPRESSO_PARALLEL_CMD[1]
+
         profile = EspressoProfile(
-            f"{self._settings.ESPRESSO_PARALLEL_CMD[0]} {self._bin_path} {self._settings.ESPRESSO_PARALLEL_CMD[1]}",
-            self._pseudo_path,
+            f"{cmd_prefix} {self._bin_path} {cmd_suffix}", self._pseudo_path
         )
 
         super().__init__(

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -467,12 +467,9 @@ class QuaccSettings(BaseSettings):
         cls, v: Union[str, tuple[str, str]]
     ) -> tuple[str, str]:
         """Clean up Espresso parallel command."""
-        parsl_mpi_prefix = os.environ.get("PARSL_MPI_PREFIX")
 
         if isinstance(v, str):
             v = (v, "")
-        if parsl_mpi_prefix:
-            v = (parsl_mpi_prefix, v[1])
 
         return v
 


### PR DESCRIPTION
## Summary of Changes

As discussed in (https://github.com/Quantum-Accelerators/quacc/issues/2419) this is an attempt to fix the current issue with the 

## Expected behavior

Users can redecorate their job, adding the `parsl_resource_specification`, Parsl take these informations and define environment variables such as `PARSL_MPI_PREFIX`. If the users redecorate multiple jobs, different `PARSL_MPI_PREFIX` will be accessible on a per job basis.

### Example:

``` python
resource_specification_slow = {
    "num_nodes": 1,
    "ranks_per_node": 128,
    "num_ranks": 128,
    "launcher_options": "-vv --cpu-freq=2250000 --hint=nomultithread --distribution=block:block",
}
resource_specification_fast = {
    "num_nodes": 4,
    "ranks_per_node": 128,
    "num_ranks": 128 * 4,
    "launcher_options": "-vv --cpu-freq=2250000 --hint=nomultithread --distribution=block:block",
}

relax_job_slow = redecorate(
    relax_job, job(parsl_resource_specification=resource_specification_slow)
)
relax_job_fast = redecorate(
    relax_job, job(parsl_resource_specification=resource_specification_fast)
)
```
In this case, each job will have access to a different `PARSL_MPI_PREFIX` environment variable.

## The problem

Right now, the `ESPRESSO_PARALLEL_CMD` is modified in `settings.py` based on the `PARSL_MPI_PREFIX`, the problem is that this env variable is only defined within jobs. `ESPRESSO_PARALLEL_CMD` end up being defined before that, leading to wrong commands.

## The problem

One solution is to modify the command being lunched at the last moment inside the espresso calculator before the command is lunched. 

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [ ] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
