### PR TITLE
A `GenericRunner` to run arbitrary commands

### DIFF
--- a/src/quacc/runners/generic.py
+++ b/src/quacc/runners/generic.py
@@ -33,7 +33,7 @@ class GenericRunner(BaseRunner):
     ) -> None:
         """
         Initialize the `GenericRunner` with the command and optional copy files and environment variables.
-        
+
         Parameters
         ----------
         command

--- a/src/quacc/runners/generic.py
+++ b/src/quacc/runners/generic.py
@@ -18,15 +18,6 @@ if TYPE_CHECKING:
 class GenericRunner(BaseRunner):
     """
     A class to run generic (IO) commands in a subprocess. Inherits from BaseRunner, which handles setup and cleanup of the calculation.
-
-    Parameters
-    ----------
-    command
-        The command to run in the subprocess.
-    copy_files
-        Files to copy to the runtime directory.
-    environment
-        Environment variables to set for the subprocess. If None, the current environment is used.
     """
 
     filepaths: ClassVar[dict[str, SourceDirectory | None]] = {
@@ -39,8 +30,23 @@ class GenericRunner(BaseRunner):
         command: str,
         copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
         environment: dict[str, str] | None = None,
-    ):
-        """Initialize the `GenericRunner` with the command and optional copy files and environment variables."""
+    ) -> None:
+        """
+        Initialize the `GenericRunner` with the command and optional copy files and environment variables.
+        
+        Parameters
+        ----------
+        command
+            The command to run in the subprocess.
+        copy_files
+            Files to copy to the runtime directory.
+        environment
+            Environment variables to set for the subprocess. If None, the current environment is used.
+
+        Returns
+        -------
+        None
+        """
         self.command: Final[list[str]] = split(command)
         self.environment = environment
 

--- a/src/quacc/runners/generic.py
+++ b/src/quacc/runners/generic.py
@@ -1,0 +1,79 @@
+"""Class to run generic commands in a subprocess."""
+
+from __future__ import annotations
+
+import os
+from contextlib import ExitStack
+from pathlib import Path
+from shlex import split
+from subprocess import PIPE, CompletedProcess, run
+from typing import TYPE_CHECKING, ClassVar, Final
+
+from quacc.runners._base import BaseRunner
+
+if TYPE_CHECKING:
+    from quacc.types import Filenames, SourceDirectory
+
+
+class GenericRunner(BaseRunner):
+    """
+    A class to run generic (IO) commands in a subprocess. Inherits from BaseRunner, which handles setup and cleanup of the calculation.
+
+    Parameters
+    ----------
+    command
+        The command to run in the subprocess.
+    copy_files
+        Files to copy to the runtime directory.
+    environment
+        Environment variables to set for the subprocess. If None, the current environment is used.
+    """
+
+    filepaths: ClassVar[dict[str, SourceDirectory | None]] = {
+        "fd_out": None,
+        "fd_err": None,
+    }
+
+    def __init__(
+        self,
+        command: str,
+        copy_files: SourceDirectory | dict[SourceDirectory, Filenames] | None = None,
+        environment: dict[str, str] | None = None,
+    ):
+        """Initialize the `GenericRunner` with the command and optional copy files and environment variables."""
+        self.command: Final[list[str]] = split(command)
+        self.environment = environment
+
+        super().__init__(copy_files=copy_files)
+
+        self.setup()
+
+    def run_cmd(self) -> CompletedProcess:
+        """
+        Run a command in a subprocess.
+
+        Returns
+        -------
+        CompletedProcess
+            The result of the subprocess execution.
+        """
+        with ExitStack() as stack:
+            files = {
+                name: stack.enter_context(Path(self.tmpdir, path).open("w"))
+                for name, path in self.filepaths.items()
+                if path is not None
+            }
+
+            cmd_results = run(
+                self.command,
+                cwd=self.tmpdir,
+                shell=False,
+                check=True,
+                env=self.environment if self.environment is not None else os.environ,
+                stdout=files.get("fd_out", PIPE),
+                stderr=files.get("fd_err", PIPE),
+                text=True,
+            )
+
+        self.cleanup()
+        return cmd_results

--- a/tests/core/runners/test_generic.py
+++ b/tests/core/runners/test_generic.py
@@ -54,4 +54,4 @@ def test_generic_runner(tmp_path, monkeypatch):
         assert (
             "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1."
             in str(e)
-        )  # noqa: PT017
+        )

--- a/tests/core/runners/test_generic.py
+++ b/tests/core/runners/test_generic.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from subprocess import CalledProcessError
+
+import pytest
+
+from quacc import change_settings
+from quacc.runners.generic import GenericRunner
+
+
+def test_generic_runner(tmp_path, monkeypatch):
+    """Test the `GenericRunner` class with a simple command."""
+    gr = GenericRunner(command="echo Hello, World!")
+
+    gr.filepaths["fd_out"] = "fd_out"
+    gr.filepaths["fd_err"] = "fd_err"
+
+    assert gr.tmpdir.exists()
+    assert not gr.job_results_dir.exists()
+
+    with change_settings({"GZIP_FILES": False}):
+        gr.run_cmd()
+
+    assert (gr.job_results_dir / "fd_out").read_text() == "Hello, World!\n"
+    assert (gr.job_results_dir / "fd_err").read_text() == ""
+
+    assert not gr.tmpdir.exists()
+    assert gr.job_results_dir.exists()
+
+    gr = GenericRunner(command="acommandthatdoesnotexistsurely")
+
+    with pytest.raises(FileNotFoundError):
+        gr.run_cmd()
+
+    gr = GenericRunner(
+        command='sh -c "echo VAR=${MY_VAR}; echo SHOULD_NOT=${SHOULD_NOT_EXIST:-missing}"',
+        environment={"MY_VAR": "custom_value"},
+    )
+
+    gr.filepaths["fd_out"] = None
+    gr.filepaths["fd_err"] = None
+
+    results = gr.run_cmd()
+
+    assert results.stdout == "VAR=custom_value\nSHOULD_NOT=missing\n"
+
+    gr = GenericRunner(
+        command="sh -c 'exit 1'",
+    )
+
+    try:
+        results = gr.run_cmd()
+        assert results.returncode == 1
+    except CalledProcessError as e:
+        assert e.returncode == 1 # noqa: PT017
+        assert "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1." in str(e) # noqa: PT017

--- a/tests/core/runners/test_generic.py
+++ b/tests/core/runners/test_generic.py
@@ -44,13 +44,14 @@ def test_generic_runner(tmp_path, monkeypatch):
 
     assert results.stdout == "VAR=custom_value\nSHOULD_NOT=missing\n"
 
-    gr = GenericRunner(
-        command="sh -c 'exit 1'",
-    )
+    gr = GenericRunner(command="sh -c 'exit 1'")
 
     try:
         results = gr.run_cmd()
         assert results.returncode == 1
     except CalledProcessError as e:
-        assert e.returncode == 1 # noqa: PT017
-        assert "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1." in str(e) # noqa: PT017
+        assert e.returncode == 1  # noqa: PT017
+        assert (
+            "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1."
+            in str(e)
+        )  # noqa: PT017

--- a/tests/core/runners/test_generic.py
+++ b/tests/core/runners/test_generic.py
@@ -46,12 +46,9 @@ def test_generic_runner(tmp_path, monkeypatch):
 
     gr = GenericRunner(command="sh -c 'exit 1'")
 
-    try:
+    with pytest.raises(CalledProcessError) as exc_info:
         results = gr.run_cmd()
-        assert results.returncode == 1
-    except CalledProcessError as e:
-        assert e.returncode == 1  # noqa: PT017
-        assert (
-            "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1."
-            in str(e)
-        )
+
+    e = exc_info.value
+    assert e.returncode == 1
+    assert "Command '['sh', '-c', 'exit 1']' returned non-zero exit status 1." in str(e)


### PR DESCRIPTION
## Summary of Changes

In this PR I attempt to implement a `GenericRunner` which can be used to run external commands, the class currently:

- Manage IO via ClassVar which can be changed when subclassing.
- Take the command and split it, this is final, new instance should be created if the command needs to be changed.
- Users can send custom environments if needed.

Hope that's not out of scope 🙃

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
