### PR TITLE
Update symprec value from 1e-8 to 1e-6 in `relax_job`

### DIFF
--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -129,7 +129,7 @@ def relax_job(
         "lcharg": False,
         "lwave": False,
         "nsw": 200,
-        "symprec": 1e-8,
+        "symprec": 1e-6,
     }
     return run_and_summarize(
         atoms,


### PR DESCRIPTION
The default value of SYMPREC is set to 1e-8 in the VASP `relax_job`. This can cause a bravais warning because it is so low. It is better to set this to the VASP-recommended default of 1e-6.