### PR TITLE
Small bug fix for async prefect flows

### DIFF
--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -193,8 +193,7 @@ graph LR
         return output2
 
 
-    future = workflow(1, 2, 3)  #  (3)!
-    result = future.result()  #  (4)!
+    result = workflow(1, 2, 3)  #  (3)!
     print(result)  # 9
     ```
 
@@ -202,9 +201,7 @@ graph LR
 
     2. The `#!Python @flow` decorator will be transformed into a Prefect `#!Python @flow`.
 
-    3. This will create and run the `Flow`. At this point, the workflow has been dispatched, but only a reference is returned.
-
-    4. Calling `.result()` will return the result of the workflow.
+    3. This will create and run the `Flow`. At this point, the workflow has been dispatched and the final results are returned.
 
 === "Redun"
 

--- a/docs/user/wflow_engine/executors.md
+++ b/docs/user/wflow_engine/executors.md
@@ -564,8 +564,7 @@ If you haven't done so already:
     from ase.collections import g2
 
     atoms_objects = [g2[name] for name in g2.names[:20]]
-    futures = workflow(atoms_objects)
-    results = [future.result() for future in futures]
+    results = workflow(atoms_objects)
     ```
 
     !!! Tip "One-Time Dask Clusters"
@@ -909,8 +908,7 @@ First, prepare your `QUACC_VASP_PP_PATH` environment variable in the `~/.bashrc`
     from ase.build import bulk
 
     list_of_atoms = [bulk("Cu"), bulk("C")]
-    futures = workflow(list_of_atoms)
-    results = [future.result() for future in futures]
+    results = workflow(list_of_atoms)
     ```
 
 === "Jobflow"

--- a/docs/user/wflow_engine/wflow_engines1.md
+++ b/docs/user/wflow_engine/wflow_engines1.md
@@ -159,18 +159,14 @@ graph LR
 
 
     # Dispatch the workflow
-    future = workflow(atoms)  # (2)!
+    result = workflow(atoms)  # (2)!
 
-    # Fetch the result
-    result = future.result()  # (3)!
     print(result)
     ```
 
     1. The `relax_job` function was pre-defined in quacc with a `#!Python @job` decorator, which is why we did not need to include it here.
 
-    2. The workflow has been dispatched to the Prefect server at this point.
-
-    3. Finally, we fetch the result of the completed workflow.
+    2. The workflow has been dispatched to the Prefect server at this point and the result returned.
 
 === "Redun"
 
@@ -308,11 +304,11 @@ graph LR
     # Define the Atoms object
     atoms = bulk("Cu")
 
-    # Dispatch the workflow
-    futures = bulk_to_slabs_flow(atoms)
+    # Dispatch the workflow and get results
+    results = bulk_to_slabs_flow(atoms)
 
     # Print the results
-    results = [future.result() for future in futures]
+    print(results)
     ```
 
 === "Redun"

--- a/docs/user/wflow_engine/wflow_engines2.md
+++ b/docs/user/wflow_engine/wflow_engines2.md
@@ -236,7 +236,7 @@ graph LR
     atoms = bulk("Cu")
 
     # Run the workflow with Prefect tracking
-    result = workflow(atoms).result()
+    result = workflow(atoms)
     print(result)
     ```
 
@@ -486,11 +486,11 @@ graph LR
     atoms2 = molecule("N2")
 
     # Dispatch the workflow
-    futures = workflow(atoms1, atoms2)
+    results = workflow(atoms1, atoms2)
 
     # Fetch the results
-    result1 = futures["result1"].result()
-    result2 = futures["result2"].result()
+    result1 = results["result1"]
+    result2 = results["result2"]
     print(result1, result2)
     ```
 
@@ -730,10 +730,9 @@ graph LR
     atoms = bulk("Cu")
 
     # Dispatch the workflow
-    futures = workflow(atoms)
+    results = workflow(atoms)
 
-    # Fetch the results
-    results = [future.result() for future in futures]
+    # print the results
     print(results)
     ```
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -349,11 +349,11 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
     elif settings.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow
 
