### PR TITLE
Breaking: No longer support `quacc_results.json` file and automated storing of data in the `STORE`

### DIFF
--- a/docs/user/db/basics.md
+++ b/docs/user/db/basics.md
@@ -4,7 +4,7 @@ Here, we describe how to set up quacc with a database of your choosing.
 
 === "General Purpose"
 
-    For a given recipe, you can have quacc automatically store the final output summaries in your desired database by defining a [Maggma data store](https://materialsproject.github.io/maggma/reference/stores/) in the `STORE` [quacc setting](../settings/settings.md).
+    You can store the output of quacc jobs and flows in your database of choice by defining a [Maggma data store](https://materialsproject.github.io/maggma/reference/stores/).
 
     For instance, let's pretend you have decided to make a [`MongoStore`](https://materialsproject.github.io/maggma/reference/stores/#maggma.stores.mongolike.MongoStore) be your database of choice. Instantiating that class might look like the following
 
@@ -21,42 +21,27 @@ Here, we describe how to set up quacc with a database of your choosing.
     )
     ```
 
-    To replicate the same behavior, simply specify the `STORE` setting in your `~/.quacc.yaml` file using the class as the name of the `Store` and all arguments provided as key-value pairs.
+    Then, to store results in your database, you can use the [quacc.wflow_tools.db.results_to_db][] function, as shown in the example below.
 
-    ```yaml title="~/.quacc.yaml"
-    STORE:
-      MongoStore:
-        database: my_db_name
-        collection_name: my_collection_name
-        username: my_username
-        password: my_password
-        host: my_hostname
-        port: 27017
+    ```python
+    from maggma.stores import MongoStore
+    from quacc.wflow_tools.db import results_to_db
+
+    # Let `results` be an output (or list of outputs) from quacc recipes
+
+    # Define your database details
+    store = MongoStore(
+        database="my_db_name",
+        collection_name="my_collection_name",
+        username="my_username",
+        password="my_password",
+        host="my_hostname",
+        port=27017,
+    )
+
+    # Store the results
+    results_to_db(store, results)
     ```
-
-    ??? "How to Manually Upload to a Data Store"
-
-        If you would prefer to store results in your database manually (perhaps because you are limited in terms of how much data you can store), you can use the [quacc.wflow_tools.db.results_to_db][] function, as shown in the example below.
-
-        ```python
-        from maggma.stores import MongoStore
-        from quacc.wflow_tools.db import results_to_db
-
-        # Let `results` be an output (or list of outputs) from quacc recipes
-
-        # Define your database details
-        store = MongoStore(
-            database="my_db_name",
-            collection_name="my_collection_name",
-            username="my_username",
-            password="my_password",
-            host="my_hostname",
-            port=27017,
-        )
-
-        # Store the results
-        results_to_db(store, results)
-        ```
 
 === "Covalent"
 

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -118,16 +118,6 @@ print(result)
     'volume': 11.761470249999999}
     ```
 
-!!! Note "Loading the JSON Output"
-
-    A serialized version of the printed output above is also written to the filesystem with the name `quacc_results.json.gz`. It can be read back in as follows:
-
-    ```python
-    from monty.serialization import loadfn
-
-    results = loadfn("quacc_results.json.gz")
-    ```
-
 ### A Mixed-Code Workflow
 
 ```mermaid
@@ -447,7 +437,7 @@ print(result)
     'volume': 11.563195249785407}
     ```
 
-You will also see that [quacc.recipes.emt.core.relax_job][] takes an `opt_params` keyword argument that allows you to pass in a dictionary of parameters to the optimizer. That may look something like the following.
+You will also see that [quacc.recipes.emt.core.relax_job][] takes a variety of other keyword arguments that allow you to modify the behavior of the optimization settings. That may look something like the following.
 
 ```python
 from ase.build import bulk
@@ -458,7 +448,7 @@ from quacc.recipes.emt.core import relax_job
 atoms = bulk("Cu")
 
 # Run a structure relaxation with modified optimizer parameters
-result = relax_job(atoms, opt_params={"fmax": 1e-3, "optimizer": LBFGS})
+result = relax_job(atoms, fmax=1e-3, optimizer=LBFGS)
 print(result)
 ```
 

--- a/docs/user/recipes/recipes_intro.md
+++ b/docs/user/recipes/recipes_intro.md
@@ -118,6 +118,16 @@ print(result)
     'volume': 11.761470249999999}
     ```
 
+!!! Note "Loading the JSON Output"
+
+    A serialized version of the printed output above is also written to the filesystem with the name `quacc_results.json.gz`. It can be read back in as follows:
+
+    ```python
+    from monty.serialization import loadfn
+
+    results = loadfn("quacc_results.json.gz")
+    ```
+
 ### A Mixed-Code Workflow
 
 ```mermaid
@@ -437,7 +447,7 @@ print(result)
     'volume': 11.563195249785407}
     ```
 
-You will also see that [quacc.recipes.emt.core.relax_job][] takes a variety of other keyword arguments that allow you to modify the behavior of the optimization settings. That may look something like the following.
+You will also see that [quacc.recipes.emt.core.relax_job][] takes an `opt_params` keyword argument that allows you to pass in a dictionary of parameters to the optimizer. That may look something like the following.
 
 ```python
 from ase.build import bulk
@@ -448,7 +458,7 @@ from quacc.recipes.emt.core import relax_job
 atoms = bulk("Cu")
 
 # Run a structure relaxation with modified optimizer parameters
-result = relax_job(atoms, fmax=1e-3, optimizer=LBFGS)
+result = relax_job(atoms, opt_params={"fmax": 1e-3, "optimizer": LBFGS})
 print(result)
 ```
 

--- a/docs/user/recipes/workflows.md
+++ b/docs/user/recipes/workflows.md
@@ -35,7 +35,7 @@ print(result)
 
 ### Modifying a Subset of Jobs
 
