### PR TITLE
Correct call params to write_espresso_ph (changed in ase on 01/13/26)

### DIFF
--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -137,7 +137,7 @@ class EspressoTemplate(EspressoTemplate_):
             )
         elif self.binary in ["ph", "phcg"]:
             with Path(directory, self.inputname).open(mode="w") as fd:
-                write_espresso_ph(file=fd, properties=properties, **parameters)
+                write_espresso_ph(fd, properties=properties, **parameters)
         else:
             with Path(directory, self.inputname).open(mode="w") as fd:
                 write_fortran_namelist(


### PR DESCRIPTION
## Summary of Changes

Change to correctly call `write_espresso_ph` due to an upstream [change](https://gitlab.com/ase/ase/-/commit/9836e30b22a8ef6269d0fa89f8ecb8bfe7b2c82e) in ASE. Using a positional arg works for both old ASE and after their change.

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
