### PR TITLE
Use ISEARCH = 1 when ALGO = All in VASP

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -88,7 +88,7 @@ def get_param_swaps(
         not calc.string_params["algo"] or calc.string_params["algo"].lower() != "all"
     ):
         LOGGER.info("Recommending ALGO = All because you have a meta-GGA calculation.")
-        calc.set(algo="all")
+        calc.set(algo="all", isearch=1)
 
     if calc.bool_params["lhfcalc"] and (
         not calc.string_params["algo"]
@@ -230,6 +230,15 @@ def get_param_swaps(
         calc.set(isym=-1)
 
     if (
+        calc.string_params["algo"]
+        and calc.string_params["algo"].lower() == "all"
+        and not calc.int_params["isearch"]
+        and calc.int_params["isearch"] != 1
+    ):
+        LOGGER.info("Recommending ISEARCH = 1 because you have ALGO = All.")
+        calc.set(isearch=1)
+
+    if (
         calc.int_params.get("isif", 2) in (3, 6, 7, 8)
         and calc.int_params["nsw"]
         and calc.int_params["nsw"] > 0
@@ -259,7 +268,6 @@ def get_param_swaps(
     if (
         calc.string_params["metagga"]
         and calc.string_params["metagga"].lower() == "r2scan"
-        and calc.int_params["ivdw"]
         and calc.int_params["ivdw"] == 13
         and not calc.float_params["vdw_s6"]
         and not calc.float_params["vdw_s8"]
@@ -270,11 +278,8 @@ def get_param_swaps(
         calc.set(vdw_s6=1.0, vdw_s8=0.60187490, vdw_a1=0.51559235, vdw_a2=5.77342911)
 
     if (
-        calc.bool_params["lhfcalc"]
-        and calc.bool_params["lhfcalc"] is True
-        and calc.float_params["hfscreen"]
+        calc.bool_params["lhfcalc"] is True
         and calc.float_params["hfscreen"] == 0.2
-        and calc.int_params["ivdw"]
         and calc.int_params["ivdw"] == 12
         and not calc.float_params["vdw_s6"]
         and not calc.float_params["vdw_s8"]

--- a/src/quacc/calculators/vasp/presets/DefaultSetHybrid.yaml
+++ b/src/quacc/calculators/vasp/presets/DefaultSetHybrid.yaml
@@ -2,5 +2,6 @@
 # HSE06-D3(BJ)
 inputs:
   algo: all
+  isearch: 1
   xc: HSE06
 parent: DefaultSetGGA

--- a/src/quacc/calculators/vasp/presets/DefaultSetMetaGGA.yaml
+++ b/src/quacc/calculators/vasp/presets/DefaultSetMetaGGA.yaml
@@ -2,6 +2,7 @@
 # r2SCAN-D4
 inputs:
   algo: all
+  isearch: 1
   ivdw: 13
   xc: r2SCAN
 parent: DefaultSetGGA

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -101,6 +101,15 @@ def test_presets_mp():
     assert calc.exp_params["ediff"] == 1e-5
 
 
+def test_isearch():
+    atoms = bulk("Cu")
+    calc = Vasp(atoms, algo="all")
+    assert calc.int_params["isearch"] == 1
+
+    calc = Vasp(atoms, algo="all", isearch=0)
+    assert calc.int_params["isearch"] == 0
+
+
 def test_gga_preset():
     params = {
         "algo": "fast",
@@ -246,6 +255,7 @@ def test_metagga_preset():
         "gamma": True,
         "gga_compat": False,
         "ibrion": 2,
+        "isearch": 1,
         "ismear": 0,
         "ivdw": 13,
         "kpts": [12, 12, 12],
@@ -387,6 +397,7 @@ def test_hybrid_preset():
         "gga_compat": False,
         "hfscreen": 0.2,
         "ibrion": 2,
+        "isearch": 1,
         "ismear": 0,
         "ivdw": 12,
         "kpts": [12, 12, 12],
@@ -527,6 +538,7 @@ def test_rosen_preset1():
         "gga": "PE",
         "gga_compat": False,
         "ibrion": 2,
+        "isearch": 1,
         "ismear": 0,
         "ivdw": 12,
         "kpts": None,
@@ -662,6 +674,7 @@ def test_rosen_preset2():
         "gamma": None,
         "gga_compat": False,
         "ibrion": 2,
+        "isearch": 1,
         "ismear": 0,
         "ivdw": 13,
         "kpts": None,


### PR DESCRIPTION
## Summary of Changes

When ALGO = "All", we should be using ISEARCH = 1 per the VASP manual.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
