### PR TITLE
Add a setting to store the logger file to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fixed user setting of logger level
+- Fixed user setting of LOGGER level
 - Fixed a glob-based issue with `copy_decompress_files`
 
 ## [0.7.1]
@@ -457,7 +457,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Raised the default logger level from `WARNING` to `INFO`
+- Raised the default LOGGER level from `WARNING` to `INFO`
 
 ### Fixed
 

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -94,7 +94,10 @@ _settings = get_settings()
 QuaccDefault = DefaultSetting()
 
 # Set logging info
-logging.basicConfig(level=logging.DEBUG if _settings.DEBUG else logging.INFO)
+logging.basicConfig(
+    filename=_settings.LOG_FILENAME,
+    level=logging.getLevelNamesMapping()[_settings.LOG_LEVEL],
+)
 
 
 # Custom exceptions

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from importlib.metadata import version
-from logging import basicConfig, getLevelNamesMapping
+from logging import basicConfig, getLevelName
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -94,9 +94,7 @@ _settings = get_settings()
 QuaccDefault = DefaultSetting()
 
 # Set logging info
-basicConfig(
-    filename=_settings.LOG_FILENAME, level=getLevelNamesMapping()[_settings.LOG_LEVEL]
-)
+basicConfig(filename=_settings.LOG_FILENAME, level=getLevelName(_settings.LOG_LEVEL))
 
 
 # Custom exceptions

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import threading
 from importlib.metadata import version
+from logging import basicConfig, getLevelNamesMapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -94,9 +94,8 @@ _settings = get_settings()
 QuaccDefault = DefaultSetting()
 
 # Set logging info
