### PR TITLE
fix doc of espresso.py

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -370,7 +370,7 @@ class Espresso(GenericFileIOCalculator):
         input_atoms
             The input Atoms object to be used for the calculation.
         preset
-            A YAML file containing a list of INCAR parameters to use as a "preset"
+            A YAML file containing a list of parameters to use as a "preset"
             for the calculator. If `preset` has a .yml or .yaml file extension, the
             path to this file will be used directly. If `preset` is a string without
             an extension, the corresponding YAML file will be assumed to be in the


### PR DESCRIPTION
Since it's relevant to Quantum Espresso, the "INCAR" used for VASP was removed to avoid confusion.
Feel free to reject this pull request because it's just a small fix of the document. 

## Summary of Changes

Since it's relevant to Quantum Espresso, the "INCAR" used for VASP was removed to avoid confusion.

### Requirements

- [ ] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [ ] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [ ] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