-        from quacc.wflow_tools.prefect_utils import resolve_futures_to_data
+        from quacc.wflow_tools.prefect_utils import resolve_futures_to_results
 
         @wraps(_func)
         def wrapper(*f_args, **f_kwargs):
-            return resolve_futures_to_data(_func(*f_args, **f_kwargs))
+            return resolve_futures_to_results(_func(*f_args, **f_kwargs))
 
         return prefect_flow(wrapper, validate_parameters=False, **kwargs)
     else:
@@ -586,11 +586,11 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
     elif settings.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow
 
-        from quacc.wflow_tools.prefect_utils import resolve_futures_to_data
+        from quacc.wflow_tools.prefect_utils import resolve_futures_to_results
 
         @wraps(_func)
         def wrapper(*f_args, **f_kwargs):
-            return resolve_futures_to_data(_func(*f_args, **f_kwargs))
+            return resolve_futures_to_results(_func(*f_args, **f_kwargs))
 
         return prefect_flow(wrapper, validate_parameters=False, **kwargs)
     elif settings.WORKFLOW_ENGINE == "redun":

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -349,7 +349,13 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
     elif settings.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow
 
-        return prefect_flow(_func, validate_parameters=False, **kwargs)
+        from quacc.wflow_tools.prefect_utils import resolve_futures_to_data
+
+        @wraps(_func)
+        def wrapper(*f_args, **f_kwargs):
+            return resolve_futures_to_data(_func(*f_args, **f_kwargs))
+
+        return prefect_flow(wrapper, validate_parameters=False, **kwargs)
     else:
         return _func
 
@@ -559,7 +565,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
 
         return ct.electron(ct.lattice(_func), **kwargs)
     elif settings.WORKFLOW_ENGINE == "dask":
-        from dask import delayed
+        from dask.delayed import delayed
         from dask.distributed import worker_client
 
         # See https://github.com/dask/dask/issues/10733
@@ -580,7 +586,13 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
     elif settings.WORKFLOW_ENGINE == "prefect":
         from prefect import flow as prefect_flow
 
-        return prefect_flow(_func, validate_parameters=False, **kwargs)
+        from quacc.wflow_tools.prefect_utils import resolve_futures_to_data
+
+        @wraps(_func)
+        def wrapper(*f_args, **f_kwargs):
+            return resolve_futures_to_data(_func(*f_args, **f_kwargs))
+
+        return prefect_flow(wrapper, validate_parameters=False, **kwargs)
     elif settings.WORKFLOW_ENGINE == "redun":
         from redun import task
 

--- a/src/quacc/wflow_tools/prefect_utils.py
+++ b/src/quacc/wflow_tools/prefect_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Any, Union
+
+from prefect.futures import PrefectFuture
+from prefect.utilities.annotations import quote
+from prefect.utilities.collections import StopVisiting, visit_collection
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from prefect.states import State
+
+F = TypeVar("F")
+R = TypeVar("R")
+
+
+def resolve_futures_to_data(expr: PrefectFuture | Any) -> State | Any:
+    """
+    Given a Python built-in collection, recursively find `PrefectFutures` and build a
+    new collection with the same structure with futures resolved to their final states.
+    Resolving futures to their final states may wait for execution to complete.
+
+    Unsupported object types will be returned without modification.
+    """
+    futures: set[PrefectFuture] = set()
+
+    def _collect_futures(futures, expr, context):
+        # Expressions inside quotes should not be traversed
+        if isinstance(context.get("annotation"), quote):
+            raise StopVisiting()
+
+        if isinstance(expr, PrefectFuture):
+            futures.add(expr)
+
+        return expr
+
+    visit_collection(
+        expr, visit_fn=partial(_collect_futures, futures), return_data=False, context={}
+    )
+
+    # if no futures were found, return the original expression
+    if not futures:
+        return expr
+
+    # Get final states for each future
+    results = []
+    for future in futures:
+        future.wait()
+        results.append(future.state.result().get())
+
+    states_by_future = dict(zip(futures, results))
+
+    def replace_futures_with_states(expr, context):
+        # Expressions inside quotes should not be modified
+        if isinstance(context.get("annotation"), quote):
+            raise StopVisiting()
+
+        if isinstance(expr, PrefectFuture):
+            return states_by_future[expr]
+        else:
+            return expr
+
+    return visit_collection(
+        expr, visit_fn=replace_futures_with_states, return_data=True, context={}
+    )

