### PR TITLE
Clean up kspacing handling

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -300,6 +300,12 @@ def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:
         for ldau_flag in ldau_flags:
             user_calc_params.pop(ldau_flag, None)
 
+    # Handle kspacing flags
+    if user_calc_params.get("kspacing") is None:
+        user_calc_params.pop("kgamma", None)
+    else:
+        user_calc_params.pop("gamma", None)
+
     # Remove None keys
     none_keys = [k for k, v in user_calc_params.items() if v is None]
     for none_key in none_keys:

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -308,7 +308,7 @@ def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:
         user_calc_params.pop("kgamma", None)
 
     # Remove None keys
-    none_keys = [k for k, v in user_calc_params.items() if v is None]
+    none_keys = [k for k, v in user_calc_params.items() if v is None and k != "kpts"]
     for none_key in none_keys:
         del user_calc_params[none_key]
 

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -301,10 +301,11 @@ def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:
             user_calc_params.pop(ldau_flag, None)
 
     # Handle kspacing flags
-    if user_calc_params.get("kspacing") is None:
-        user_calc_params.pop("kgamma", None)
-    else:
+    if user_calc_params.get("kspacing"):
         user_calc_params.pop("gamma", None)
+        user_calc_params["kpts"] = None
+    else:
+        user_calc_params.pop("kgamma", None)
 
     # Remove None keys
     none_keys = [k for k, v in user_calc_params.items() if v is None]

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -302,7 +302,7 @@ def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:
 
     # Handle kspacing flags
     if user_calc_params.get("kspacing"):
-        user_calc_params.pop("gamma", None)
+        user_calc_params["gamma"] = None
         user_calc_params["kpts"] = None
     else:
         user_calc_params.pop("kgamma", None)

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -308,7 +308,11 @@ def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:
         user_calc_params.pop("kgamma", None)
 
     # Remove None keys
-    none_keys = [k for k, v in user_calc_params.items() if v is None and k != "kpts"]
+    none_keys = [
+        k
+        for k, v in user_calc_params.items()
+        if v is None and k not in Vasp_().input_params
+    ]
     for none_key in none_keys:
         del user_calc_params[none_key]
 

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -11,7 +11,6 @@ import numpy as np
 from ase.calculators.vasp import Vasp as Vasp_
 from ase.calculators.vasp import setups as ase_setups
 from ase.constraints import FixAtoms
-from pymatgen.core import Structure
 
 from quacc import QuaccDefault, get_settings
 from quacc.calculators.vasp.io import load_vasp_yaml_calc
@@ -187,6 +186,8 @@ class Vasp(Vasp_):
 
         # Return vanilla ASE command
         if kspacing := self.user_calc_params.get("kspacing"):
+            from pymatgen.core import Structure
+
             nk = [
                 int(
                     max(

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -186,9 +186,7 @@ class Vasp(Vasp_):
             os.environ["ASE_VASP_VDW"] = str(self._settings.VASP_VDW)
 
         # Return vanilla ASE command
-        if np.prod(self.user_calc_params.get("kpts", [1, 1, 1])) == 1:
-            use_gamma = True
-        elif kspacing := self.user_calc_params.get("kspacing"):
+        if kspacing := self.user_calc_params.get("kspacing"):
             nk = [
                 int(
                     max(
@@ -204,6 +202,8 @@ class Vasp(Vasp_):
                 for ik in range(3)
             ]
             use_gamma = bool(np.prod(nk) == 1)
+        elif np.prod(self.user_calc_params.get("kpts", [1, 1, 1])) == 1:
+            use_gamma = True
         else:
             use_gamma = False
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -157,6 +157,17 @@ def test_kspacing():
     calc = Vasp(atoms, kspacing=100, ismear=-5)
     assert calc.int_params["ismear"] == -5
 
+    calc = Vasp(atoms, kspacing=0.1, preset="BulkSet")
+    assert calc.int_params["kspacing"] == 0.1
+    assert calc.kpts is None
+
+    calc = Vasp(atoms, kspacing=0.1, gamma=True)
+    assert calc.int_params["kspacing"] == 0.1
+    assert calc.input_params["gamma"] is None
+
+    calc = Vasp(atoms, kgamma=True)
+    assert calc.bool_params["kgamma"] is None
+
 
 def test_kspacing_aggressive():
     with change_settings({"VASP_INCAR_COPILOT": "aggressive"}):

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -164,8 +164,9 @@ def test_kspacing():
     calc = Vasp(atoms, kspacing=0.1, gamma=True)
     assert calc.float_params["kspacing"] == 0.1
     assert calc.input_params["gamma"] is None
+    assert calc.kpts is None
 
-    calc = Vasp(atoms, kgamma=True)
+    calc = Vasp(atoms, kpts=[1, 1, 1], kgamma=True)
     assert calc.bool_params["kgamma"] is None
 
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -158,11 +158,11 @@ def test_kspacing():
     assert calc.int_params["ismear"] == -5
 
     calc = Vasp(atoms, kspacing=0.1, preset="BulkSet")
-    assert calc.int_params["kspacing"] == 0.1
+    assert calc.float_params["kspacing"] == 0.1
     assert calc.kpts is None
 
     calc = Vasp(atoms, kspacing=0.1, gamma=True)
-    assert calc.int_params["kspacing"] == 0.1
+    assert calc.float_params["kspacing"] == 0.1
     assert calc.input_params["gamma"] is None
 
     calc = Vasp(atoms, kgamma=True)

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -53,7 +53,8 @@ def test_vanilla_vasp():
 
     atoms = bulk("Cu")
     calc = Vasp(atoms, use_custodian=False, kspacing=0.5, incar_copilot=False)
-    assert calc.asdict() == Vasp_().asdict()
+    assert calc.input_params.get("gamma", None) is None
+    assert calc.input_params.get("kpts", None) is None
 
     atoms = bulk("Cu")
     calc = Vasp(atoms, encut=None, incar_copilot=False)

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -52,6 +52,10 @@ def test_vanilla_vasp():
     assert calc.asdict() == Vasp_().asdict()
 
     atoms = bulk("Cu")
+    calc = Vasp(atoms, use_custodian=False, kspacing=0.5, incar_copilot=False)
+    assert calc.asdict() == Vasp_().asdict()
+
+    atoms = bulk("Cu")
     calc = Vasp(atoms, encut=None, incar_copilot=False)
     assert calc.asdict() == Vasp_().asdict()
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -53,8 +53,8 @@ def test_vanilla_vasp():
 
     atoms = bulk("Cu")
     calc = Vasp(atoms, use_custodian=False, kspacing=0.5, incar_copilot=False)
-    assert calc.input_params.get("gamma", None) is None
-    assert calc.input_params.get("kpts", None) is None
+    assert calc.input_params["gamma"] is None
+    assert calc.kpts is None
 
     atoms = bulk("Cu")
     calc = Vasp(atoms, encut=None, incar_copilot=False)


### PR DESCRIPTION
Improve the `Vasp` calculator's handling of KSPACING, e.g. automatically choosing the gamma-point only version of VASP based on how many kpoints there are and making sure there is no conflict between kpts and KSPACING.