### PR TITLE
add wflow_tools.job_patterns.unpartition

### DIFF
--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -168,5 +168,19 @@ def kwarg_map(
 
 
 @job
-def unpartition(lists_to_combine: list[list[Any]]):
+def unpartition(lists_to_combine: list[list[Any]]) -> list[Any]:
+    """
+    Given a partitioned list (list of lists), recombine
+    it to a single list
+
+    Parameters
+    ----------
+    lists_to_combine
+        the list of lists to recombine
+
+    Returns
+    -------
+    list[Any]
+        a single recombined list
+    """
     return list(itertools.chain(*lists_to_combine))

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -165,3 +165,8 @@ def kwarg_map(
         func(**{k: v[i] for k, v in iter(mapped_kwargs.items())}, **unmapped_kwargs)
         for i in range(n_elements)
     ]
+
+
+@job
+def unpartition(lists_to_combine: list[list[Any]]):
+    return list(itertools.chain(*lists_to_combine))

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 from typing import TYPE_CHECKING
 
 from quacc.wflow_tools.customizers import strip_decorator

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -33,7 +33,6 @@ def test_unpartition():
     np.testing.assert_allclose(partitioned_list[0], list(range(10)))
 
 
-
 def test_kwarg_map():
     def test_fun(a, b):
         return {"a": a, "b": b}

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -22,6 +22,17 @@ def test_partition():
     np.testing.assert_allclose(partitioned_list[0], [0, 1, 2, 3])
 
 
+def test_unpartition():
+    @job
+    def simple_list():
+        return list(range(10))
+
+    partitioned_list = unpartition(partition(simple_list(), 3))
+    assert len(partitioned_list) == 10
+    np.testing.assert_allclose(partitioned_list[0], list(range(10)))
+
+
+
 def test_kwarg_map():
     def test_fun(a, b):
         return {"a": a, "b": b}

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -9,6 +9,7 @@ from quacc.wflow_tools.job_patterns import (
     map_partition,
     map_partitioned_lists,
     partition,
+    unpartition
 )
 
 

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -9,7 +9,7 @@ from quacc.wflow_tools.job_patterns import (
     map_partition,
     map_partitioned_lists,
     partition,
-    unpartition
+    unpartition,
 )
 
 

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -28,9 +28,9 @@ def test_unpartition():
     def simple_list():
         return list(range(10))
 
-    partitioned_list = unpartition(partition(simple_list(), 3))
-    assert len(partitioned_list) == 10
-    np.testing.assert_allclose(partitioned_list[0], list(range(10)))
+    unpartitioned_list = unpartition(partition(simple_list(), 3))
+    assert len(unpartitioned_list) == 10
+    np.testing.assert_allclose(partitioned_list, list(range(10)))
 
 
 def test_kwarg_map():

--- a/tests/core/wflow/test_job_patterns.py
+++ b/tests/core/wflow/test_job_patterns.py
@@ -30,7 +30,7 @@ def test_unpartition():
 
     unpartitioned_list = unpartition(partition(simple_list(), 3))
     assert len(unpartitioned_list) == 10
-    np.testing.assert_allclose(partitioned_list, list(range(10)))
+    np.testing.assert_allclose(unpartitioned_list, list(range(10)))
 
 
 def test_kwarg_map():


### PR DESCRIPTION
Add a helper utility to unpartition partitioned lists.

## Summary of Changes

Add a simple helper utility to unpartition partitioned lists. Example usage:

```
partitioned_lists = partition(my_list, num_partitions)
partitioned_results = map_partitions(myfun, partitioned_lists, ...)
results = unpartition(partitioned_results)
```

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
