### PR TITLE
Fix the overlapping filenames when using `bands.x`

### DIFF
--- a/src/quacc/calculators/espresso/utils.py
+++ b/src/quacc/calculators/espresso/utils.py
@@ -180,7 +180,7 @@ def espresso_prepare_dir(outdir: str | Path, binary: str = "pw") -> dict[str, An
         },
         "q2r": {"input": {"fildyn": "matdyn", "flfrc": "q2r.fc"}},
         "bands": {
-            "bands": {"prefix": "pwscf", "filband": "bands.out", "outdir": outdir}
+            "bands": {"prefix": "pwscf", "filband": "bands.dat", "outdir": outdir}
         },
         "fs": {
             "fermi": {

--- a/tests/core/recipes/espresso_recipes/test_bands.py
+++ b/tests/core/recipes/espresso_recipes/test_bands.py
@@ -39,6 +39,9 @@ def test_bands_flow(tmp_path, monkeypatch):
         == "bands"
     )
 
+    assert Path(output["bands_pp"]["dir_name"], "bands.out.gz").exists()
+    assert Path(output["bands_pp"]["dir_name"], "bands.dat.gz").exists()
+
     assert_allclose(
         output["bands_pw"]["atoms"].get_positions(), atoms.get_positions(), atol=1.0e-4
     )


### PR DESCRIPTION
## Summary of Changes

Closes https://github.com/Quantum-Accelerators/quacc/issues/2724

@BCAyers2000

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