--- a/src/quacc/wflow_tools/prefect_utils.py
+++ b/src/quacc/wflow_tools/prefect_utils.py
@@ -15,7 +15,7 @@ F = TypeVar("F")
 R = TypeVar("R")
 
 
-def resolve_futures_to_data(expr: PrefectFuture | Any) -> State | Any:
+def resolve_futures_to_results(expr: PrefectFuture | Any) -> State | Any:
     """
     Given a Python built-in collection, recursively find `PrefectFutures` and build a
     new collection with the same structure with futures resolved to their final result.

--- a/src/quacc/wflow_tools/prefect_utils.py
+++ b/src/quacc/wflow_tools/prefect_utils.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from prefect.futures import PrefectFuture
+from prefect.results import BaseResult
 from prefect.utilities.annotations import quote
 from prefect.utilities.collections import StopVisiting, visit_collection
 from typing_extensions import TypeVar
@@ -50,7 +51,10 @@ def resolve_futures_to_results(expr: PrefectFuture | Any) -> State | Any:
     results = []
     for future in futures:
         future.wait()
-        results.append(future.state.result().get())
+        result = future.state.result()
+        if isinstance(result, BaseResult):
+            result = result.get()
+        results.append(result)
 
     states_by_future = dict(zip(futures, results))
 

--- a/src/quacc/wflow_tools/prefect_utils.py
+++ b/src/quacc/wflow_tools/prefect_utils.py
@@ -18,10 +18,13 @@ R = TypeVar("R")
 def resolve_futures_to_data(expr: PrefectFuture | Any) -> State | Any:
     """
     Given a Python built-in collection, recursively find `PrefectFutures` and build a
-    new collection with the same structure with futures resolved to their final states.
-    Resolving futures to their final states may wait for execution to complete.
+    new collection with the same structure with futures resolved to their final result.
+    Resolving futures to their final result may wait for execution to complete.
 
     Unsupported object types will be returned without modification.