-To modify the default parameters of a subset of jobs in a pre-made workflow, you can pass a dictionary of parameters to the `job_params` keyword argument of the workflow function (note: the name and `@job` definition for each step in the pre-made workflow is specified in the flow's docstring). The example below sets `fmax=1e-4` for the `relax_job` called within `bulk_to_slabs_flow`:
+To modify the default parameters of a subset of jobs in a pre-made workflow, you can pass a dictionary of parameters to the `job_params` keyword argument of the workflow function (note: the name and `@job` definition for each step in the pre-made workflow is specified in the flow's docstring). The example below modifies sets `opt_params={"fmax": 1e-4}` for the `relax_job` called within `bulk_to_slabs_flow`:
 
 ```python
 from ase.build import bulk
@@ -45,7 +45,9 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 atoms = bulk("Cu")
 
 # Define the workflow with modified parameters for the `relax_job` step
-result = bulk_to_slabs_flow(atoms, job_params={"relax_job": {"fmax": 1e-4}})
+result = bulk_to_slabs_flow(
+    atoms, job_params={"relax_job": {"opt_params": {"fmax": 1e-4}}}
+)
 
 # Print the result
 print(result)

--- a/docs/user/recipes/workflows.md
+++ b/docs/user/recipes/workflows.md
@@ -35,7 +35,7 @@ print(result)
 
 ### Modifying a Subset of Jobs
 
-To modify the default parameters of a subset of jobs in a pre-made workflow, you can pass a dictionary of parameters to the `job_params` keyword argument of the workflow function (note: the name and `@job` definition for each step in the pre-made workflow is specified in the flow's docstring). The example below modifies sets `opt_params={"fmax": 1e-4}` for the `relax_job` called within `bulk_to_slabs_flow`:
+To modify the default parameters of a subset of jobs in a pre-made workflow, you can pass a dictionary of parameters to the `job_params` keyword argument of the workflow function (note: the name and `@job` definition for each step in the pre-made workflow is specified in the flow's docstring). The example below sets `fmax=1e-4` for the `relax_job` called within `bulk_to_slabs_flow`:
 
 ```python
 from ase.build import bulk
@@ -45,9 +45,7 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 atoms = bulk("Cu")
 
 # Define the workflow with modified parameters for the `relax_job` step
-result = bulk_to_slabs_flow(
-    atoms, job_params={"relax_job": {"opt_params": {"fmax": 1e-4}}}
-)
+result = bulk_to_slabs_flow(atoms, job_params={"relax_job": {"fmax": 1e-4}})
 
 # Print the result
 print(result)

--- a/docs/user/settings/file_management.md
+++ b/docs/user/settings/file_management.md
@@ -80,8 +80,7 @@ Once the job successfully completes, the file structure looks like:
 RESULTS_DIR
 ├── quacc-2023-12-08-67890
 │   ├── INPUT.gz
-    ├── OUTPUT.gz
-    └── quacc_results.json.gz
+    └── OUTPUT.gz
 ```
 
 ```text

--- a/src/quacc/_cli/quacc.py
+++ b/src/quacc/_cli/quacc.py
@@ -10,11 +10,11 @@ from typer import Exit, Option, Typer
 from quacc import get_settings
 from quacc.settings import QuaccSettings, _type_handler
 
-app = Typer()
-
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
+
+app = Typer()
 
 
 def callback(value: bool) -> None:

--- a/src/quacc/recipes/dftb/_base.py
+++ b/src/quacc/recipes/dftb/_base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from quacc.types import Filenames, RunSchema, SourceDirectory
 
-GEOM_FILE = "geo_end.gen"
+_GEOM_FILE = "geo_end.gen"
 
 
 def run_and_summarize(
@@ -55,7 +55,7 @@ def run_and_summarize(
 
     calc = Dftb(**calc_flags)
     final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc(
-        geom_file=GEOM_FILE
+        geom_file=_GEOM_FILE
     )
 
     return Summarize(additional_fields=additional_fields).run(final_atoms, atoms)

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from quacc import job
+from quacc import Remove, job
 from quacc.recipes.dftb._base import run_and_summarize
 
 if TYPE_CHECKING:
@@ -55,9 +55,8 @@ def static_job(
         "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
         "Hamiltonian_MaxSccIterations": 200,
         "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
+        "Hamiltonian_Method": method if "xtb" in method.lower() else Remove,
     }
-    if "xtb" in method.lower():
-        calc_defaults["Hamiltonian_Method"] = method
 
     return run_and_summarize(
         atoms,
@@ -109,16 +108,15 @@ def relax_job(
         See the return type-hint for the data structure.
     """
     calc_defaults = {
+        "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
+        "Hamiltonian_MaxSccIterations": 200,
+        "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
+        "Hamiltonian_Method": method if "xtb" in method.lower() else Remove,
         "Driver_": "GeometryOptimization",
         "Driver_AppendGeometries": "Yes",
         "Driver_LatticeOpt": "Yes" if relax_cell else "No",
         "Driver_MaxSteps": 2000,
-        "Hamiltonian_": "xTB" if "xtb" in method.lower() else "DFTB",
-        "Hamiltonian_MaxSccIterations": 200,
-        "kpts": kpts or ((1, 1, 1) if atoms.pbc.any() else None),
     }
-    if "xtb" in method.lower():
-        calc_defaults["Hamiltonian_Method"] = method
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -19,15 +19,12 @@ if TYPE_CHECKING:
 
     from ase.atoms import Atoms
 
-    from quacc.types import Filenames, OptParams, OptSchema, RunSchema, SourceDirectory
+    from quacc.types import OptParams, OptSchema, RunSchema
 
 
 @job
 def static_job(
-    atoms: Atoms,
-    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
-    additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    atoms: Atoms, additional_fields: dict[str, Any] | None = None, **calc_kwargs
 ) -> RunSchema:
     """
     Carry out a static calculation.
@@ -36,8 +33,6 @@ def static_job(
     ----------
     atoms
         Atoms object
-    copy_files
-        Files to copy (and decompress) from source to the runtime directory.
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -52,7 +47,7 @@ def static_job(
         See the type-hint for the data structure.
     """
     calc = EMT(**calc_kwargs)
-    final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
+    final_atoms = Runner(atoms, calc).run_calc()
 
     return Summarize(
         additional_fields={"name": "EMT Static"} | (additional_fields or {})
@@ -64,7 +59,6 @@ def relax_job(
     atoms: Atoms,
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
-    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
@@ -80,8 +74,6 @@ def relax_job(
     opt_params
         Dictionary of custom kwargs for the optimization process. For a list
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
-    copy_files
-        Files to copy (and decompress) from source to the runtime directory.
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -98,9 +90,7 @@ def relax_job(
     opt_params = opt_params or {}
 
     calc = EMT(**calc_kwargs)
-    dyn = Runner(atoms, calc, copy_files=copy_files).run_opt(
-        relax_cell=relax_cell, **opt_params
-    )
+    dyn = Runner(atoms, calc).run_opt(relax_cell=relax_cell, **opt_params)
 
     return Summarize(
         additional_fields={"name": "EMT Relax"} | (additional_fields or {})

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 import psutil
 
-from quacc import job
-from quacc.recipes.gaussian._base import run_and_summarize
+from quacc import Remove, job
+from quacc.recipes.gaussian._base import _LABEL, run_and_summarize
 
 if TYPE_CHECKING:
     from typing import Any
@@ -58,20 +58,21 @@ def static_job(
         Dictionary of results
     """
     calc_defaults = {
+        # General settings
         "mem": "16GB",
-        "chk": "Gaussian.chk",
+        "chk": f"{_LABEL}.chk",
         "nprocshared": psutil.cpu_count(logical=False),
         "xc": xc,
         "basis": basis,
         "charge": charge,
         "mult": spin_multiplicity,
-        "force": "",
         "scf": ["maxcycle=250", "xqc"],
         "integral": "ultrafine",
-        "nosymmetry": "",
         "pop": "CM5",
+        # Job-specific settings
+        "force": "",
         "gfinput": "",
-        "ioplist": ["6/7=3", "2/9=2000"],  # see ASE issue #660
+        "ioplist": ["6/7=3", "2/9=2000"],  # https://gitlab.com/ase/ase/-/issues/660
     }
     return run_and_summarize(
         atoms,
@@ -126,22 +127,23 @@ def relax_job(
         Dictionary of results
     """
     calc_defaults = {
+        # General settings
         "mem": "16GB",
-        "chk": "Gaussian.chk",
+        "chk": f"{_LABEL}.chk",
         "nprocshared": psutil.cpu_count(logical=False),
         "xc": xc,
         "basis": basis,
         "charge": charge,
         "mult": spin_multiplicity,
-        "opt": "",
-        "pop": "CM5",
         "scf": ["maxcycle=250", "xqc"],
         "integral": "ultrafine",
+        "pop": "CM5",
+        # Job-specific settings
+        "opt": "",
         "nosymmetry": "",
-        "ioplist": ["2/9=2000"],  # ASE issue #660
+        "ioplist": ["2/9=2000"],  # https://gitlab.com/ase/ase/-/issues/660
+        "freq": "" if freq else Remove,
     }
-    if freq:
-        calc_defaults["freq"] = ""
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -32,10 +32,7 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms,
-    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
-    additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    atoms: Atoms, additional_fields: dict[str, Any] | None = None, **calc_kwargs
 ) -> RunSchema:
     """
     Function to carry out a static calculation.
@@ -44,8 +41,6 @@ def static_job(
     ----------
     atoms
         Atoms object
-    copy_files
-        Files to copy (and decompress) from source to the runtime directory.
     **calc_kwargs
         Dictionary of custom kwargs for the LJ calculator. Set a value to
         `quacc.Remove` to remove a pre-existing key entirely. For a list of available
@@ -58,7 +53,7 @@ def static_job(
         See the type-hint for the data structure.
     """
     calc = LennardJones(**calc_kwargs)
-    final_atoms = Runner(atoms, calc, copy_files=copy_files).run_calc()
+    final_atoms = Runner(atoms, calc).run_calc()
 
     return Summarize(
         additional_fields={"name": "LJ Static"} | (additional_fields or {})
@@ -69,7 +64,6 @@ def static_job(
 def relax_job(
     atoms: Atoms,
     opt_params: OptParams | None = None,
-    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
@@ -83,8 +77,6 @@ def relax_job(
     opt_params
         Dictionary of custom kwargs for the optimization process. For a list
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
-    copy_files
-        Files to copy (and decompress) from source to the runtime directory.
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -101,7 +93,7 @@ def relax_job(
     opt_params = opt_params or {}
 
     calc = LennardJones(**calc_kwargs)
-    dyn = Runner(atoms, calc, copy_files=copy_files).run_opt(**opt_params)
+    dyn = Runner(atoms, calc).run_opt(**opt_params)
 
     return Summarize(
         additional_fields={"name": "LJ Relax"} | (additional_fields or {})
@@ -115,7 +107,6 @@ def freq_job(
     temperature: float = 298.15,
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
-    copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VibThermoSchema:
@@ -134,8 +125,6 @@ def freq_job(
         Pressure in bar.
     vib_kwargs
         Dictionary of kwargs for the [ase.vibrations.Vibrations][] class.
-    copy_files
-        Files to copy (and decompress) from source to the runtime directory.
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -151,7 +140,7 @@ def freq_job(
     vib_kwargs = vib_kwargs or {}
 
     calc = LennardJones(**calc_kwargs)
-    vib = Runner(atoms, calc, copy_files=copy_files).run_vib(vib_kwargs=vib_kwargs)
+    vib = Runner(atoms, calc).run_vib(vib_kwargs=vib_kwargs)
 
     return VibSummarize(
         vib,

--- a/src/quacc/recipes/mlp/_base.py
+++ b/src/quacc/recipes/mlp/_base.py
@@ -1,4 +1,4 @@
-"""Base functions for universal machine-learned interatomic potentials."""
+"""Common utility functions for universal machine-learned interatomic potentials."""
 
 from __future__ import annotations
 
@@ -7,9 +7,12 @@ from importlib.util import find_spec
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
+from monty.dev import requires
+
+has_frozen = bool(find_spec("frozendict"))
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Literal
 
     from ase.calculators.calculator import BaseCalculator
@@ -17,11 +20,24 @@ if TYPE_CHECKING:
 LOGGER = getLogger(__name__)
 
 
-def freezeargs(func):
-    """Convert a mutable dictionary into immutable.
+@requires(has_frozen, "frozendict must be installed. Run pip install frozendict.")
+def freezeargs(func: Callable) -> Callable:
+    """
+    Convert a mutable dictionary into immutable.
     Useful to make sure dictionary args are compatible with cache
     From https://stackoverflow.com/a/53394430
+
+    Parameters
+    ----------
+    func
+        Function to be wrapped.
+
+    Returns
+    -------
+    Callable
+        Wrapped function with frozen dictionary arguments.
     """
+    from frozendict import frozendict
 
     @wraps(func)
     def wrapped(*args, **kwargs):
@@ -63,8 +79,8 @@ def pick_calculator(
 
     Returns
     -------
-    Calculator
-        The chosen calculator
+    BaseCalculator
+        The instantiated calculator
     """
     import torch
 

--- a/src/quacc/recipes/mlp/core.py
+++ b/src/quacc/recipes/mlp/core.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     method: Literal["mace-mp-0", "m3gnet", "chgnet", "sevennet", "orb", "fairchem"],
-    properties: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> RunSchema:
@@ -35,8 +34,6 @@ def static_job(
         Atoms object
     method
         Universal ML interatomic potential method to use
-    properties
-        A list of properties to obtain. Defaults to ["energy", "forces"]
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -54,9 +51,7 @@ def static_job(
         See the type-hint for the data structure.
     """
     calc = pick_calculator(method, **calc_kwargs)
-    if properties is None:
-        properties = ["energy", "forces"]
-    final_atoms = Runner(atoms, calc).run_calc(properties=properties)
+    final_atoms = Runner(atoms, calc).run_calc()
     return Summarize(
         additional_fields={"name": f"{method} Static"} | (additional_fields or {})
     ).run(final_atoms, atoms)

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -240,10 +240,12 @@ class Runner(BaseRunner):
         if relax_cell and self.atoms.pbc.any():
             self.atoms = FrechetCellFilter(self.atoms, **filter_kwargs)
 
-        # Run optimization
+        # Define run kwargs
         full_run_kwargs = {"steps": max_steps, **run_kwargs}
         if not issubclass(optimizer, MolecularDynamics):
             full_run_kwargs["fmax"] = fmax
+
+        # Run optimization
         try:
             with traj, optimizer(self.atoms, **merged_optimizer_kwargs) as dyn:
                 if issubclass(optimizer, SciPyOptimizer | MolecularDynamics):
@@ -372,7 +374,7 @@ class Runner(BaseRunner):
         relax_cell: bool = False,
         fmax: float = 0.01,
         max_steps: int | None = 1000,
-        optimizer: Optimizer = NEBOptimizer,
+        optimizer: type[Optimizer] = NEBOptimizer,
         optimizer_kwargs: dict[str, Any] | None = None,
         neb_kwargs: dict[str, Any] | None = None,
         run_kwargs: dict[str, Any] | None = None,

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -93,7 +93,9 @@ class Runner(BaseRunner):
             self.atoms.calc = calculator
             self.setup()
 
-    def run_calc(self, geom_file: str | None = None) -> Atoms:
+    def run_calc(
+        self, properties: list[str] | None = None, geom_file: str | None = None
+    ) -> Atoms:
         """
         This is a wrapper around `atoms.calc.calculate()`.
 
@@ -104,16 +106,20 @@ class Runner(BaseRunner):
             update the atoms object's positions and cell after a job. It is better
             to specify this rather than relying on ASE to update the positions, as the
             latter behavior varies between codes.
+        properties
+            A list of properties to obtain. Defaults to ["energy", "forces"]
 
         Returns
         -------
         Atoms
             The updated Atoms object.
         """
-        if isinstance(self.atoms.calc, Gaussian):
-            properties = ["energy"]  # TODO: Use GaussianOptimizer to avoid this hack
-        else:
-            properties = ["energy", "forces"]
+        if not properties:
+            properties = (
+                ["energy"]
+                if isinstance(self.atoms.calc, Gaussian)
+                else ["energy", "forces"]
+            )  # TODO: Use GaussianOptimizer to avoid this hack
 
         # Run calculation
         try:

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -235,7 +235,7 @@ class Runner(BaseRunner):
             self.atoms = FrechetCellFilter(self.atoms, **filter_kwargs)
 
         # Run optimization
-        full_run_kwargs = {"fmax": fmax, "steps": max_steps, **run_kwargs}
+        full_run_kwargs = {"steps": max_steps, **run_kwargs}
         if not issubclass(optimizer, MolecularDynamics):
             full_run_kwargs["fmax"] = fmax
         try:

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -479,14 +479,12 @@ class VibSummarize:
 
         # Generate vib data
         vib_schema = self.vib(is_molecule=is_molecule)
-        directory = vib_schema["dir_name"]
 
         # Generate thermo data
         thermo_summary = ThermoSummarize(
             atoms,
             vib_schema["results"]["vib_freqs_raw"],
             energy=energy,
-            directory=directory,
             additional_fields=self.additional_fields,
         )
         if thermo_method == "ideal_gas":

--- a/src/quacc/schemas/phonons.py
+++ b/src/quacc/schemas/phonons.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 
 from monty.dev import requires
 
-from quacc import QuaccDefault, __version__, get_settings
+from quacc import QuaccDefault, __version__
 from quacc.schemas.atoms import atoms_to_metadata
-from quacc.utils.dicts import finalize_dict
+from quacc.utils.dicts import clean_dict
 from quacc.utils.files import get_uri
 
 has_phonopy = bool(find_spec("phonopy"))
@@ -34,7 +34,6 @@ def summarize_phonopy(
     directory: str | Path,
     parameters: dict[str, Any] | None = None,
     additional_fields: dict[str, Any] | None = None,
-    store: Store | None | DefaultSetting = QuaccDefault,
 ) -> PhononSchema:
     """
     Summarize a Phonopy object.
@@ -51,8 +50,6 @@ def summarize_phonopy(
         Calculator parameters used to generate the phonon object.
     additional_fields
         Additional fields to add to the document.
-    store
-        Whether to store the document in the database.
 
     Returns
     -------
@@ -60,8 +57,6 @@ def summarize_phonopy(
         The PhononSchema.
     """
     additional_fields = additional_fields or {}
-    settings = get_settings()
-    store = settings.STORE if store == QuaccDefault else store
 
     inputs = {
         "parameters": parameters,
@@ -82,9 +77,4 @@ def summarize_phonopy(
 
     atoms_metadata = atoms_to_metadata(input_atoms)
     unsorted_task_doc = atoms_metadata | inputs | results | additional_fields
-    return finalize_dict(
-        unsorted_task_doc,
-        directory=directory,
-        gzip_file=settings.GZIP_FILES,
-        store=store,
-    )
+    return clean_dict(unsorted_task_doc)

--- a/src/quacc/schemas/thermo.py
+++ b/src/quacc/schemas/thermo.py
@@ -169,8 +169,6 @@ class ThermoSummarize:
                 "n_imag": harmonic_thermo.n_imag,
                 "method": "harmonic",
             },
-            "nid": get_uri(self.directory).split(":")[0],
-            "dir_name": self.directory,
             "quacc_version": __version__,
         }
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -436,20 +436,6 @@ class QuaccSettings(BaseSettings):
             v.mkdir(exist_ok=True, parents=True)
         return v
 
-    @field_validator("STORE")
-    @classmethod
-    def generate_store(cls, v: Union[dict[str, dict[str, Any]], Store]) -> Store:
-        """Generate the Maggma store."""
-        from maggma import stores
-
-        if isinstance(v, dict):
-            store_name = next(iter(v.keys()))
-            store = getattr(stores, store_name)
-
-            return store(**v[store_name])
-        else:
-            return v
-
     @field_validator("ESPRESSO_PARALLEL_CMD")
     @classmethod
     def validate_espresso_parallel_cmd(

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -107,32 +107,6 @@ class QuaccSettings(BaseSettings):
     )
 
     # ---------------------------
-    # Data Store Settings
-    # ---------------------------
-    STORE: Optional[Union[dict[str, dict], Store]] = Field(
-        None,
-        description=(
-            """
-            The desired Maggma data store where calculation results will be stored. All data stores listed in
-            `maggma.stores.__init__.py` are supported. If a dictionary is provided, the first key must be set
-            to the desired store type. The sub-parameters are the keyword arguments accepted by the Store.
-            An example is shown below:
-
-            ```yaml
-            STORE:
-              MongoStore:
-                database: my_db
-                collection_name: my_collection
-                username: my_username
-                password: my_password
-                host: localhost
-                port: 27017
-            ```
-            """
-        ),
-    )
-
-    # ---------------------------
     # Prefect Settings
     # ---------------------------
     PREFECT_AUTO_SUBMIT: bool = Field(

--- a/src/quacc/utils/dicts.py
+++ b/src/quacc/utils/dicts.py
@@ -5,18 +5,10 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from copy import deepcopy
 from logging import getLogger
-from pathlib import Path
 from typing import TYPE_CHECKING
-
-from monty.json import jsanitize
-from monty.serialization import dumpfn
-
-from quacc.wflow_tools.db import results_to_db
 
 if TYPE_CHECKING:
     from typing import Any
-
-    from maggma.stores import Store
 
 LOGGER = getLogger(__name__)
 
@@ -180,53 +172,3 @@ def clean_dict(start_dict: MutableMapping[str, Any]) -> MutableMapping[str, Any]
         Cleaned dictionary
     """
     return sort_dict(remove_dict_entries(start_dict, None))
-
-
-def finalize_dict(
-    task_doc: dict,
-    directory: str | Path | None = None,
-    gzip_file: bool = True,
-    store: Store | None = None,
-) -> MutableMapping[str, Any]:
-    """
-    Finalize a schema by cleaning it and storing it in a database and/or file.
-
-    Parameters
-    ----------
-    task_doc
-        Dictionary representation of the task document.
-    directory
-        Directory where the results file is stored.
-    gzip_file
-        Whether to gzip the results file.
-    store
-        Maggma Store object to store the results in.
-
-    Returns
-    -------
-    dict
-        Cleaned task document
-    """
-
-    cleaned_task_doc = clean_dict(task_doc)
-    if directory:
-        if "tmp-quacc" in str(directory):
-            raise ValueError("The directory should not be a temporary directory.")
-
-        sanitized_schema = jsanitize(
-            cleaned_task_doc, enum_values=True, recursive_msonable=True
-        )
-        dumpfn(
-            sanitized_schema,
-            Path(
-                directory,
-                "quacc_results.json.gz" if gzip_file else "quacc_results.json",
-            ),
-            fmt="json",
-            indent=4,
-        )
-
-    if store:
-        results_to_db(store, task_doc)
-
-    return cleaned_task_doc

--- a/tests/core/.quacc.yaml
+++ b/tests/core/.quacc.yaml
@@ -1,5 +1,2 @@
 LOG_LEVEL: DEBUG
 WORKFLOW_ENGINE: null
-STORE:
-  MemoryStore:
-    collection_name: test_store

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from logging import getLogger
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -225,7 +224,6 @@ def test_customizer_v2():
     results = bulk_to_slabs_flow(atoms, job_params={"relax_job": {"asap_cutoff": True}})
     for result in results:
         assert result["parameters"]["asap_cutoff"] is False
-        assert Path(result["dir_name"], "quacc_results.json.gz").exists()
 
 
 def test_all_customizers():

--- a/tests/core/recipes/lj_recipes/test_lj_recipes.py
+++ b/tests/core/recipes/lj_recipes/test_lj_recipes.py
@@ -3,33 +3,30 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from ase.build import bulk, molecule
-from maggma.stores import MemoryStore
 
-from quacc import change_settings
 from quacc.recipes.lj.core import freq_job, relax_job, static_job
 
 
 def test_static_job(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    with change_settings({"STORE": MemoryStore()}):
-        atoms = molecule("H2O")
+    atoms = molecule("H2O")
 
-        output = static_job(atoms)
-        assert output["molecule_metadata"]["natoms"] == len(atoms)
-        assert output["parameters"]["epsilon"] == 1.0
-        assert output["parameters"]["sigma"] == 1.0
-        assert output["parameters"]["rc"] == 3
-        assert output["parameters"]["ro"] == 0.66 * 3
-        assert output["results"]["energy"] == pytest.approx(1.772068860679255)
+    output = static_job(atoms)
+    assert output["molecule_metadata"]["natoms"] == len(atoms)
+    assert output["parameters"]["epsilon"] == 1.0
+    assert output["parameters"]["sigma"] == 1.0
+    assert output["parameters"]["rc"] == 3
+    assert output["parameters"]["ro"] == 0.66 * 3
+    assert output["results"]["energy"] == pytest.approx(1.772068860679255)
 
-        output = static_job(atoms, epsilon=2.0, rc=0.5)
-        assert output["molecule_metadata"]["natoms"] == len(atoms)
-        assert output["parameters"]["epsilon"] == 2.0
-        assert output["parameters"]["sigma"] == 1.0
-        assert output["parameters"]["rc"] == 0.5
-        assert output["parameters"]["ro"] == 0.66 * 0.5
-        assert output["results"]["energy"] == pytest.approx(0.0)
+    output = static_job(atoms, epsilon=2.0, rc=0.5)
+    assert output["molecule_metadata"]["natoms"] == len(atoms)
+    assert output["parameters"]["epsilon"] == 2.0
+    assert output["parameters"]["sigma"] == 1.0
+    assert output["parameters"]["rc"] == 0.5
+    assert output["parameters"]["ro"] == 0.66 * 0.5
+    assert output["results"]["energy"] == pytest.approx(0.0)
 
 
 def test_static_job_v2(tmp_path, monkeypatch):

--- a/tests/core/schemas/test_ase.py
+++ b/tests/core/schemas/test_ase.py
@@ -197,9 +197,6 @@ def test_vib_run1(monkeypatch, tmp_path):
     assert len(results["results"]["vib_energies"]) == 1
     assert results["results"]["vib_energies"][0] == pytest.approx(0.11507528256667966)
 
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
-
 
 def test_vib_run2(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
@@ -272,9 +269,6 @@ def test_summarize_vib_and_thermo_run1(tmp_path, monkeypatch):
     assert len(results["results"]["vib_energies"]) == 1
     assert results["results"]["vib_energies"][0] == pytest.approx(0.11507528256667966)
 
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
-
 
 def test_summarize_vib_and_thermo_run2(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -289,9 +283,6 @@ def test_summarize_vib_and_thermo_run2(tmp_path, monkeypatch):
 
     results = VibSummarize(vib).vib_and_thermo("ideal_gas")
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
-
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
 
     # test document can be jsanitized and decoded
     d = jsanitize(results, strict=True, enum_values=True)
@@ -316,9 +307,6 @@ def test_summarize_vib_and_thermo_run3(tmp_path, monkeypatch):
     assert len(results["results"]["vib_energies_raw"]) == 6
     assert len(results["results"]["vib_freqs"]) == 6
     assert len(results["results"]["vib_energies"]) == 6
-
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
 
 
 def test_summarize_vib_and_thermo_run4(tmp_path, monkeypatch):

--- a/tests/core/schemas/test_thermo.py
+++ b/tests/core/schemas/test_thermo.py
@@ -17,38 +17,34 @@ LOGGER = getLogger(__name__)
 LOGGER.propagate = True
 
 
-def test_run_ideal_gas(tmp_path):
+def test_run_ideal_gas():
     co2 = molecule("CO2")
-    igt = ThermoSummarize(
-        co2, [526, 526, 1480, 2565], directory=tmp_path
-    )._make_ideal_gas()
+    igt = ThermoSummarize(co2, [526, 526, 1480, 2565])._make_ideal_gas()
     assert igt.geometry == "linear"
     assert igt.spin == 0
     assert igt.get_ZPE_correction() == pytest.approx(2548.5 * invcm)
 
     co2 = molecule("CO2")
-    igt = ThermoSummarize(
-        co2, [526, 526, 1480, 2565], directory=tmp_path
-    )._make_ideal_gas(spin_multiplicity=2)
+    igt = ThermoSummarize(co2, [526, 526, 1480, 2565])._make_ideal_gas(
+        spin_multiplicity=2
+    )
     assert igt.geometry == "linear"
     assert igt.spin == 0.5
     assert igt.get_ZPE_correction() == pytest.approx(2548.5 * invcm)
 
     co2 = molecule("CO2")
-    igt = ThermoSummarize(
-        co2, [-12, 526, 526, 1480, 2565], directory=tmp_path
-    )._make_ideal_gas(spin_multiplicity=2)
+    igt = ThermoSummarize(co2, [-12, 526, 526, 1480, 2565])._make_ideal_gas(
+        spin_multiplicity=2
+    )
     assert igt.geometry == "linear"
     assert igt.spin == 0.5
     assert igt.get_ZPE_correction() == pytest.approx(2548.5 * invcm)
 
 
-def test_summarize_ideal_gas_thermo1(tmp_path):
+def test_summarize_ideal_gas_thermo1():
     # Make sure metadata is made
     atoms = molecule("N2")
-    results = ThermoSummarize(atoms, [0.34 / invcm], directory=tmp_path).ideal_gas(
-        spin_multiplicity=1
-    )
+    results = ThermoSummarize(atoms, [0.34 / invcm]).ideal_gas(spin_multiplicity=1)
     assert results["molecule_metadata"]["natoms"] == len(atoms)
     assert results["atoms"] == atoms
     assert results["parameters_thermo"]["vib_energies"] == [0.34]
@@ -56,12 +52,12 @@ def test_summarize_ideal_gas_thermo1(tmp_path):
     assert results["results"]["energy"] == 0
 
 
-def test_summarize_ideal_gas_thermo2(tmp_path):
+def test_summarize_ideal_gas_thermo2():
     # Make sure right number of vib energies are reported
     atoms = molecule("N2")
-    results = ThermoSummarize(
-        atoms, [0.0 / invcm, 0.34 / invcm], energy=-1, directory=tmp_path
-    ).ideal_gas(spin_multiplicity=1)
+    results = ThermoSummarize(atoms, [0.0 / invcm, 0.34 / invcm], energy=-1).ideal_gas(
+        spin_multiplicity=1
+    )
     assert results["molecule_metadata"]["natoms"] == len(atoms)
     assert results["atoms"] == atoms
     assert results["parameters_thermo"]["vib_energies"] == [0.34]
@@ -69,18 +65,18 @@ def test_summarize_ideal_gas_thermo2(tmp_path):
     assert results["results"]["energy"] == -1
 
 
-def test_summarize_ideal_gas_thermo3(tmp_path):
+def test_summarize_ideal_gas_thermo3():
     # # # Make sure info tags are handled appropriately
     atoms = molecule("N2")
     atoms.info["test_dict"] = {"hi": "there", "foo": "bar"}
     atoms.calc = EMT()
-    results = ThermoSummarize(
-        atoms, [0.0 / invcm, 0.34 / invcm], energy=-1, directory=tmp_path
-    ).ideal_gas(spin_multiplicity=1)
+    results = ThermoSummarize(atoms, [0.0 / invcm, 0.34 / invcm], energy=-1).ideal_gas(
+        spin_multiplicity=1
+    )
     assert results["atoms"].info.get("test_dict", None) == {"hi": "there", "foo": "bar"}
 
 
-def test_summarize_ideal_gas_thermo4(tmp_path, caplog):
+def test_summarize_ideal_gas_thermo4(caplog):
     # Make sure spin works right
     atoms = molecule("CH3")
     vib_energies = [
@@ -99,7 +95,7 @@ def test_summarize_ideal_gas_thermo4(tmp_path, caplog):
     ]
     with caplog.at_level(WARNING):
         results = ThermoSummarize(
-            atoms, np.array(vib_energies) / invcm, energy=-10.0, directory=tmp_path
+            atoms, np.array(vib_energies) / invcm, energy=-10.0
         ).ideal_gas(temperature=1000.0, pressure=20.0)
     assert "Using a spin multiplicity of 2" in caplog.text
 
@@ -118,7 +114,7 @@ def test_summarize_ideal_gas_thermo4(tmp_path, caplog):
     assert results["parameters_thermo"]["spin_multiplicity"] == 2
 
 
-def test_summarize_ideal_gas_thermo5(tmp_path):
+def test_summarize_ideal_gas_thermo5():
     # Test custom spin
     atoms = molecule("CH3")
     vib_energies = [
@@ -136,13 +132,13 @@ def test_summarize_ideal_gas_thermo5(tmp_path):
         (0.3880868821616261 + 0j),
     ]
     results = ThermoSummarize(
-        atoms, np.array(vib_energies) / invcm, energy=-10.0, directory=tmp_path
+        atoms, np.array(vib_energies) / invcm, energy=-10.0
     ).ideal_gas(spin_multiplicity=2, temperature=1000.0, pressure=20.0)
     assert results["results"]["entropy"] == pytest.approx(0.0023506788982171896)
     assert results["parameters_thermo"]["spin_multiplicity"] == 2
 
 
-def test_summarize_ideal_gas_thermo6(tmp_path):
+def test_summarize_ideal_gas_thermo6():
     # Test custom spin
     atoms = molecule("CH3")
     vib_energies = [
@@ -160,7 +156,7 @@ def test_summarize_ideal_gas_thermo6(tmp_path):
         (0.3880868821616261 + 0j),
     ]
     results = ThermoSummarize(
-        atoms, np.array(vib_energies) / invcm, energy=-10.0, directory=tmp_path
+        atoms, np.array(vib_energies) / invcm, energy=-10.0
     ).ideal_gas(spin_multiplicity=4, temperature=1000.0, pressure=20.0)
     assert results["results"]["entropy"] == pytest.approx(0.0024104096804891486)
     assert results["parameters_thermo"]["spin_multiplicity"] == 4
@@ -173,25 +169,21 @@ def test_summarize_ideal_gas_thermo6(tmp_path):
     MontyDecoder().process_decoded(d)
 
 
-def test_run_harmonic_thermo(tmp_path):
+def test_run_harmonic_thermo():
     co2 = molecule("CO2")
-    ht = ThermoSummarize(
-        co2, [526, 526, 1480, 2565], directory=tmp_path
-    )._make_harmonic_thermo()
+    ht = ThermoSummarize(co2, [526, 526, 1480, 2565])._make_harmonic_thermo()
     assert ht.get_ZPE_correction() == pytest.approx(2548.5 * invcm)
 
     co2 = molecule("CO2")
-    ht = ThermoSummarize(
-        co2, [-12, 526, 526, 1480, 2565], directory=tmp_path
-    )._make_harmonic_thermo()
+    ht = ThermoSummarize(co2, [-12, 526, 526, 1480, 2565])._make_harmonic_thermo()
     assert ht.get_ZPE_correction() == pytest.approx(2548.5 * invcm)
 
 
-def test_summarize_harmonic_thermo(tmp_path):
+def test_summarize_harmonic_thermo():
     atoms = molecule("H2")
 
     # Make sure metadata is made
-    results = ThermoSummarize(atoms, [0.34 / invcm], directory=tmp_path).harmonic()
+    results = ThermoSummarize(atoms, [0.34 / invcm]).harmonic()
     assert results["parameters_thermo"]["vib_energies"] == [0.34]
     assert results["parameters_thermo"]["vib_freqs"] == [0.34 / invcm]
     assert results["results"]["energy"] == 0

--- a/tests/core/schemas/test_thermo.py
+++ b/tests/core/schemas/test_thermo.py
@@ -161,9 +161,6 @@ def test_summarize_ideal_gas_thermo6():
     assert results["results"]["entropy"] == pytest.approx(0.0024104096804891486)
     assert results["parameters_thermo"]["spin_multiplicity"] == 4
 
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
-
     # test document can be jsanitized and decoded
     d = jsanitize(results, strict=True, enum_values=True)
     MontyDecoder().process_decoded(d)
@@ -191,9 +188,6 @@ def test_summarize_harmonic_thermo():
     assert results["results"]["internal_energy"] == pytest.approx(0.1700006085385999)
     assert results["results"]["entropy"] == pytest.approx(2.1952829783392438e-09)
     assert results["results"]["zpe"] == pytest.approx(0.17)
-
-    json_results = loadfn(Path(results["dir_name"], "quacc_results.json.gz"))
-    assert json_results.keys() == results.keys()
 
     # test document can be jsanitized and decoded
     d = jsanitize(results, strict=True, enum_values=True)

--- a/tests/core/schemas/test_vasp_schema.py
+++ b/tests/core/schemas/test_vasp_schema.py
@@ -79,12 +79,6 @@ def test_vasp_summarize_run(run1, monkeypatch, tmp_path):
     VaspSummarize().run(atoms)
     monkeypatch.chdir(tmp_path)
 
-    # Test DB
-    atoms = read(os.path.join(p, "OUTCAR.gz"))
-    store = MemoryStore()
-    VaspSummarize(directory=p).run(atoms, store=store)
-    assert store.count() == 1
-
     # Make sure metadata is made
     atoms = read(os.path.join(run1, "OUTCAR.gz"))
     results = VaspSummarize(directory=p, additional_fields={"test": "hi"}).run(atoms)

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -4,10 +4,9 @@ import os
 from pathlib import Path
 
 from ase.build import bulk
-from maggma.stores import MemoryStore
 
 from quacc import change_settings
-from quacc.recipes.emt.core import relax_job, static_job
+from quacc.recipes.emt.core import relax_job
 from quacc.settings import QuaccSettings
 
 FILE_DIR = Path(__file__).parent
@@ -22,13 +21,6 @@ def test_file(tmp_path, monkeypatch):
     assert QuaccSettings().WORKFLOW_ENGINE is None
     assert QuaccSettings().STORE is None
     os.remove(tmp_path / "quacc_test.yaml")
-
-
-def test_store(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    with change_settings({"STORE": MemoryStore()}):
-        atoms = bulk("Cu")
-        static_job(atoms)
 
 
 def test_results_dir(tmp_path, monkeypatch):

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -19,7 +19,6 @@ def test_file(tmp_path, monkeypatch):
 
     assert QuaccSettings().GZIP_FILES is False
     assert QuaccSettings().WORKFLOW_ENGINE is None
-    assert QuaccSettings().STORE is None
     os.remove(tmp_path / "quacc_test.yaml")
 
 

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -15,7 +15,7 @@ FILE_DIR = Path(__file__).parent
 
 def test_file(tmp_path, monkeypatch):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
-        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None\nSTORE: null")
+        f.write("GZIP_FILES: false\nWORKFLOW_ENGINE: None")
     monkeypatch.setenv("QUACC_CONFIG_FILE", os.path.join(tmp_path, "quacc_test.yaml"))
 
     assert QuaccSettings().GZIP_FILES is False

--- a/tests/core/utils/test_dicts.py
+++ b/tests/core/utils/test_dicts.py
@@ -5,7 +5,7 @@ from logging import WARNING, getLogger
 import pytest
 
 from quacc import Remove
-from quacc.utils.dicts import finalize_dict, recursive_dict_merge, remove_dict_entries
+from quacc.utils.dicts import recursive_dict_merge, remove_dict_entries
 
 LOGGER = getLogger(__name__)
 LOGGER.propagate = True
@@ -82,8 +82,3 @@ def test_recursive_dict_merge_verbose(caplog):
 def test_remove_instantiation():
     with pytest.raises(NotImplementedError):
         Remove()
-
-
-def test_finalize_dict():
-    with pytest.raises(ValueError, match="The directory should not"):
-        finalize_dict({}, directory="tmp-quacc")


### PR DESCRIPTION
This PR removes two features:
- There is no more `quacc_results.json.gz` file written out to disk. This turned out to be way more trouble than it was worth, over-complicating recipes by requiring the use of schemas with knowledge of the current working directory at all times.
- There is no more `STORE` quacc setting. Storing in databases will require calling the `results_to_db` function or using a workflow engine (e.g. Jobflow, FireWorks, Prefect, Covalent). 