### PR TITLE
Add legacy MP recipes back

### DIFF
--- a/src/quacc/recipes/vasp/mp24.py
+++ b/src/quacc/recipes/vasp/mp24.py
@@ -1,5 +1,5 @@
 """
-Materials Project-compatible recipes.
+Materials Project-compatible recipes using the MP24 sets.
 
 !!! Important
 

--- a/src/quacc/recipes/vasp/mp_legacy.py
+++ b/src/quacc/recipes/vasp/mp_legacy.py
@@ -1,0 +1,183 @@
+"""
+Materials Project-compatible recipes using the original MP settings.
+
+!!! Important
+
+    Make sure that you use the Materials Project-compatible pseudpotential
+    versions. The GGA workflows use the old (no version) PAW PBE potentials.
+"""
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+from monty.dev import requires
+
+from quacc import change_settings, flow, job
+from quacc.calculators.vasp.params import MPtoASEConverter
+from quacc.recipes.vasp._base import run_and_summarize
+from quacc.wflow_tools.customizers import customize_funcs
+
+has_atomate2 = bool(find_spec("atomate2"))
+if has_atomate2:
+    from atomate2.vasp.jobs.mp import MPGGARelaxMaker, MPGGAStaticMaker
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any, TypedDict
+
+    from ase.atoms import Atoms
+
+    from quacc.types import SourceDirectory, VaspSchema
+
+    class MPGGARelaxFlowSchema(TypedDict):
+        """Type hint associated with the MP GGA relaxation flows."""
+
+        relax1: VaspSchema
+        relax2: VaspSchema
+        static: VaspSchema
+
+
+_MP_SETTINGS = {"VASP_INCAR_COPILOT": "off", "VASP_USE_CUSTODIAN": True}
+
+
+@job
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def mp_gga_relax_job(
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+) -> VaspSchema:
+    """
+    Function to relax a structure with the original Materials Project GGA(+U) settings.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    prev_dir
+        A previous directory for a prior step in the workflow.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to
+        `None` to remove a pre-existing key entirely. For a list of available
+        keys, refer to [quacc.calculators.vasp.vasp.Vasp][].
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results.
+    """
+    calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_vasp_maker(
+        MPGGARelaxMaker()
+    )
+    with change_settings(_MP_SETTINGS):
+        return run_and_summarize(
+            atoms,
+            calc_defaults=calc_defaults,
+            calc_swaps=calc_kwargs,
+            report_mp_corrections=True,
+            additional_fields={"name": "MP GGA Relax"},
+            copy_files={prev_dir: ["WAVECAR*"]},
+        )
+
+
+@job
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def mp_gga_static_job(
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+) -> VaspSchema:
+    """
+    Function to run a static calculation on a structure with the original Materials Project GGA(+U) settings.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    prev_dir
+        A previous directory for a prior step in the workflow.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to
+        `None` to remove a pre-existing key entirely. For a list of available
+        keys, refer to [quacc.calculators.vasp.vasp.Vasp][].
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
+    """
+    calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_vasp_maker(
+        MPGGAStaticMaker()
+    )
+    with change_settings(_MP_SETTINGS):
+        return run_and_summarize(
+            atoms,
+            calc_defaults=calc_defaults,
+            calc_swaps=calc_kwargs,
+            report_mp_corrections=True,
+            additional_fields={"name": "MP GGA Static"},
+            copy_files={prev_dir: ["WAVECAR*"]},
+        )
+
+
+@flow
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def mp_gga_relax_flow(
+    atoms: Atoms,
+    job_params: dict[str, dict[str, Any]] | None = None,
+    job_decorators: dict[str, Callable | None] | None = None,
+) -> MPGGARelaxFlowSchema:
+    """
+    Materials Project GGA workflow consisting of:
+
+    1. MP-compatible relax
+        - name: "mp_gga_relax_job"
+        - job: [quacc.recipes.vasp.mp.mp_gga_relax_job][]
+
+    2. MP-compatible (second) relax
+        - name: "mp_gga_relax_job"
+        - job: [quacc.recipes.vasp.mp.mp_gga_relax_job][]
+
+    3. MP-compatible static
+        - name: "mp_gga_static_job"
+        - job: [quacc.recipes.vasp.mp.mp_gga_static_job][]
+
+    Parameters
+    ----------
+    atoms
+        Atoms object for the structure.
+    job_params
+        Custom parameters to pass to each Job in the Flow. This is a dictinoary where
+        the keys are the names of the jobs and the values are dictionaries of parameters.
+    job_decorators
+        Custom decorators to apply to each Job in the Flow. This is a dictionary where
+        the keys are the names of the jobs and the values are decorators.
+
+    Returns
+    -------
+    MPGGARelaxFlowSchema
+        Dictionary of results. See the type-hint for the data structure.
+    """
+    (mp_gga_relax_job_, mp_gga_static_job_) = customize_funcs(
+        ["mp_gga_relax_job", "mp_gga_static_job"],
+        [mp_gga_relax_job, mp_gga_static_job],
+        param_swaps=job_params,
+        decorators=job_decorators,
+    )
+
+    # Run the relax
+    relax_results = mp_gga_relax_job_(atoms)
+
+    # Run the second relax
+    double_relax_results = mp_gga_relax_job_(
+        relax_results["atoms"], prev_dir=relax_results["dir_name"]
+    )
+
+    # Run the static
+    static_results = mp_gga_static_job_(
+        double_relax_results["atoms"], prev_dir=double_relax_results["dir_name"]
+    )
+
+    return {
+        "relax1": relax_results,
+        "relax2": double_relax_results,
+        "static": static_results,
+    }

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -17,11 +17,16 @@ from quacc.recipes.vasp.core import (
     relax_job,
     static_job,
 )
-from quacc.recipes.vasp.mp import (
+from quacc.recipes.vasp.mp24 import (
     mp_metagga_relax_flow,
     mp_metagga_relax_job,
     mp_metagga_static_job,
     mp_prerelax_job,
+)
+from quacc.recipes.vasp.mp_legacy import (
+    mp_gga_relax_flow,
+    mp_gga_relax_job,
+    mp_gga_static_job,
 )
 from quacc.recipes.vasp.qmof import qmof_relax_job
 from quacc.recipes.vasp.slabs import bulk_to_slabs_flow, slab_to_ads_flow
@@ -678,6 +683,173 @@ def test_mp_metagga_relax_flow_nonmetallic(tmp_path, patch_nonmetallic_taskdoc):
         assert output["static"]["parameters"]["nsw"] == 0
         assert output["static"]["parameters"]["algo"] == "normal"
         assert output["static"]["parameters"]["magmom"] == [0.0, 0.0]
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_mp_gga_relax_job(patch_nonmetallic_taskdoc):
+    atoms = bulk("Ni") * (2, 1, 1)
+    atoms[0].symbol = "O"
+    del atoms.arrays["initial_magmoms"]
+    output = mp_gga_relax_job(atoms)
+
+    assert output["structure_metadata"]["nsites"] == len(atoms)
+    assert output["parameters"] == {
+        "algo": "fast",
+        "ediff": 0.0001,
+        "encut": 520,
+        "gamma": True,
+        "ibrion": 2,
+        "isif": 3,
+        "ismear": -5,
+        "ispin": 2,
+        "kpts": (5, 11, 11),
+        "lasph": True,
+        "ldau": True,
+        "ldauj": [0, 0],
+        "ldaul": [0, 2],
+        "ldauprint": 1,
+        "ldautype": 2,
+        "ldauu": [0, 6.2],
+        "lmaxmix": 4,
+        "lorbit": 11,
+        "lreal": "auto",
+        "lwave": False,
+        "magmom": [0.6, 5.0],
+        "nelm": 100,
+        "nsw": 99,
+        "prec": "accurate",
+        "sigma": 0.05,
+        "pp": "pbe",
+        "setups": {"O": "", "Ni": "_pv"},
+    }
+    assert output["atoms"].get_chemical_symbols() == ["O", "Ni"]
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_mp_gga_static_job(patch_nonmetallic_taskdoc):
+    atoms = bulk("Ni") * (2, 1, 1)
+    atoms[0].symbol = "O"
+    del atoms.arrays["initial_magmoms"]
+    output = mp_gga_static_job(atoms)
+    assert output["structure_metadata"]["nsites"] == len(atoms)
+    assert output["parameters"] == {
+        "algo": "fast",
+        "ediff": 0.0001,
+        "encut": 520,
+        "gamma": True,
+        "ismear": -5,
+        "ispin": 2,
+        "kpts": (6, 13, 13),
+        "lasph": True,
+        "lcharg": True,
+        "ldau": True,
+        "ldauj": [0, 0],
+        "ldaul": [0, 2],
+        "ldauprint": 1,
+        "ldautype": 2,
+        "ldauu": [0, 6.2],
+        "lmaxmix": 4,
+        "lorbit": 11,
+        "lreal": False,
+        "lwave": False,
+        "magmom": [0.6, 5],
+        "nelm": 100,
+        "nsw": 0,
+        "prec": "accurate",
+        "sigma": 0.05,
+        "pp": "pbe",
+        "setups": {"Ni": "_pv", "O": ""},
+    }
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_mp_gga_relax_flow(tmp_path, patch_nonmetallic_taskdoc):
+    with change_settings({"CREATE_UNIQUE_DIR": False, "RESULTS_DIR": tmp_path}):
+        copy_r(MOCKED_DIR / "nonmetallic", tmp_path)
+
+        atoms = bulk("Ni") * (2, 1, 1)
+        atoms[0].symbol = "O"
+        del atoms.arrays["initial_magmoms"]
+        output = mp_gga_relax_flow(atoms)
+        relax_params = {
+            "algo": "fast",
+            "ediff": 0.0001,
+            "encut": 520,
+            "gamma": True,
+            "ibrion": 2,
+            "isif": 3,
+            "ismear": -5,
+            "ispin": 2,
+            "kpts": (5, 11, 11),
+            "lasph": True,
+            "ldau": True,
+            "ldauj": [0, 0],
+            "ldaul": [0, 2],
+            "ldauprint": 1,
+            "ldautype": 2,
+            "ldauu": [0, 6.2],
+            "lmaxmix": 4,
+            "lorbit": 11,
+            "lreal": "auto",
+            "lwave": False,
+            "magmom": [0.6, 5],
+            "nelm": 100,
+            "nsw": 99,
+            "prec": "accurate",
+            "sigma": 0.05,
+            "pp": "pbe",
+            "setups": {"O": "", "Ni": "_pv"},
+        }
+        relax2_params = relax_params.copy()
+        relax2_params["magmom"] = [0.0, 0.0]
+
+        assert output["relax1"]["parameters"] == relax_params
+        assert output["relax2"]["parameters"] == relax2_params
+        assert output["static"]["parameters"] == {
+            "algo": "fast",
+            "ediff": 0.0001,
+            "encut": 520,
+            "gamma": True,
+            "ismear": -5,
+            "ispin": 2,
+            "kpts": (6, 13, 13),
+            "lasph": True,
+            "lcharg": True,
+            "ldau": True,
+            "ldauj": [0, 0],
+            "ldaul": [0, 2],
+            "ldauprint": 1,
+            "ldautype": 2,
+            "ldauu": [0, 6.2],
+            "lmaxmix": 4,
+            "lorbit": 11,
+            "lreal": False,
+            "lwave": False,
+            "magmom": [0.0, 0.0],
+            "nelm": 100,
+            "nsw": 0,
+            "prec": "accurate",
+            "sigma": 0.05,
+            "pp": "pbe",
+            "setups": {"Ni": "_pv", "O": ""},
+        }
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_mp_relax_flow_custom(tmp_path, patch_nonmetallic_taskdoc):
+    with change_settings({"CREATE_UNIQUE_DIR": False, "RESULTS_DIR": tmp_path}):
+        copy_r(MOCKED_DIR / "nonmetallic", tmp_path)
+
+        atoms = bulk("Ni") * (2, 1, 1)
+        atoms[0].symbol = "O"
+        del atoms.arrays["initial_magmoms"]
+        output = mp_metagga_relax_flow(
+            mp_gga_relax_flow(atoms, job_params={"mp_gga_relax_job": {"nsw": 0}})[
+                "static"
+            ]["atoms"],
+            job_params={"mp_metagga_relax_job": {"nsw": 0}},
+        )
+        assert output["relax2"]["parameters"]["nsw"] == 0
 
 
 def test_freq_job():


### PR DESCRIPTION
## Summary of Changes

This PR adds the legacy MP settings back under a new module: `quacc.recipes.vasp.mp_legacy`. The new MP settings are now moved to a new `quacc.recipes.vasp.mp24` module.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