+
+    This function is a trivial change from resolve_futures_to_states here:
+    https://github.com/PrefectHQ/prefect/blob/main/src/prefect/futures.py
     """
     futures: set[PrefectFuture] = set()
 

--- a/tests/prefect/test_customizers.py
+++ b/tests/prefect/test_customizers.py
@@ -49,7 +49,7 @@ def test_change_settings_redecorate_job(tmp_path_factory):
     def my_flow():
         return write_file_job()
 
-    my_flow().result()
+    my_flow()
     assert Path(tmp_dir1 / "job.txt").exists()
 
 
@@ -71,7 +71,7 @@ def test_change_settings_redecorate_flow(tmp_path_factory):
     # Test with redecorating a job in a flow
     write_file_flow(
         job_decorators={"write_file_job": job(settings_swap={"RESULTS_DIR": tmp_dir2})}
-    ).result()
+    )
     assert Path(tmp_dir2 / "flow.txt").exists()
 
 
@@ -95,6 +95,6 @@ def test_double_change_settings_redecorate_job(tmp_path_factory):
     def my_flow():
         return write_file_job()
 
-    my_flow().result()
+    my_flow()
     assert not Path(tmp_dir1 / "job.txt").exists()
     assert Path(tmp_dir2 / "job.txt").exists()

--- a/tests/prefect/test_emt_recipes.py
+++ b/tests/prefect/test_emt_recipes.py
@@ -21,10 +21,9 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
         job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
         job_decorators=job_decorators,
     )
-    result = [future.result() for future in output]
-    assert len(result) == 4
-    assert "atoms" in result[-1]
-    assert result[-1]["parameters_opt"]["fmax"] == 0.1
+    assert len(output) == 4
+    assert "atoms" in output[-1]
+    assert output[-1]["parameters_opt"]["fmax"] == 0.1
 
 
 def test_copy_files(tmp_path, monkeypatch):
@@ -36,7 +35,7 @@ def test_copy_files(tmp_path, monkeypatch):
         result1 = relax_job(atoms)
         return relax_job(result1["atoms"], copy_files={result1["dir_name"]: "opt.*"})
 
-    assert "atoms" in myflow(atoms).result()
+    assert "atoms" in myflow(atoms)
 
 
 def test_phonon_flow(tmp_path, monkeypatch):
@@ -47,6 +46,4 @@ def test_phonon_flow(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     output = phonon_flow(atoms)
-    assert output.result()["results"]["thermal_properties"]["temperatures"].shape == (
-        101,
-    )
+    assert output["results"]["thermal_properties"]["temperatures"].shape == (101,)

--- a/tests/prefect/test_map_partitions.py
+++ b/tests/prefect/test_map_partitions.py
@@ -21,7 +21,7 @@ def test_partition():
     def test_flow():
         return partition(simple_list(), 3)
 
-    partitioned_list = test_flow().result()
+    partitioned_list = test_flow()
     assert len(partitioned_list) == 3
     np.testing.assert_allclose(partitioned_list[0], [0, 1, 2, 3])
 
@@ -60,15 +60,21 @@ def test_map_partitioned_lists():
         )
 
     num_partitions = 4
-    assert test_flow(testfun, num_partitions)[0].result() == [0, 2, 4]
-    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[
-        0
-    ].result() == [0, 3, 6]
+    assert test_flow(testfun, num_partitions)[0] == [0, 2, 4]
+    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[0] == [
+        0,
+        3,
+        6,
+    ]
     num_partitions = 2
-    assert test_flow(testfun, num_partitions)[0].result() == [0, 2, 4, 6, 8]
-    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[
-        1
-    ].result() == [15, 18, 21, 24, 27]
+    assert test_flow(testfun, num_partitions)[0] == [0, 2, 4, 6, 8]
+    assert test_flow(testfun, num_partitions, unmapped_kwargs={"const": 3})[1] == [
+        15,
+        18,
+        21,
+        24,
+        27,
+    ]
 
 
 def test_map_partition():
@@ -79,10 +85,10 @@ def test_map_partition():
     def test_flow1():
         return map_partition(test_fun, a=[1, 2], b=["c", "d"])
 
-    assert test_flow1().result() == [{"a": 1, "b": "c"}, {"a": 2, "b": "d"}]
+    assert test_flow1() == [{"a": 1, "b": "c"}, {"a": 2, "b": "d"}]
 
     @flow
     def test_flow2():
         return map_partition(test_fun, unmapped_kwargs={"b": 1}, a=[1, 2])
 
-    assert test_flow2().result() == [{"a": 1, "b": 1}, {"a": 2, "b": 1}]
+    assert test_flow2() == [{"a": 1, "b": 1}, {"a": 2, "b": 1}]

--- a/tests/prefect/test_syntax.py
+++ b/tests/prefect/test_syntax.py
@@ -27,7 +27,7 @@ def test_patch():
         future1 = task1(val)
         return task2(future1["result"])
 
-    assert workflow(1).result() == {"input": 100, "result": 20000}
+    assert workflow(1) == {"input": 100, "result": 20000}
 
 
 def test_patch_local():
@@ -60,7 +60,7 @@ def test_prefect_decorators1(tmp_path, monkeypatch):
     def add_flow(a, b):
         return add(a, b)
 
-    assert add_flow(1, 2).result() == 3
+    assert add_flow(1, 2) == 3
 
 
 def test_prefect_decorators2(tmp_path, monkeypatch):
@@ -78,7 +78,7 @@ def test_prefect_decorators2(tmp_path, monkeypatch):
     def workflow(a, b, c):
         return mult(add(a, b), c)
 
-    assert workflow(1, 2, 3).result() == 9
+    assert workflow(1, 2, 3) == 9
 
 
 def test_prefect_decorators3(tmp_path, monkeypatch):
@@ -102,7 +102,7 @@ def test_prefect_decorators3(tmp_path, monkeypatch):
         result2 = make_more(result1)
         return add_distributed(result2, c)
 
-    assert [r.result() for r in dynamic_workflow(1, 2, 3)] == [6, 6, 6]
+    assert dynamic_workflow(1, 2, 3) == [6, 6, 6]
 
 
 def test_prefect_decorators4(tmp_path, monkeypatch):
@@ -126,7 +126,7 @@ def test_prefect_decorators4(tmp_path, monkeypatch):
         result2 = make_more(result1)
         return add_distributed2(result2, c, add)
 
-    assert [r.result() for r in dynamic_workflow2(1, 2, 3)] == [6, 6, 6]
+    assert dynamic_workflow2(1, 2, 3) == [6, 6, 6]
 
 
 def test_prefect_decorators5(tmp_path, monkeypatch):
@@ -152,7 +152,7 @@ def test_prefect_decorators5(tmp_path, monkeypatch):
         result4 = add_distributed(result3, c)
         return add(result4[0], c)
 
-    assert dynamic_workflow3(1, 2, 3).result() == 12
+    assert dynamic_workflow3(1, 2, 3) == 12
 
 
 def test_prefect_decorators_local(tmp_path, monkeypatch):
@@ -239,10 +239,6 @@ def test_state_patch():
 
         return 2
 
-    # Note: No need for `.result()` here because we are returning data, not a PrefectFuture
-    # Doing `my_flow(return_state=True)` would force the need for a `.result()`. In general,
-    # Prefect flows return the object as-is unless `return_state=True` is set. It's just
-    # that in general throughout quacc, we are often returning an unresolved `PrefectFuture`
     assert my_flow() == 2
 
 

--- a/tests/prefect/test_tutorials.py
+++ b/tests/prefect/test_tutorials.py
@@ -22,10 +22,8 @@ def test_tutorial1a(tmp_path, monkeypatch):
         return relax_job(atoms)  # (1)!
 
     # Dispatch the workflow
-    future = workflow(atoms)  # (2)!
+    result = workflow(atoms)  # (2)!
 
-    # Fetch the result
-    result = future.result()  # (3)!
     assert "atoms" in result
 
 
@@ -36,10 +34,9 @@ def test_tutorial1b(tmp_path, monkeypatch):
     atoms = bulk("Cu")
 
     # Dispatch the workflow
-    futures = bulk_to_slabs_flow(atoms)  # (1)!
+    results = bulk_to_slabs_flow(atoms)  # (1)!
 
     # Print the results
-    results = [future.result() for future in futures]
     for result in results:
         assert "atoms" in result
 
@@ -60,7 +57,7 @@ def test_tutorial2a(tmp_path, monkeypatch):
     atoms = bulk("Cu")
 
     # Run the workflow with Prefect tracking
-    result = workflow(atoms).result()
+    result = workflow(atoms)
     assert "atoms" in result
 
 
@@ -84,8 +81,8 @@ def test_tutorial2b(tmp_path, monkeypatch):
     futures = workflow(atoms1, atoms2)
 
     # Fetch the results
-    result1 = futures["result1"].result()
-    result2 = futures["result2"].result()
+    result1 = futures["result1"]
+    result2 = futures["result2"]
     assert "atoms" in result1
     assert "atoms" in result2
 
@@ -103,8 +100,7 @@ def test_tutorial2c(tmp_path, monkeypatch):
     atoms = bulk("Cu")
 
     # Dispatch the workflow and retrieve result
-    futures = workflow(atoms)
-    results = [future.result() for future in futures]
+    results = workflow(atoms)
     assert len(results) == 4
     for result in results:
         assert "atoms" in result

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,7 @@ maggma==0.69.3
 monty==2024.7.30
 numpy==1.26.4
 psutil==5.9.8
-pydantic==2.8.2
+pydantic==2.9.1
 pydantic-settings==2.4.0
 pymatgen==2024.7.18
 ruamel.yaml==0.18.6


### PR DESCRIPTION
## Summary of Changes

This provides a small bug fix for the recent patch to how prefect flows are handled. The prior methods only worked for sync flows. 

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
