### PR TITLE
Add auto_ispin parameter to matpes.py

### DIFF
--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -37,6 +37,7 @@ def matpes_static_job(
     kspacing: float | None = 0.22,
     use_improvements: bool = False,
     write_extra_files: bool = False,
+    auto_ispin: bool = False,
     prev_dir: SourceDirectory | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
@@ -58,6 +59,10 @@ def matpes_static_job(
         and ENAUG deleted.
     write_extra_files
         Whether to write out the following IO files: LELF = True and NEDOS = 3001.
+    auto_ispin
+        If generating input set from a previous calculation, this controls whether
+        to disable magnetisation (ISPIN = 1) if the absolute value of all magnetic
+        moments are less than 0.02.
     prev_dir
         A previous directory for a prior step in the workflow.
     **calc_kwargs
@@ -75,7 +80,7 @@ def matpes_static_job(
     from atomate2.vasp.jobs.matpes import MatPesGGAStaticMaker
 
     maker = MatPesGGAStaticMaker()
-    maker.input_set_generator.auto_ispin = True
+    maker.input_set_generator.auto_ispin = auto_ispin
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         maker
     )

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -71,4 +71,6 @@ def mof_off_static_job(
             default_parameters["ivdw"] = 13
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)
 
-    return matpes_static_job(atoms, level=level, auto_ispin=True, prev_dir=prev_dir, **calc_flags)
+    return matpes_static_job(
+        atoms, level=level, auto_ispin=True, prev_dir=prev_dir, **calc_flags
+    )

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -71,4 +71,4 @@ def mof_off_static_job(
             default_parameters["ivdw"] = 13
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)
 
-    return matpes_static_job(atoms, level=level, prev_dir=prev_dir, **calc_flags)
+    return matpes_static_job(atoms, level=level, auto_ispin=True, prev_dir=prev_dir, **calc_flags)


### PR DESCRIPTION
Added auto_ispin parameter to control magnetization settings based on previous calculations. Defaults now to **False** for matpes.
