### PR TITLE
add line split for potcar_symbols

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -449,7 +449,7 @@ class MPtoASEConverter:
         )
         self.incar_dict = input_set.incar
         self.pmg_kpts = input_set.kpoints
-        self.potcar_symbols = input_set.potcar.split("\n")
+        self.potcar_symbols = input_set.potcar.split("\n") if isinstance(input_set.potcar, str) else input_set.potcar
         self.potcar_functional = input_set_generator.potcar_functional
         self.poscar = input_set.poscar
         return self._convert()

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -449,7 +449,11 @@ class MPtoASEConverter:
         )
         self.incar_dict = input_set.incar
         self.pmg_kpts = input_set.kpoints
-        self.potcar_symbols = input_set.potcar.split("\n") if isinstance(input_set.potcar, str) else input_set.potcar
+        self.potcar_symbols = (
+            input_set.potcar.split("\n")
+            if isinstance(input_set.potcar, str)
+            else input_set.potcar
+        )
         self.potcar_functional = input_set_generator.potcar_functional
         self.poscar = input_set.poscar
         return self._convert()

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -449,7 +449,7 @@ class MPtoASEConverter:
         )
         self.incar_dict = input_set.incar
         self.pmg_kpts = input_set.kpoints
-        self.potcar_symbols = input_set.potcar
+        self.potcar_symbols = input_set.potcar.split("\n")
         self.potcar_functional = input_set_generator.potcar_functional
         self.poscar = input_set.poscar
         return self._convert()


### PR DESCRIPTION
@Andrew-S-Rosen  I found the problem. It is not `emmet-core` or `pymargen` version issue. `input_set.potcar` needs line splitting similar to what is done at [line 424](https://github.com/chiang-yuan/quacc/blob/ea34aa63b76d7cdd3c1eed0d674827dd04a16337/src/quacc/calculators/vasp/params.py#L424)

I tested the vasp workflow locally and didn't run into any errors

This will close issue #2457 and close https://github.com/materialsproject/atomate2/pull/984

