### PR TITLE
Add 'use_custodian=False' option to calc_defaults for relevant fairchem recipes

### DIFF
--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -117,7 +117,7 @@ def omc_static_job(
     """
 
     calc_defaults = _make_omc_inputs(atoms)
-    calc_defaults |= {"pp_version": "54", "incar_copilot": "light"}
+    calc_defaults |= {"pp_version": "54", "incar_copilot": "light", "use_custodian": False}
 
     return run_and_summarize(
         atoms,
@@ -241,7 +241,7 @@ def odac_static_job(
         "isym": 0,
         "pp_version": "54",
     }
-    calc_defaults |= {"incar_copilot": "light"}
+    calc_defaults |= {"incar_copilot": "light", "use_custodian": False}
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
@@ -291,6 +291,7 @@ def oc20_static_job(
         "xc": "RPBE",
         "pp_version": "54",
         "incar_copilot": "light",
+        "use_custodian": False,
     }
 
     return run_and_summarize(

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -117,7 +117,11 @@ def omc_static_job(
     """
 
     calc_defaults = _make_omc_inputs(atoms)
-    calc_defaults |= {"pp_version": "54", "incar_copilot": "light", "use_custodian": False}
+    calc_defaults |= {
+        "pp_version": "54",
+        "incar_copilot": "light",
+        "use_custodian": False,
+    }
 
     return run_and_summarize(
         atoms,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,12 +1,11 @@
 ase @ git+https://gitlab.com/ase/ase.git
 custodian==2025.12.14
-emmet-core==0.86.4
+emmet-core==0.87.0
 frozendict==2.4.7
 monty==2026.5.18
 psutil==7.2.2
 pydantic==2.13.4
 pydantic-settings==2.14.1
 pymatgen==2026.5.4
-pymatgen-core==2026.5.18
 ruamel.yaml==0.19.1
 typer==0.25.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,5 +7,6 @@ psutil==7.2.2
 pydantic==2.13.4
 pydantic-settings==2.14.1
 pymatgen==2026.5.4
+pymatgen-core==2026.5.18
 ruamel.yaml==0.19.1
 typer==0.25.1


### PR DESCRIPTION
## Summary of Changes

For 1:1 full reproducibility of some fairchem recipes, we disable the use of Custodian by default.

### Requirements

- [X] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [X] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [X] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