-logging.basicConfig(
-    filename=_settings.LOG_FILENAME,
-    level=logging.getLevelNamesMapping()[_settings.LOG_LEVEL],
+basicConfig(
+    filename=_settings.LOG_FILENAME, level=getLevelNamesMapping()[_settings.LOG_LEVEL]
 )
 
 

--- a/src/quacc/atoms/core.py
+++ b/src/quacc/atoms/core.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 from copy import deepcopy
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ase.optimize.optimize import Dynamics
     from numpy.typing import NDArray
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def get_atoms_id(atoms: Atoms) -> str:

--- a/src/quacc/atoms/core.py
+++ b/src/quacc/atoms/core.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ase.optimize.optimize import Dynamics
     from numpy.typing import NDArray
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def get_atoms_id(atoms: Atoms) -> str:
@@ -213,7 +213,7 @@ def check_charge_and_spin(
             f"Charge of {mol.charge} and spin multiplicity of {mol.spin_multiplicity} is"
             " not possible for this molecule."
         )
-    logger.debug(
+    LOGGER.debug(
         f"Setting charge to {mol.charge} and spin multiplicity to {mol.spin_multiplicity}"
     )
 

--- a/src/quacc/atoms/slabs.py
+++ b/src/quacc/atoms/slabs.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from quacc.types import AdsSiteFinderKwargs, FindAdsSitesKwargs
 
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def flip_atoms(

--- a/src/quacc/atoms/slabs.py
+++ b/src/quacc/atoms/slabs.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from quacc.types import AdsSiteFinderKwargs, FindAdsSitesKwargs
 
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def flip_atoms(

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import re
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,7 +34,7 @@ from quacc.utils.files import load_yaml_calc, safe_decompress_dir
 if TYPE_CHECKING:
     from typing import Any
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 class EspressoTemplate(EspressoTemplate_):

--- a/src/quacc/calculators/espresso/utils.py
+++ b/src/quacc/calculators/espresso/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, SourceDirectory
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def get_pseudopotential_info(

--- a/src/quacc/calculators/qchem/params.py
+++ b/src/quacc/calculators/qchem/params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from pymatgen.io.ase import AseAtomsAdaptor
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from quacc.calculators.qchem.qchem import QChem
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def make_qc_input(qchem: QChem, atoms: Atoms) -> QCInput:

--- a/src/quacc/calculators/qchem/params.py
+++ b/src/quacc/calculators/qchem/params.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from quacc.calculators.qchem.qchem import QChem
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def make_qc_input(qchem: QChem, atoms: Atoms) -> QCInput:
@@ -154,11 +154,11 @@ def get_rem_swaps(rem: dict[str, Any], restart: bool = False) -> dict[str, Any]:
         rem dictionary with swaps
     """
     if restart and "scf_guess" not in rem:
-        logger.info("Copilot: Setting scf_guess in `rem` to 'read'")
+        LOGGER.info("Copilot: Setting scf_guess in `rem` to 'read'")
         rem["scf_guess"] = "read"
     if "max_scf_cycles" not in rem:
         rem["max_scf_cycles"] = 200 if rem.get("scf_algorithm") == "gdm" else 100
-        logger.info(
+        LOGGER.info(
             f"Copilot: Setting max_scf_cycles in `rem` to {rem['max_scf_cycles']}"
         )
 

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from importlib.util import find_spec
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     if has_atomate2:
         from atomate2.vasp.jobs.base import BaseVaspMaker
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def get_param_swaps(

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     if has_atomate2:
         from atomate2.vasp.jobs.base import BaseVaspMaker
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def get_param_swaps(
@@ -63,12 +63,12 @@ def get_param_swaps(
     if (
         not calc.int_params["lmaxmix"] or calc.int_params["lmaxmix"] < 6
     ) and max_Z > 56:
-        logger.info("Recommending LMAXMIX = 6 because you have f electrons.")
+        LOGGER.info("Recommending LMAXMIX = 6 because you have f electrons.")
         calc.set(lmaxmix=6)
     elif (
         not calc.int_params["lmaxmix"] or calc.int_params["lmaxmix"] < 4
     ) and max_Z > 20:
-        logger.info("Recommending LMAXMIX = 4 because you have d electrons.")
+        LOGGER.info("Recommending LMAXMIX = 4 because you have d electrons.")
         calc.set(lmaxmix=4)
 
     if (
@@ -78,7 +78,7 @@ def get_param_swaps(
         or calc.dict_params["ldau_luj"]
         or calc.string_params["metagga"]
     ) and not calc.bool_params["lasph"]:
-        logger.info(
+        LOGGER.info(
             "Recommending LASPH = True because you have a +U, vdW, meta-GGA, or hybrid calculation."
         )
         calc.set(lasph=True)
@@ -86,14 +86,14 @@ def get_param_swaps(
     if calc.string_params["metagga"] and (
         not calc.string_params["algo"] or calc.string_params["algo"].lower() != "all"
     ):
-        logger.info("Recommending ALGO = All because you have a meta-GGA calculation.")
+        LOGGER.info("Recommending ALGO = All because you have a meta-GGA calculation.")
         calc.set(algo="all")
 
     if calc.bool_params["lhfcalc"] and (
         not calc.string_params["algo"]
         or calc.string_params["algo"].lower() not in ["all", "damped", "normal"]
     ):
-        logger.info("Recommending ALGO = Normal because you have a hybrid calculation.")
+        LOGGER.info("Recommending ALGO = Normal because you have a hybrid calculation.")
         calc.set(algo="normal")
 
     if (
@@ -101,7 +101,7 @@ def get_param_swaps(
         and (calc.int_params["ismear"] and calc.int_params["ismear"] < 0)
         and (calc.int_params["nsw"] and calc.int_params["nsw"] > 0)
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending ISMEAR = 1 and SIGMA = 0.1 because you are likely relaxing a metal."
         )
         calc.set(ismear=1, sigma=0.1)
@@ -114,7 +114,7 @@ def get_param_swaps(
             or (calc.float_params["kspacing"] and calc.float_params["kspacing"] <= 0.5)
         )
     ):
-        logger.info("Recommending ISMEAR = -5 because you have a static calculation.")
+        LOGGER.info("Recommending ISMEAR = -5 because you have a static calculation.")
         calc.set(ismear=-5)
 
     if (
@@ -122,7 +122,7 @@ def get_param_swaps(
         and np.prod(calc.kpts) < 4
         and calc.float_params["kspacing"] is None
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending ISMEAR = 0 because you don't have enough k-points for ISMEAR = -5."
         )
         calc.set(ismear=0)
@@ -132,13 +132,13 @@ def get_param_swaps(
         and calc.float_params["kspacing"] > 0.5
         and calc.int_params["ismear"] == -5
     ):
-        logger.info(
+        LOGGER.info(
             "Recocmmending ISMEAR = 0 because KSPACING is likely too large for ISMEAR = -5."
         )
         calc.set(ismear=0)
 
     if pmg_kpts and pmg_kpts.get("line_density") and calc.int_params["ismear"] != 0:
-        logger.info(
+        LOGGER.info(
             "Recommending ISMEAR = 0 and SIGMA = 0.01 because you are doing a line mode calculation."
         )
         calc.set(ismear=0, sigma=0.01)
@@ -146,7 +146,7 @@ def get_param_swaps(
     if calc.int_params["ismear"] == 0 and (
         not calc.float_params["sigma"] or calc.float_params["sigma"] > 0.05
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending SIGMA = 0.05 because ISMEAR = 0 was requested with SIGMA > 0.05."
         )
         calc.set(sigma=0.05)
@@ -156,7 +156,7 @@ def get_param_swaps(
         and calc.int_params["nsw"] > 0
         and calc.bool_params["laechg"]
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending LAECHG = False because you have NSW > 0. LAECHG is not compatible with NSW > 0."
         )
         calc.set(laechg=False)
@@ -164,11 +164,11 @@ def get_param_swaps(
     if calc.int_params["ldauprint"] in (None, 0) and (
         calc.bool_params["ldau"] or calc.dict_params["ldau_luj"]
     ):
-        logger.info("Recommending LDAUPRINT = 1 because LDAU = True.")
+        LOGGER.info("Recommending LDAUPRINT = 1 because LDAU = True.")
         calc.set(ldauprint=1)
 
     if calc.special_params["lreal"] and len(input_atoms) < 30:
-        logger.info(
+        LOGGER.info(
             "Recommending LREAL = False because you have a small system (< 30 atoms/cell)."
         )
         calc.set(lreal=False)
@@ -177,7 +177,7 @@ def get_param_swaps(
         calc.int_params["ispin"] == 2
         or np.any(input_atoms.get_initial_magnetic_moments() != 0)
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending LORBIT = 11 because you have a spin-polarized calculation."
         )
         calc.set(lorbit=11)
@@ -191,7 +191,7 @@ def get_param_swaps(
         or calc.bool_params["lepsilon"] is True
         or calc.int_params["ibrion"] in [5, 6, 7, 8]
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending NCORE = 1 because NCORE/NPAR is not compatible with this job type."
         )
         calc.set(ncore=1, npar=None)
@@ -201,19 +201,19 @@ def get_param_swaps(
         and calc.int_params["kpar"] > np.prod(calc.kpts)
         and calc.float_params["kspacing"] is None
     ):
-        logger.info(
+        LOGGER.info(
             "Recommending KPAR = 1 because you have too few k-points to parallelize."
         )
         calc.set(kpar=1)
 
     if calc.bool_params["lhfcalc"] is True and calc.int_params["isym"] in (1, 2):
-        logger.info(
+        LOGGER.info(
             "Recommending ISYM = 3 because you are running a hybrid calculation."
         )
         calc.set(isym=3)
 
     if calc.bool_params["lsorbit"]:
-        logger.info(
+        LOGGER.info(
             "Recommending ISYM = -1 because you are running an SOC calculation."
         )
         calc.set(isym=-1)
@@ -222,7 +222,7 @@ def get_param_swaps(
         (calc.int_params["ncore"] and calc.int_params["ncore"] > 1)
         or (calc.int_params["npar"] and calc.int_params["npar"] > 1)
     ) and (calc.bool_params["lelf"] is True):
-        logger.info(
+        LOGGER.info(
             "Recommending NPAR = 1 because NCORE/NPAR is not compatible with this job type."
         )
         calc.set(npar=1, ncore=None)
@@ -239,7 +239,7 @@ def get_param_swaps(
     if changed_parameters := {
         k: new_parameters[k] for k in set(new_parameters) - set(user_calc_params)
     }:
-        logger.info(
+        LOGGER.info(
             f"The following parameters were changed: {sort_dict(changed_parameters)}"
         )
 

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 import os
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from ase.calculators.gulp import GULP
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 GEOM_FILE_PBC = "gulp.cif"
 GEOM_FILE_NOPBC = "gulp.xyz"

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 GEOM_FILE_PBC = "gulp.cif"
 GEOM_FILE_NOPBC = "gulp.xyz"

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
     from ase.calculators.calculator import Calculator
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 @lru_cache
@@ -39,7 +39,7 @@ def pick_calculator(
     import torch
 
     if not torch.cuda.is_available():
-        logger.warning("CUDA is not available to PyTorch. Calculations will be slow.")
+        LOGGER.warning("CUDA is not available to PyTorch. Calculations will be slow.")
 
     if method.lower() == "m3gnet":
         import matgl

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from functools import lru_cache
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
     from ase.calculators.calculator import Calculator
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 @lru_cache

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -7,7 +7,7 @@ Reference: https://doi.org/10.1016/j.matt.2021.02.015
 
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from ase.optimize import BFGSLineSearch
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
         VaspSchema,
     )
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 @job

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -189,12 +189,8 @@ class Runner(BaseRunner):
             The ASE Dynamics object following an optimization.
         """
         # Set defaults
-        settings = get_settings()
         merged_optimizer_kwargs = recursive_dict_merge(
-            {
-                "logfile": "-" if settings.DEBUG else self.tmpdir / "opt.log",
-                "restart": self.tmpdir / "opt.json",
-            },
+            {"logfile": self.tmpdir / "opt.log", "restart": self.tmpdir / "opt.json"},
             optimizer_kwargs,
         )
         run_kwargs = run_kwargs or {}
@@ -278,7 +274,6 @@ class Runner(BaseRunner):
         """
         # Set defaults
         vib_kwargs = vib_kwargs or {}
-        settings = get_settings()
 
         # Run calculation
         vib = Vibrations(self.atoms, name=str(self.tmpdir / "vib"), **vib_kwargs)
@@ -288,9 +283,7 @@ class Runner(BaseRunner):
             terminate(self.tmpdir, exception)
 
         # Summarize run
-        vib.summary(
-            log=sys.stdout if settings.DEBUG else str(self.tmpdir / "vib_summary.log")
-        )
+        vib.summary(log=str(self.tmpdir / "vib_summary.log"))
 
         # Perform cleanup operations
         self.cleanup()
@@ -339,8 +332,7 @@ class Runner(BaseRunner):
         # Set defaults
         dynamics_kwargs = dynamics_kwargs or {}
         maxwell_boltzmann_kwargs = maxwell_boltzmann_kwargs or {}
-        settings = get_settings()
-        dynamics_kwargs["logfile"] = "-" if settings.DEBUG else self.tmpdir / "md.log"
+        dynamics_kwargs["logfile"] = self.tmpdir / "md.log"
 
         if maxwell_boltzmann_kwargs:
             MaxwellBoltzmannDistribution(self.atoms, **maxwell_boltzmann_kwargs)

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from importlib.util import find_spec
+from logging import getLogger
 from shutil import copy, copytree
 from typing import TYPE_CHECKING, Callable
 
@@ -28,7 +28,7 @@ from quacc.runners._base import BaseRunner
 from quacc.runners.prep import terminate
 from quacc.utils.dicts import recursive_dict_merge
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 has_sella = bool(find_spec("sella"))
 

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, SourceDirectory
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def calc_setup(
@@ -56,7 +56,7 @@ def calc_setup(
     settings = get_settings()
     tmpdir_base = settings.SCRATCH_DIR or settings.RESULTS_DIR
     tmpdir = make_unique_dir(base_path=tmpdir_base, prefix="tmp-quacc-")
-    logger.info(f"Calculation will run at {tmpdir}")
+    LOGGER.info(f"Calculation will run at {tmpdir}")
 
     # Set the calculator's directory
     if atoms is not None:
@@ -130,7 +130,7 @@ def calc_cleanup(
         for file_name in os.listdir(tmpdir):
             move(tmpdir / file_name, job_results_dir / file_name)
         rmtree(tmpdir)
-    logger.info(f"Calculation results stored at {job_results_dir}")
+    LOGGER.info(f"Calculation results stored at {job_results_dir}")
 
     # Remove symlink to tmpdir
     if os.name != "nt" and settings.SCRATCH_DIR:
@@ -165,7 +165,7 @@ def terminate(tmpdir: Path | str, exception: Exception) -> None:
     tmpdir.rename(job_failed_dir)
 
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
-    logger.info(msg)
+    LOGGER.info(msg)
 
     if os.name != "nt" and settings.SCRATCH_DIR:
         old_symlink_path = settings.RESULTS_DIR / f"symlink-{tmpdir.name}"

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 import os
+from logging import getLogger
 from pathlib import Path
 from shutil import move, rmtree
 from typing import TYPE_CHECKING
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, SourceDirectory
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def calc_setup(
@@ -165,7 +165,7 @@ def terminate(tmpdir: Path | str, exception: Exception) -> None:
     tmpdir.rename(job_failed_dir)
 
     msg = f"Calculation failed! Files stored at {job_failed_dir}"
-    logging.info(msg)
+    logger.info(msg)
 
     if os.name != "nt" and settings.SCRATCH_DIR:
         old_symlink_path = settings.RESULTS_DIR / f"symlink-{tmpdir.name}"

--- a/src/quacc/schemas/prep.py
+++ b/src/quacc/schemas/prep.py
@@ -12,7 +12,7 @@ from quacc.atoms.core import copy_atoms, get_atoms_id
 if TYPE_CHECKING:
     from ase.atoms import Atoms
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def prep_next_run(atoms: Atoms, move_magmoms: bool = False) -> Atoms:

--- a/src/quacc/schemas/prep.py
+++ b/src/quacc/schemas/prep.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -12,7 +12,7 @@ from quacc.atoms.core import copy_atoms, get_atoms_id
 if TYPE_CHECKING:
     from ase.atoms import Atoms
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def prep_next_run(atoms: Atoms, move_magmoms: bool = False) -> Atoms:

--- a/src/quacc/schemas/thermo.py
+++ b/src/quacc/schemas/thermo.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
     from quacc.types import DefaultSetting, ThermoSchema
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 class ThermoSummarize:

--- a/src/quacc/schemas/thermo.py
+++ b/src/quacc/schemas/thermo.py
@@ -140,13 +140,9 @@ class ThermoSummarize:
         results = {
             "results": {
                 "energy": igt.potentialenergy,
-                "enthalpy": igt.get_enthalpy(temperature, verbose=self._settings.DEBUG),
-                "entropy": igt.get_entropy(
-                    temperature, pressure * 10**5, verbose=self._settings.DEBUG
-                ),
-                "gibbs_energy": igt.get_gibbs_energy(
-                    temperature, pressure * 10**5, verbose=self._settings.DEBUG
-                ),
+                "enthalpy": igt.get_enthalpy(temperature),
+                "entropy": igt.get_entropy(temperature, pressure * 10**5),
+                "gibbs_energy": igt.get_gibbs_energy(temperature, pressure * 10**5),
                 "zpe": igt.get_ZPE_correction(),
             }
         }
@@ -213,15 +209,9 @@ class ThermoSummarize:
         results = {
             "results": {
                 "energy": harmonic_thermo.potentialenergy,
-                "helmholtz_energy": harmonic_thermo.get_helmholtz_energy(
-                    temperature, verbose=self._settings.DEBUG
-                ),
-                "internal_energy": harmonic_thermo.get_internal_energy(
-                    temperature, verbose=self._settings.DEBUG
-                ),
-                "entropy": harmonic_thermo.get_entropy(
-                    temperature, verbose=self._settings.DEBUG
-                ),
+                "helmholtz_energy": harmonic_thermo.get_helmholtz_energy(temperature),
+                "internal_energy": harmonic_thermo.get_internal_energy(temperature),
+                "entropy": harmonic_thermo.get_entropy(temperature),
                 "zpe": harmonic_thermo.get_ZPE_correction(),
             }
         }

--- a/src/quacc/schemas/vasp.py
+++ b/src/quacc/schemas/vasp.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 import os
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     )
 
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class VaspSummarize:

--- a/src/quacc/schemas/vasp.py
+++ b/src/quacc/schemas/vasp.py
@@ -180,7 +180,7 @@ class VaspSummarize:
                 bader_results = bader_runner(directory)
             except Exception:
                 bader_results = None
-                logging.warning("Bader analysis could not be performed.", exc_info=True)
+                logger.warning("Bader analysis could not be performed.", exc_info=True)
 
             if bader_results:
                 vasp_task_doc["bader"] = bader_results
@@ -191,7 +191,7 @@ class VaspSummarize:
                 chargemol_results = chargemol_runner(directory)
             except Exception:
                 chargemol_results = None
-                logging.warning(
+                logger.warning(
                     "Chargemol analysis could not be performed.", exc_info=True
                 )
 

--- a/src/quacc/schemas/vasp.py
+++ b/src/quacc/schemas/vasp.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     )
 
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 class VaspSummarize:
@@ -145,7 +145,7 @@ class VaspSummarize:
                 )
                 vasp_task_model.entry = corrected_entry
             except CompatibilityError as err:
-                logger.warning(err)
+                LOGGER.warning(err)
 
         # Convert the VASP task model to a dictionary
         vasp_task_doc = vasp_task_model.model_dump()
@@ -180,7 +180,7 @@ class VaspSummarize:
                 bader_results = bader_runner(directory)
             except Exception:
                 bader_results = None
-                logger.warning("Bader analysis could not be performed.", exc_info=True)
+                LOGGER.warning("Bader analysis could not be performed.", exc_info=True)
 
             if bader_results:
                 vasp_task_doc["bader"] = bader_results
@@ -191,7 +191,7 @@ class VaspSummarize:
                 chargemol_results = chargemol_runner(directory)
             except Exception:
                 chargemol_results = None
-                logger.warning(
+                LOGGER.warning(
                     "Chargemol analysis could not be performed.", exc_info=True
                 )
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -409,11 +409,11 @@ class QuaccSettings(BaseSettings):
     # Logger Settings
     # ---------------------------
     LOG_FILENAME: Optional[Path] = Field(
-        Path.cwd() / "quacc.log", description="Path to store the log file."
+        None, description="Path to store the log file."
     )
-    LOG_LEVEL: Optional[
-        Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
-    ] = Field("INFO", description=("Logger level."))
+    LOG_LEVEL: Optional[Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]] = (
+        Field("INFO", description=("Logger level."))
+    )
 
     # --8<-- [end:settings]
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -409,7 +409,7 @@ class QuaccSettings(BaseSettings):
     # Logger Settings
     # ---------------------------
     LOG_FILENAME: Optional[Path] = Field(
-        None, description="Path to store the log file."
+        Path.cwd() / "quacc.log", description="Path to store the log file."
     )
     LOG_LEVEL: Optional[Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]] = (
         Field("INFO", description=("Logger level."))

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -406,17 +406,14 @@ class QuaccSettings(BaseSettings):
     )
 
     # ---------------------------
-    # Debug Settings
+    # Logger Settings
     # ---------------------------
-    DEBUG: bool = Field(
-        False,
-        description=(
-            """
-            Whether to run in debug mode. This will set the logging level to DEBUG,
-            ASE logs (e.g. optimizations, vibrations, thermo) are printed to stdout.
-            """
-        ),
+    LOG_FILENAME: Optional[Path] = Field(
+        Path.cwd() / "quacc.log", description="Path to store the log file."
     )
+    LOG_LEVEL: Optional[
+        Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
+    ] = Field("INFO", description=("Logger level."))
 
     # --8<-- [end:settings]
 

--- a/src/quacc/utils/dicts.py
+++ b/src/quacc/utils/dicts.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import MutableMapping
 from copy import deepcopy
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from maggma.stores import Store
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 class Remove:

--- a/src/quacc/utils/files.py
+++ b/src/quacc/utils/files.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from quacc.types import Filenames, SourceDirectory
 
 
-logger = getLogger(__name__)
+LOGGER = getLogger(__name__)
 
 
 def check_logfile(logfile: str | Path, check_str: str) -> bool:
@@ -139,7 +139,7 @@ def copy_decompress_files(
     for f in filenames:
         globs_found = list(source_directory.glob(str(f)))
         if not globs_found:
-            logger.warning(f"Cannot find file {f} in {source_directory}")
+            LOGGER.warning(f"Cannot find file {f} in {source_directory}")
         for source_filepath in globs_found:
             destination_filepath = destination_directory / source_filepath.relative_to(
                 source_directory
@@ -313,4 +313,4 @@ def safe_decompress_dir(path: str | Path) -> None:
             try:
                 decompress_file(Path(parent, f))
             except FileNotFoundError:
-                logger.debug(f"Cannot find {f} in {parent}. Skipping.")
+                LOGGER.debug(f"Cannot find {f} in {parent}. Skipping.")

--- a/src/quacc/utils/files.py
+++ b/src/quacc/utils/files.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import contextlib
-import logging
 import os
 import socket
 from copy import deepcopy
 from datetime import datetime, timezone
+from logging import getLogger
 from pathlib import Path
 from random import randint
 from shutil import copy
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from quacc.types import Filenames, SourceDirectory
 
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def check_logfile(logfile: str | Path, check_str: str) -> bool:

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,4 +1,4 @@
-DEBUG: true
+LOG_LEVEL: DEBUG
 WORKFLOW_ENGINE: null
 STORE:
   MemoryStore:

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import logging
 import os
 from copy import deepcopy
-from logging import getLogger
+from logging import INFO, getLogger
 from pathlib import Path
 from shutil import which
 
@@ -824,7 +823,7 @@ def test_preset_override():
 
 def test_logging(caplog):
     atoms = bulk("Cu")
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(3, 3, 3))
     assert "Recommending LMAXMIX = 4" in caplog.text
     assert "Recommending ISMEAR = -5" in caplog.text
@@ -833,7 +832,7 @@ def test_logging(caplog):
         in caplog.text
     )
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(2, 2, 1), ismear=0)
     assert "Recommending LMAXMIX = 4" in caplog.text
     assert "Recommending ISMEAR = -5" in caplog.text

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import logging
 import os
 from copy import deepcopy
+from logging import getLogger
 from pathlib import Path
 from shutil import which
 
@@ -22,7 +22,7 @@ from quacc.schemas.prep import prep_next_run
 
 FILE_DIR = Path(__file__).parent
 PSEUDO_DIR = FILE_DIR / "fake_pseudos"
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from copy import deepcopy
 from logging import getLogger

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -174,7 +174,7 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     with (
-        caplog.at_level(logging.INFO),
+        caplog.at_level(LOGGER.INFO),
         change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
     ):
         with pytest.raises(JobFailure, match="Calculation failed!") as err:
@@ -190,7 +190,7 @@ def test_child_errors2(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     with (
-        caplog.at_level(logging.INFO),
+        caplog.at_level(LOGGER.INFO),
         change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
     ):
         with pytest.raises(JobFailure, match="Calculation failed!") as err:

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -7,8 +7,8 @@ import pytest
 DFTBPLUS_EXISTS = bool(which("dftb+"))
 
 pytestmark = pytest.mark.skipif(not DFTBPLUS_EXISTS, reason="Needs DFTB+")
-import logging
 import os
+from logging import getLogger
 
 import numpy as np
 from ase.build import bulk, molecule
@@ -16,7 +16,7 @@ from ase.build import bulk, molecule
 from quacc import JobFailure, change_settings
 from quacc.recipes.dftb.core import relax_job, static_job
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
+++ b/tests/core/recipes/dftb_recipes/test_dftb_recipes.py
@@ -8,7 +8,7 @@ DFTBPLUS_EXISTS = bool(which("dftb+"))
 
 pytestmark = pytest.mark.skipif(not DFTBPLUS_EXISTS, reason="Needs DFTB+")
 import os
-from logging import getLogger
+from logging import INFO, getLogger
 
 import numpy as np
 from ase.build import bulk, molecule
@@ -173,10 +173,7 @@ def test_relax_job_cu_supercell_errors(tmp_path, monkeypatch):
 def test_child_errors(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with (
-        caplog.at_level(LOGGER.INFO),
-        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
-    ):
+    with caplog.at_level(INFO), change_settings({"SCRATCH_DIR": tmp_path / "scratch"}):
         with pytest.raises(JobFailure, match="Calculation failed!") as err:
             static_job(atoms)
         with pytest.raises(RuntimeError, match="failed with command"):
@@ -189,10 +186,7 @@ def test_child_errors(tmp_path, monkeypatch, caplog):
 def test_child_errors2(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    with (
-        caplog.at_level(LOGGER.INFO),
-        change_settings({"SCRATCH_DIR": tmp_path / "scratch"}),
-    ):
+    with caplog.at_level(INFO), change_settings({"SCRATCH_DIR": tmp_path / "scratch"}):
         with pytest.raises(JobFailure, match="Calculation failed!") as err:
             relax_job(atoms)
         with pytest.raises(RuntimeError, match="failed with command"):

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from pathlib import Path
 
 import numpy as np
@@ -15,7 +15,7 @@ from quacc.recipes.emt.core import relax_job, static_job
 from quacc.recipes.emt.md import md_job
 from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from logging import getLogger
 from shutil import which
 

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import logging
-from logging import getLogger
+from logging import WARNING, getLogger
 from shutil import which
 
 import pytest
@@ -416,7 +415,7 @@ def test_phonon_calculation_si_spin_orbit(tmp_path, monkeypatch, caplog):
             "kpts": (2, 2, 2),
         }
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(WARNING):
             si_relax_results = relax_job(si_atoms, **si_relax_params)
 
             assert "The occupations are set to 'fixed'" in caplog.text
@@ -500,7 +499,7 @@ def test_phonon_induced_renormalization(tmp_path, monkeypatch, caplog):
             }
         }
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(WARNING):
             c_ph_results = phonon_job(c_scf_results["dir_name"], **c_ph_params)
             assert "Overwriting key 'fildyn'" in caplog.text
 
@@ -527,7 +526,7 @@ def test_phonon_induced_renormalization(tmp_path, monkeypatch, caplog):
             }
         }
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(WARNING):
             dvscf_q2r_results = dvscf_q2r_job(
                 c_ph_results["dir_name"], **dvscf_q2r_params
             )

--- a/tests/core/recipes/espresso_recipes/test_phonons.py
+++ b/tests/core/recipes/espresso_recipes/test_phonons.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from shutil import which
 
 import pytest
@@ -36,7 +36,7 @@ from quacc.utils.files import copy_decompress_files
 
 DATA_DIR = Path(__file__).parent / "data"
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import glob
-import logging
 import os
+from logging import getLogger
 from pathlib import Path
 from shutil import rmtree
 
@@ -19,7 +19,7 @@ from quacc import JobFailure, change_settings, get_settings
 from quacc.runners._base import BaseRunner
 from quacc.runners.ase import Runner
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import logging
 import os
 from logging import getLogger
 from pathlib import Path

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import glob
-import logging
 import os
-from logging import getLogger
+from logging import WARNING, getLogger
 from pathlib import Path
 from shutil import rmtree
 
@@ -197,12 +196,12 @@ def test_bad_runs(tmp_path, monkeypatch, caplog):
     atoms = bulk("Cu")
 
     # No file
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         Runner(atoms, EMT(), copy_files={Path(): "test_file.txt"}).run_calc()
     assert "Cannot find file" in caplog.text
 
     # No file again
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         Runner(atoms, EMT(), copy_files={Path(): "test_file.txt"}).run_opt()
     assert "Cannot find file" in caplog.text
 

--- a/tests/core/schemas/test_thermo.py
+++ b/tests/core/schemas/test_thermo.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from pathlib import Path
 
 import numpy as np
@@ -13,7 +13,7 @@ from monty.serialization import loadfn
 
 from quacc.schemas.thermo import ThermoSummarize
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger.getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/schemas/test_thermo.py
+++ b/tests/core/schemas/test_thermo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import logging
-from logging import getLogger
+from logging import INFO, getLogger
 from pathlib import Path
 
 import numpy as np
@@ -14,7 +13,7 @@ from monty.serialization import loadfn
 
 from quacc.schemas.thermo import ThermoSummarize
 
-LOGGER = getLogger.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 
@@ -97,7 +96,7 @@ def test_summarize_ideal_gas_thermo4(tmp_path, caplog):
         (0.38803854931751625 + 0j),
         (0.3880868821616261 + 0j),
     ]
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(INFO):
         results = ThermoSummarize(
             atoms, np.array(vib_energies) / invcm, energy=-10.0, directory=tmp_path
         ).ideal_gas(temperature=1000.0, pressure=20.0)

--- a/tests/core/schemas/test_thermo.py
+++ b/tests/core/schemas/test_thermo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from logging import getLogger
 from pathlib import Path
 

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import logging
 import os
-from logging import getLogger
+from logging import WARNING, getLogger
 from pathlib import Path
 from shutil import copytree, move
 
@@ -218,7 +217,7 @@ def test_summarize_mp_bad(monkeypatch, run1, tmp_path, caplog):
     p = tmp_path / "vasp_run"
     copytree(run1, p)
     atoms = read(p / "OUTCAR.gz")
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         VaspSummarize(directory=p, report_mp_corrections=True).run(atoms)
     assert "invalid run type" in caplog.text
 
@@ -228,7 +227,7 @@ def test_no_bader(tmp_path, monkeypatch, run1, caplog):
     p = tmp_path / "vasp_run"
     copytree(run1, p)
     atoms = read(p / "OUTCAR.gz")
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         VaspSummarize(directory=p, run_bader=True, run_chargemol=False).run(atoms)
     assert "Bader analysis could not be performed." in caplog.text
 
@@ -238,6 +237,6 @@ def test_no_chargemol(tmp_path, monkeypatch, run1, caplog):
     p = tmp_path / "vasp_run"
     copytree(run1, p)
     atoms = read(p / "OUTCAR.gz")
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         VaspSummarize(directory=p, run_bader=False, run_chargemol=True).run(atoms)
     assert "Chargemol analysis could not be performed." in caplog.text

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from logging import getLogger
 from pathlib import Path

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 import os
+from logging import getLogger
 from pathlib import Path
 from shutil import copytree, move
 
@@ -13,7 +13,7 @@ from monty.json import MontyDecoder, jsanitize
 from quacc.calculators.vasp import Vasp
 from quacc.schemas.vasp import VaspSummarize
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -15,12 +15,11 @@ FILE_DIR = Path(__file__).parent
 
 def test_file(tmp_path, monkeypatch):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
-        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nDEBUG: True\nSTORE: null")
+        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nSTORE: null")
     monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
 
     assert QuaccSettings().GZIP_FILES is False
     assert QuaccSettings().WORKFLOW_ENGINE is None
-    assert QuaccSettings().DEBUG is True
     assert QuaccSettings().STORE is None
     os.remove(tmp_path / "quacc_test.yaml")
 

--- a/tests/core/utils/test_dicts.py
+++ b/tests/core/utils/test_dicts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from logging import getLogger
 
 import pytest

--- a/tests/core/utils/test_dicts.py
+++ b/tests/core/utils/test_dicts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from logging import WARNNG, getLogger
+from logging import WARNING, getLogger
 
 import pytest
 

--- a/tests/core/utils/test_dicts.py
+++ b/tests/core/utils/test_dicts.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import logging
-from logging import getLogger
+from logging import WARNNG, getLogger
 
 import pytest
 
@@ -74,7 +73,7 @@ def test_recursive_dict_merge2():
 def test_recursive_dict_merge_verbose(caplog):
     defaults = {"a": 1, "b": {"a": 1, "b": 2}}
     calc_swaps = {"a": Remove, "b": {"b": 3, "d": 1}}
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         recursive_dict_merge(defaults, calc_swaps, verbose=True)
         assert "Overwriting key 'a'" in caplog.text
         assert "Overwriting key 'b' to: '3'" in caplog.text

--- a/tests/core/utils/test_dicts.py
+++ b/tests/core/utils/test_dicts.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 
 import pytest
 
 from quacc import Remove
 from quacc.utils.dicts import finalize_dict, recursive_dict_merge, remove_dict_entries
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import gzip
-import logging
 import os
 import time
+from logging import getLogger
 from pathlib import Path
 
 import pytest
@@ -15,7 +15,7 @@ from quacc.utils.files import (
     make_unique_dir,
 )
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import gzip
-import logging
 import os
 import time
-from logging import getLogger
+from logging import WARNING, getLogger
 from pathlib import Path
 
 import pytest
@@ -120,7 +119,7 @@ def test_copy_decompress_files_v4(tmp_path):
 
 
 def test_copy_decompress_files_from_dir_warning(caplog):
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(WARNING):
         copy_decompress_files("fake", "file", "test")
     assert "Cannot find file" in caplog.text
 

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import logging
 import os
 import time
 from logging import getLogger


### PR DESCRIPTION
## Summary of Changes

Provides a setting to store the log files to disk. Before, it was only shown in the console. Now, we have an option to write it out to a custom file if desired by the user.

@tomdemeyere: I think this explains part of the confusion. I had assumed the logger metadata was being written out to disk and was confused why you had to go digging through folders to find out which failed. However, it was only shown in the console.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
