### PR TITLE
Quote pip install argument in Steps to Contribute

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -14,7 +14,7 @@ To contribute to quacc, we recommend doing the following:
 
 - [Clone this forked repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local machine, e.g. via `git clone <repo url>.git`.
 
-- In the newly downloaded `quacc` base directory, run `pip install -e .[dev]` to install quacc in editable mode and with the development dependencies. For reproducibility purposes, we strongly recommend installing quacc in a fresh virtual environment.
+- In the newly downloaded `quacc` base directory, run `pip install -e '.[dev]'` to install quacc in editable mode and with the development dependencies. For reproducibility purposes, we strongly recommend installing quacc in a fresh virtual environment.
 
 - [Commit your changes](https://github.com/git-guides/git-commit) and [push them](https://github.com/git-guides/git-push) to your personal forked repository _in a new branch_.
 

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -1,5 +1,5 @@
 # Updating the Docs
 
-To install the dependencies to build the documentation, run `pip install -e .[docs]`.
+To install the dependencies to build the documentation, run `pip install -e '.[docs]'`.
 
 The quacc documentation is built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). To build the documentation locally (e.g. to evaluate changes), run `mkdocs serve` in the base directory and open the URL shown in the terminal.

--- a/docs/install/codes.md
+++ b/docs/install/codes.md
@@ -50,13 +50,13 @@ Several pre-trained "universal" machine-learned potentials (MLPs) are natively s
 To use these potentials, you will need to install the corresponding packages. This can be done as follows:
 
 ```bash
-pip install quacc[mlp1]
+pip install 'quacc[mlp1]'
 ```
 
 or
 
 ```bash
-pip install quacc[mlp2]
+pip install 'quacc[mlp2]'
 ```
 
 Each set of extras comes with different pre-trained MLPs.
@@ -66,7 +66,7 @@ Each set of extras comes with different pre-trained MLPs.
 If you plan to use NewtonNet with Quacc, you will need to install it prior to use. This can be done as follows:
 
 ```bash
-pip install quacc[newtonnet]
+pip install 'quacc[newtonnet]'
 ```
 
 ## ONETEP
@@ -140,7 +140,7 @@ If you plan to use TBLite with quacc, you will need to install the tblite interf
 === "Pip"
 
     ```bash
-    pip install quacc[tblite] # only on Linux
+    pip install 'quacc[tblite]' # only on Linux
     ```
 
 Refer to the [TBLite documentation](https://tblite.readthedocs.io/en/latest/tutorial/parallel.html) for details on how to parallelize calculations and adjust the memory limits.

--- a/docs/install/wflow_engines.md
+++ b/docs/install/wflow_engines.md
@@ -15,7 +15,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
     To install Covalent, run
 
     ```bash
-    pip install quacc[covalent]
+    pip install 'quacc[covalent]'
     ```
 
     **Starting the Server**
@@ -43,7 +43,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
     To install Dask, run the following:
 
     ```bash
-    pip install quacc[dask]
+    pip install 'quacc[dask]'
     ```
 
 === "Parsl"
@@ -53,7 +53,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
     To install Parsl, run the following:
 
     ```bash
-    pip install quacc[parsl]
+    pip install 'quacc[parsl]'
     ```
 
     Parsl has [many configuration options](https://parsl.readthedocs.io/en/stable/userguide/configuring.html), which we will cover later in the documentation.
@@ -65,7 +65,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
     To install Prefect, run the following:
 
     ```bash
-    pip install quacc[prefect]
+    pip install 'quacc[prefect]'
     ```
 
     To connect to Prefect Cloud, run the following as well:
@@ -87,7 +87,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
     To install Redun, run the following:
 
     ```bash
-    pip install quacc[redun]
+    pip install 'quacc[redun]'
     ```
 
 === "Jobflow"
@@ -99,7 +99,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
         To install Jobflow with support for Jobflow-Remote, run the following:
 
         ```bash
-        pip install quacc[jobflow]
+        pip install 'quacc[jobflow]'
         ```
 
         **MongoDB Setup**
@@ -202,7 +202,7 @@ Using a workflow engine is a crucial component for scaling up quacc calculations
         To install Jobflow with support for Fireworks, run the following:
 
         ```bash
-        pip install quacc[jobflow] fireworks
+        pip install 'quacc[jobflow]' fireworks
         ```
 
         **MongoDB Setup**

--- a/docs/user/wflow_engine/executors.md
+++ b/docs/user/wflow_engine/executors.md
@@ -99,7 +99,7 @@ If you haven't done so already:
     On both the local and remote machines:
 
     ```bash
-    pip install quacc[covalent]
+    pip install 'quacc[covalent]'
     quacc set WORKFLOW_ENGINE covalent && quacc set CREATE_UNIQUE_DIR false  # (1)!
     ```
 
@@ -125,7 +125,7 @@ If you haven't done so already:
     On the remote machine:
 
     ```bash
-    pip install quacc[dask]
+    pip install 'quacc[dask]'
     quacc set WORKFLOW_ENGINE dask
     ```
 
@@ -138,7 +138,7 @@ If you haven't done so already:
     On the remote machine:
 
     ```bash
-    pip install quacc[parsl]
+    pip install 'quacc[parsl]'
     quacc set WORKFLOW_ENGINE parsl
     ```
 
@@ -147,7 +147,7 @@ If you haven't done so already:
     On the remote machine:
 
     ```bash
-    pip install quacc[prefect]
+    pip install 'quacc[prefect]'
     quacc set WORKFLOW_ENGINE prefect
     ```
 
@@ -168,13 +168,13 @@ If you haven't done so already:
     === "Jobflow Remote"
 
         ```bash
-        pip install quacc[jobflow]
+        pip install 'quacc[jobflow]'
         ```
 
     === "Fireworks"
 
         ```bash
-        pip install quacc[jobflow] fireworks
+        pip install 'quacc[jobflow]' fireworks
         ```
 
 ### Concurrent Non-MPI Jobs
@@ -300,7 +300,7 @@ If you haven't done so already:
     On the remote machine, first make sure to install the necessary dependencies:
 
     ```
-    pip install quacc[tblite]
+    pip install 'quacc'[tblite]'
     ```
 
     From an interactive resource like a Jupyter Notebook or IPython kernel on the login node of the remote machine, run the following to instantiate a Dask [`SLURMCluster`](https://jobqueue.dask.org/en/latest/generated/dask_jobqueue.SLURMCluster.html) that will request two Slurm allocations of one node each, with each `#!Python @job` running on one core of the allocation:
@@ -379,7 +379,7 @@ If you haven't done so already:
     On the remote machine, make sure to install the necessary dependencies:
 
     ```
-    pip install quacc[tblite]
+    pip install 'quacc[tblite]'
     ```
 
     Now we will request a single Slurm allocation with 2 nodes, and each compute job will run on one core of that allocation.
@@ -506,7 +506,7 @@ If you haven't done so already:
     On the remote machine, first make sure to install the necessary dependencies:
 
     ```
-    pip install quacc[tblite]
+    pip install 'quacc[tblite]'
     ```
 
     From an interactive resource like a Jupyter Notebook or IPython kernel on the login node of the remote machine, you will need to instantiate a Dask [`SLURMCluster`](https://jobqueue.dask.org/en/latest/generated/dask_jobqueue.SLURMCluster.html) that will request one Slurm allocation for one node, with a `#!Python @job` running on each core of the allocation:

--- a/tests/covalent/covalent.conf
+++ b/tests/covalent/covalent.conf
@@ -1,5 +1,60 @@
+[sdk]
+config_file = "/Users/ugo/Projects/nwt/quacc/tests/covalent/covalent.conf"
+log_dir = "/Users/ugo/.cache/covalent"
+log_level = "warning"
+enable_logging = "true"
+executor_dir = "/Users/ugo/.config/covalent/executor_plugins"
+no_cluster = "false"
+exhaustive_postprocess = "false"
+dispatch_cache_dir = "/Users/ugo/.cache/covalent/dispatches"
+task_packing = "false"
+results_dir = "/Users/ugo/.cache/covalent/results"
+
+[dispatcher]
+address = "localhost"
+port = 48008
+cache_dir = "/Users/ugo/.cache/covalent"
+results_dir = "/Users/ugo/.local/share/covalent/data"
+log_dir = "/Users/ugo/.cache/covalent"
+db_path = "/Users/ugo/.local/share/covalent/dispatcher_db.sqlite"
+heartbeat_interval = 5
+heartbeat_file = "/Users/ugo/.cache/covalent/heartbeat"
+use_async_dispatcher = "true"
+asset_cache_size = 32
+
+[dask]
+cache_dir = "/Users/ugo/.cache/covalent"
+log_dir = "/Users/ugo/.cache/covalent"
+mem_per_worker = "auto"
+threads_per_worker = 1
+num_workers = 8
+
+[workflow_data]
+storage_type = "local"
+base_dir = "/Users/ugo/.local/share/covalent/workflow_data"
+
+[user_interface]
+address = "localhost"
+port = 48008
+dev_port = 49009
+log_dir = "/Users/ugo/.cache/covalent"
+
 [executors.local]
 create_unique_workdir = true
+log_stdout = "stdout.log"
+log_stderr = "stderr.log"
+cache_dir = "/Users/ugo/.cache/covalent"
+workdir = "/Users/ugo/.cache/covalent/workdir"
 
 [executors.dask]
 create_unique_workdir = true
+log_stdout = "stdout.log"
+log_stderr = "stderr.log"
+cache_dir = "/Users/ugo/.cache/covalent"
+workdir = "/Users/ugo/.cache/covalent/workdir"
+
+[executors.remote_executor]
+poll_freq = 15
+remote_cache = ".cache/covalent"
+credentials_file = ""
+covalent_version = ""


### PR DESCRIPTION


## Summary of Changes

On zsh (the default shell on MacOS as of 2019), the square brackets are interpreted as glob operators. Running `pip install -e .[dev]` with zsh leads to a 'no matches found' error as zsh is attempting [filename generation](https://zsh.sourceforge.io/Doc/Release/Expansion.html#Filename-Generation). Single-quoting the argument to pip install avoids the error.

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [ ] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).
