### PR TITLE
Modify dispersion parameters in mof_off.py

### DIFF
--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -70,15 +70,10 @@ def mof_off_static_job(
         if disp == "d3bj":
             default_parameters |= {
                 "ivdw": 15,
-                "vdw_radius": 60 * Bohr,
-                "vdw_cnradius": 40 * Bohr,
-            }  # See https://github.com/dftd3/simple-dftd3/issues/151
+                "vdw_radius": 60 * Bohr, # See https://github.com/dftd3/simple-dftd3/issues/151
+            }  
         elif disp == "d4":
-            default_parameters |= {
-                "ivdw": 13,
-                "vdw_radius": 60 * Bohr,
-                "vdw_cnradius": 30 * Bohr,
-            }
+            default_parameters["ivdw"] = 13
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)
 
     return matpes_static_job(

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
+from ase.units import Bohr
 from monty.dev import requires
 
 from quacc import job
@@ -67,9 +68,9 @@ def mof_off_static_job(
     if dispersion:
         disp = dispersion.lower()
         if disp == "d3bj":
-            default_parameters["ivdw"] = 12
+            default_parameters |= {"ivdw": 15, "vdw_radius": 60 * Bohr, "vdw_cnradius": 40 * Bohr} # See https://github.com/dftd3/simple-dftd3/issues/151 
         elif disp == "d4":
-            default_parameters["ivdw"] = 13
+            default_parameters |= {"ivdw": 13, "vdw_radius": 60 * Bohr, "vdw_cnradius": 30 * Bohr}
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)
 
     return matpes_static_job(

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -70,8 +70,9 @@ def mof_off_static_job(
         if disp == "d3bj":
             default_parameters |= {
                 "ivdw": 15,
-                "vdw_radius": 60 * Bohr, # See https://github.com/dftd3/simple-dftd3/issues/151
-            }  
+                "vdw_radius": 60
+                * Bohr,  # See https://github.com/dftd3/simple-dftd3/issues/151
+            }
         elif disp == "d4":
             default_parameters["ivdw"] = 13
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -68,9 +68,17 @@ def mof_off_static_job(
     if dispersion:
         disp = dispersion.lower()
         if disp == "d3bj":
-            default_parameters |= {"ivdw": 15, "vdw_radius": 60 * Bohr, "vdw_cnradius": 40 * Bohr} # See https://github.com/dftd3/simple-dftd3/issues/151 
+            default_parameters |= {
+                "ivdw": 15,
+                "vdw_radius": 60 * Bohr,
+                "vdw_cnradius": 40 * Bohr,
+            }  # See https://github.com/dftd3/simple-dftd3/issues/151
         elif disp == "d4":
-            default_parameters |= {"ivdw": 13, "vdw_radius": 60 * Bohr, "vdw_cnradius": 30 * Bohr}
+            default_parameters |= {
+                "ivdw": 13,
+                "vdw_radius": 60 * Bohr,
+                "vdw_cnradius": 30 * Bohr,
+            }
     calc_flags = recursive_dict_merge(default_parameters, calc_kwargs)
 
     return matpes_static_job(

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1292,7 +1292,7 @@ def test_mof_off(patch_metallic_taskdoc):
         "prec": "accurate",
         "setups": {"Al": ""},
         "sigma": 0.05,
-        "vdw_radius": 31.75063263383047
+        "vdw_radius": 31.75063263383047,
         "xc": "pbe",
     }
 

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1298,6 +1298,7 @@ def test_mof_off(patch_metallic_taskdoc):
         "vdw_a2": 5.77342911,
     }
 
+
 @pytest.mark.skipif(not has_fairchem_omat, reason="fairchem not installed")
 def test_fairchem_omat(patch_metallic_taskdoc):
     from quacc.recipes.vasp.fairchem import omat_static_job

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1292,10 +1292,6 @@ def test_mof_off(patch_metallic_taskdoc):
         "sigma": 0.05,
         "xc": "pbe",
         "ivdw": 15,
-        "vdw_s6": 1.0,
-        "vdw_s8": 0.60187490,
-        "vdw_a1": 0.51559235,
-        "vdw_a2": 5.77342911,
     }
 
 

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1267,10 +1267,12 @@ def test_mof_off(patch_metallic_taskdoc):
         "ediff": 1e-05,
         "efermi": "midgap",
         "encut": 680.0,
+        "gga": "PE",
         "gga_compat": False,
         "isearch": 1,
         "ismear": 0,
         "ispin": 2,
+        "ivdw": 15,
         "kspacing": 0.4,
         "laechg": True,
         "lasph": True,
@@ -1280,7 +1282,7 @@ def test_mof_off(patch_metallic_taskdoc):
         "lmixtau": True,
         "lorbit": 11,
         "lreal": False,
-        "lwave": False,
+        "lwave": True,
         "magmom": [0.6],
         "nedos": 3001,
         "nelm": 200,
@@ -1290,8 +1292,8 @@ def test_mof_off(patch_metallic_taskdoc):
         "prec": "accurate",
         "setups": {"Al": ""},
         "sigma": 0.05,
+        "vdw_radius": 31.75063263383047
         "xc": "pbe",
-        "ivdw": 15,
     }
 
 

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1261,6 +1261,42 @@ def test_mof_off(patch_metallic_taskdoc):
         "vdw_a2": 5.77342911,
     }
 
+    output = mof_off_static_job(bulk("Al"), level="pbe", dispersion="d3bj", ncore=None)
+    assert output["parameters"] == {
+        "algo": "all",
+        "ediff": 1e-05,
+        "efermi": "midgap",
+        "encut": 680.0,
+        "gga_compat": False,
+        "isearch": 1,
+        "ismear": 0,
+        "ispin": 2,
+        "kspacing": 0.4,
+        "laechg": True,
+        "lasph": True,
+        "lcharg": True,
+        "lelf": True,
+        "lmaxmix": 6,
+        "lmixtau": True,
+        "lorbit": 11,
+        "lreal": False,
+        "lwave": False,
+        "magmom": [0.6],
+        "nedos": 3001,
+        "nelm": 200,
+        "nsw": 0,
+        "pp": "PBE",
+        "pp_version": "64",
+        "prec": "accurate",
+        "setups": {"Al": ""},
+        "sigma": 0.05,
+        "xc": "pbe",
+        "ivdw": 15,
+        "vdw_s6": 1.0,
+        "vdw_s8": 0.60187490,
+        "vdw_a1": 0.51559235,
+        "vdw_a2": 5.77342911,
+    }
 
 @pytest.mark.skipif(not has_fairchem_omat, reason="fairchem not installed")
 def test_fairchem_omat(patch_metallic_taskdoc):


### PR DESCRIPTION
Ensure D3(BJ) compatibility by using simple-dftd3 defaults rather than builtin ivdw=12 defaults.