### PR TITLE
enforce relax_cell False for correct elastic calculations

### DIFF
--- a/src/quacc/recipes/common/elastic.py
+++ b/src/quacc/recipes/common/elastic.py
@@ -115,7 +115,7 @@ def _elastic_tensor_subflow(
 
     results = []
     for deformed in deformed_structure_set:
-        result = relax_job(deformed.to_ase_atoms())
+        result = relax_job(deformed.to_ase_atoms(), relax_cell=False)
 
         if static_job is not None:
             result = static_job(result["atoms"])


### PR DESCRIPTION
## Summary of Changes

`relax_cell=False` should be enforced for relaxations of deformed structures in the `_elastic_tensor_subflow`

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
