### PR TITLE
Fix (de)serialization of Phonopy

### DIFF
--- a/src/quacc/recipes/common/phonons.py
+++ b/src/quacc/recipes/common/phonons.py
@@ -167,7 +167,9 @@ def phonon_subflow(
 
     force_job_results = _get_forces_subflow(supercells)
     return _thermo_job(
+        atoms,
         displaced_atoms,
+        non_displaced_atoms,
         get_phonopy_kwargs,
         force_job_results,
         t_step,


### PR DESCRIPTION
## Summary of Changes

Fixes (de)serialization of the phonon workflows by avoiding passing around the `Phonopy` object directly to a `@job`-decorated function.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
