### PR TITLE
Remove material_id from elasticity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ase>=3.24.0", # for Atoms object and calculators
     "custodian>=2024.10.15", # for automated error corrections
-    "emmet-core>=0.86.0", # for pre-made schemas
+    "emmet-core>=0.84.6", # for pre-made schemas
     "frozendict>=2.4.6", # for caching of dictionaries in @lru_cache
     "maggma>=0.64.0", # for database handling
     "monty>=2024.5.15", # miscellaneous Python utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ase>=3.24.0", # for Atoms object and calculators
     "custodian>=2024.10.15", # for automated error corrections
-    "emmet-core>=0.84.3rc6", # for pre-made schemas
+    "emmet-core>=0.86.0", # for pre-made schemas
     "frozendict>=2.4.6", # for caching of dictionaries in @lru_cache
     "maggma>=0.64.0", # for database handling
     "monty>=2024.5.15", # miscellaneous Python utilities

--- a/src/quacc/recipes/common/elastic.py
+++ b/src/quacc/recipes/common/elastic.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from ase import units
 from ase.stress import voigt_6_to_full_3x3_stress
 from emmet.core.elasticity import ElasticityDoc
-from emmet.core.mpid import MPID
 from pymatgen.analysis.elasticity.stress import Stress
 from pymatgen.io.ase import AseAtomsAdaptor
 

--- a/src/quacc/recipes/common/elastic.py
+++ b/src/quacc/recipes/common/elastic.py
@@ -182,7 +182,6 @@ def _deformations_to_elastic_tensor(
     ]
     return ElasticityDoc.from_deformations_and_stresses(
         structure,
-        MPID("quacc-00"),
         deformations=deformed_structure_set.deformations,
         equilibrium_stress=equilibrium_stress,
         stresses=stresses,

--- a/tests/requirements-mlp2.txt
+++ b/tests/requirements-mlp2.txt
@@ -1,2 +1,2 @@
 mace-torch==0.3.12
-matgl @ git+https://github.com/materialsvirtuallab/matgl.git
+matgl==1.2.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ase==3.24.0
 custodian==2024.10.16
-emmet-core==0.84.6
+emmet-core==0.86.0
 frozendict==2.4.6
 maggma==0.71.5
 monty==2025.3.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ase==3.24.0
 custodian==2024.10.16
-emmet-core==0.86.0
+emmet-core==0.84.6
 frozendict==2.4.6
 maggma==0.71.5
 monty==2025.3.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ase==3.24.0
 custodian==2024.10.16
-emmet-core==0.84.5
+emmet-core==0.84.6
 frozendict==2.4.6
 maggma==0.71.5
 monty==2025.3.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 ase==3.24.0
 custodian==2024.10.16
-emmet-core==0.84.6
+emmet-core==0.84.7rc1
 frozendict==2.4.6
 maggma==0.71.5
 monty==2025.3.3


### PR DESCRIPTION
## Summary of Changes

Emmet 0.86 makes material_id optional and moves it in the function definition, breaking this code. Since we don't really need a material_id anyways, just remove it. This will now only work on emmet>=0.86.0.

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
