### PR TITLE
Change `relax_cell` to `False` in core VASP workflows per warning

### DIFF
--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
-from warnings import warn
 
 import numpy as np
 from monty.os.path import zpath
@@ -89,7 +88,7 @@ def static_job(
 def relax_job(
     atoms: Atoms,
     preset: str | None = "BulkSet",
-    relax_cell: bool = True,
+    relax_cell: bool = False,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
@@ -121,12 +120,6 @@ def relax_job(
         Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
         See the type-hint for the data structure.
     """
-    if relax_cell:
-        warn(
-            "The `relax_cell` parameter will default to `False` by default in a future version for internal consistency throughout quacc. Please set `relax_cell=True` directly.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
     calc_defaults = {
         "ediffg": -0.02,
         "isif": 3 if relax_cell else 2,
@@ -207,7 +200,7 @@ def double_relax_flow(
 def ase_relax_job(
     atoms: Atoms,
     preset: str | None = "BulkSet",
-    relax_cell: bool = True,
+    relax_cell: bool = False,
     opt_params: OptParams | None = None,
     copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     additional_fields: dict[str, Any] | None = None,
@@ -242,12 +235,6 @@ def ase_relax_job(
     VaspASEOptSchema
         Dictionary of results. See the type-hint for the data structure.
     """
-    if relax_cell:
-        warn(
-            "The `relax_cell` parameter will default to `False` by default in a future version for internal consistency throughout quacc. Please set `relax_cell=True` directly.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
     calc_defaults = {"lcharg": False, "lwave": False, "nsw": 0}
     opt_defaults = {"relax_cell": relax_cell}
     return run_and_summarize_opt(

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -168,7 +168,9 @@ def test_ase_relax_job(patch_metallic_taskdoc):
 def test_ase_relax_job2(patch_metallic_taskdoc):
     atoms = bulk("Al")
 
-    output = ase_relax_job(atoms, relax_cell=True, opt_params={"store_intermediate_results": True})
+    output = ase_relax_job(
+        atoms, relax_cell=True, opt_params={"store_intermediate_results": True}
+    )
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["nsw"] == 0
     assert output["parameters"]["lwave"] is False

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -77,7 +77,7 @@ def test_static_job(patch_metallic_taskdoc):
 def test_relax_job(patch_metallic_taskdoc):
     atoms = bulk("Al")
 
-    output = relax_job(atoms)
+    output = relax_job(atoms, relax_cell=True)
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["isym"] == 0
     assert output["parameters"]["nsw"] > 0
@@ -85,7 +85,7 @@ def test_relax_job(patch_metallic_taskdoc):
     assert output["parameters"]["lwave"] is False
     assert output["parameters"]["encut"] == 520
 
-    output = relax_job(atoms, nelmin=6)
+    output = relax_job(atoms, nelmin=6, relax_cell=True)
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["isym"] == 0
     assert output["parameters"]["nsw"] > 0
@@ -94,7 +94,7 @@ def test_relax_job(patch_metallic_taskdoc):
     assert output["parameters"]["encut"] == 520
     assert output["parameters"]["nelmin"] == 6
 
-    output = relax_job(atoms, relax_cell=False)
+    output = relax_job(atoms)
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["isym"] == 0
     assert output["parameters"]["nsw"] > 0
@@ -155,7 +155,7 @@ def test_doublerelax_flow(patch_metallic_taskdoc):
 def test_ase_relax_job(patch_metallic_taskdoc):
     atoms = bulk("Al")
 
-    output = ase_relax_job(atoms)
+    output = ase_relax_job(atoms, relax_cell=True)
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["nsw"] == 0
     assert output["parameters"]["lwave"] is False
@@ -168,7 +168,7 @@ def test_ase_relax_job(patch_metallic_taskdoc):
 def test_ase_relax_job2(patch_metallic_taskdoc):
     atoms = bulk("Al")
 
-    output = ase_relax_job(atoms, opt_params={"store_intermediate_results": True})
+    output = ase_relax_job(atoms, relax_cell=True, opt_params={"store_intermediate_results": True})
     assert output["nsites"] == len(atoms)
     assert output["parameters"]["nsw"] == 0
     assert output["parameters"]["lwave"] is False


### PR DESCRIPTION
For many months now, the `relax_job` and `ase_relax_job` in `quacc.recipes.vasp.core` had a warning that `relax_cell` would be set to `False` by default in the future to be consistent with other workflows in quacc. This change is now implemented.