### PR TITLE
Overhaul parameter swapping

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -37,7 +37,9 @@ def get_param_swaps(
     user_calc_params: dict[str, Any],
     input_atoms: Atoms,
     pmg_kpts: dict[Literal["line_density", "kppvol", "kppa"], float] | None = None,
-    incar_copilot_mode: Literal["off", "light", "default", "aggressive"] = "default",
+    incar_copilot_mode: Literal[
+        "off", "critical", "standard", "aggressive"
+    ] = "standard",
 ) -> dict[str, Any]:
     """
     Swaps out bad INCAR flags.
@@ -65,7 +67,7 @@ def get_param_swaps(
     # ----------------------------
     # General INCAR swaps
     # ----------------------------
-    if incar_copilot_mode.lower() not in {"off", "light"}:
+    if incar_copilot_mode.lower() not in {"off", "critical"}:
         if calc.parameters.get("lmaxmix", 2) < 6 and max_Z > 56:
             LOGGER.info("Recommending LMAXMIX = 6 because you have f electrons.")
             calc.set(lmaxmix=6)
@@ -178,8 +180,9 @@ def get_param_swaps(
             calc.set(isearch=1)
 
     # ----------------------------
-    # Light INCAR swaps
+    # Critical INCAR swaps
     # ----------------------------
+    pre_critical_params = dict(calc.parameters)
     if incar_copilot_mode.lower() != "off":
         if not calc.parameters.get("lorbit", False) and (
             calc.parameters.get("ispin", 1) == 2
@@ -327,16 +330,37 @@ def get_param_swaps(
                 "You are running O2 without magnetic moments, but its ground state should have 2 unpaired electrons!"
             )
 
+    critical_swap_changes = {
+        k: v for k, v in calc.parameters.items() if pre_critical_params.get(k) != v
+    }
+
     if incar_copilot_mode == "aggressive":
         new_parameters = calc.parameters
     else:
-        new_parameters = calc.parameters | user_calc_params
+        new_parameters = (calc.parameters | user_calc_params) | critical_swap_changes
 
-    if changed_parameters := {
+    if added_parameters := {
         k: new_parameters[k] for k in set(new_parameters) - set(user_calc_params)
     }:
         LOGGER.info(
-            f"The following parameters were changed: {sort_dict(changed_parameters)}"
+            f"The following parameters were added: {sort_dict(added_parameters)}"
+        )
+
+    overridden_user_params = {
+        k: (user_calc_params[k], new_parameters[k])
+        for k in user_calc_params
+        if k in new_parameters and new_parameters[k] != user_calc_params[k]
+    }
+    for k, (old, new) in overridden_user_params.items():
+        LOGGER.warning(f"{k.upper()} was changed from {old!r} to {new!r}.")
+
+    if overridden_swaps := {
+        k: new_parameters[k]
+        for k in calc.parameters
+        if calc.parameters[k] != new_parameters.get(k)
+    }:
+        LOGGER.warning(
+            f"The following parameters were recommended but not applied so as to not override user settings: {sort_dict(overridden_swaps)}"
         )
 
     return new_parameters

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -331,7 +331,9 @@ def get_param_swaps(
             )
 
     critical_swap_changes = {
-        k: v for k, v in calc.parameters.items() if pre_critical_params.get(k) != v
+        k: v
+        for k, v in calc.parameters.items()
+        if not np.array_equal(pre_critical_params.get(k), v)
     }
 
     if incar_copilot_mode == "aggressive":
@@ -349,7 +351,8 @@ def get_param_swaps(
     overridden_user_params = {
         k: (user_calc_params[k], new_parameters[k])
         for k in user_calc_params
-        if k in new_parameters and new_parameters[k] != user_calc_params[k]
+        if k in new_parameters
+        and _params_differ(new_parameters[k], user_calc_params[k])
     }
     for k, (old, new) in overridden_user_params.items():
         LOGGER.warning(f"{k.upper()} was changed from {old!r} to {new!r}.")
@@ -357,7 +360,7 @@ def get_param_swaps(
     if overridden_swaps := {
         k: new_parameters[k]
         for k in calc.parameters
-        if calc.parameters[k] != new_parameters.get(k)
+        if not np.array_equal(calc.parameters[k], new_parameters.get(k))
     }:
         LOGGER.warning(
             f"The following parameters were recommended but not applied so as to not override user settings: {sort_dict(overridden_swaps)}"
@@ -648,3 +651,12 @@ class MPtoASEConverter:
             }
 
         return full_input_params
+
+
+def _params_differ(a, b) -> bool:
+    """Compare two parameter values, handling NumPy arrays."""
+    if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+        a = np.asarray(a)
+        b = np.asarray(b)
+        return a.shape != b.shape or not np.array_equal(a, b)
+    return a != b

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -47,7 +47,7 @@ class Vasp(Vasp_):
         input_atoms: Atoms,
         preset: None | str | Path = None,
         use_custodian: bool | DefaultSetting = QuaccDefault,
-        incar_copilot: Literal["off", "light", "default", "aggressive"]
+        incar_copilot: Literal["off", "critical", "standard", "aggressive"]
         | DefaultSetting = QuaccDefault,
         copy_magmoms: bool | DefaultSetting = QuaccDefault,
         preset_mag_default: float | DefaultSetting = QuaccDefault,
@@ -82,9 +82,9 @@ class Vasp(Vasp_):
 
             Options include:
                 off: Do not use co-pilot mode.
-                light: Use co-pilot mode for a subset of swaps. This will only modify INCAR
-                flags not already set by the user.
-                default: Use co-pilot mode. This will only modify INCAR flags not already set
+                critical: Use co-pilot mode for only critical swaps. These will always be
+                applied regardless of user settings.
+                standard: Use co-pilot mode. This will only modify INCAR flags not already set
                     by the user.
                 aggressive: Use co-pilot mode in aggressive mode. This will modify INCAR
                     flags even if they are already set by the user.

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -65,7 +65,7 @@ def omat_static_job(
     from fairchem.data.omat.vasp.sets import OMat24StaticSet
 
     calc_defaults = MPtoASEConverter(atoms=atoms).convert_input_set(OMat24StaticSet())
-    calc_defaults |= {"pp_version": "54", "incar_copilot": "light"}
+    calc_defaults |= {"pp_version": "54", "incar_copilot": "critical"}
 
     return run_and_summarize(
         atoms,
@@ -111,7 +111,7 @@ def omc_static_job(
     calc_defaults = _make_omc_inputs(atoms)
     calc_defaults |= {
         "pp_version": "54",
-        "incar_copilot": "light",
+        "incar_copilot": "critical",
         "use_custodian": False,
     }
 
@@ -237,7 +237,7 @@ def odac_static_job(
         "isym": 0,
         "pp_version": "54",
     }
-    calc_defaults |= {"incar_copilot": "light", "use_custodian": False}
+    calc_defaults |= {"incar_copilot": "critical", "use_custodian": False}
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
@@ -286,7 +286,7 @@ def oc20_static_job(
     calc_defaults = VASP_FLAGS | {
         "xc": "RPBE",
         "pp_version": "54",
-        "incar_copilot": "light",
+        "incar_copilot": "critical",
         "use_custodian": False,
     }
 

--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -86,7 +86,7 @@ def matpes_static_job(
     )
 
     # Set the user-defined KSPACING
-    calc_defaults |= {"kspacing": kspacing, "incar_copilot": "light"}
+    calc_defaults |= {"kspacing": kspacing, "incar_copilot": "critical"}
 
     # Set some parameters that we think are improvements to MatPES
     if use_improvements:

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -61,7 +61,7 @@ def mof_off_static_job(
     """
     default_parameters = {
         "kspacing": 0.4,
-        "incar_copilot": "light",
+        "incar_copilot": "critical",
         "use_improvements": True,
         "write_extra_files": True,
     }

--- a/src/quacc/recipes/vasp/mp24.py
+++ b/src/quacc/recipes/vasp/mp24.py
@@ -63,7 +63,7 @@ def mp_prerelax_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MP24PreRelaxMaker()
     )
-    calc_defaults["incar_copilot"] = "light"
+    calc_defaults["incar_copilot"] = "critical"
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
@@ -105,7 +105,7 @@ def mp_metagga_relax_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MP24RelaxMaker()
     )
-    calc_defaults["incar_copilot"] = "light"
+    calc_defaults["incar_copilot"] = "critical"
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
@@ -147,7 +147,7 @@ def mp_metagga_static_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MP24StaticMaker()
     )
-    calc_defaults["incar_copilot"] = "light"
+    calc_defaults["incar_copilot"] = "critical"
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,

--- a/src/quacc/recipes/vasp/mp_legacy.py
+++ b/src/quacc/recipes/vasp/mp_legacy.py
@@ -60,7 +60,7 @@ def mp_gga_relax_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MPGGARelaxMaker()
     )
-    calc_defaults["incar_copilot"] = "light"
+    calc_defaults["incar_copilot"] = "critical"
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
@@ -103,7 +103,7 @@ def mp_gga_static_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MPGGAStaticMaker()
     )
-    calc_defaults["incar_copilot"] = "light"
+    calc_defaults["incar_copilot"] = "critical"
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -278,14 +278,14 @@ class QuaccSettings(BaseSettings):
     )
 
     # VASP Settings: General
-    VASP_INCAR_COPILOT: Literal["off", "light", "default", "aggressive"] = Field(
-        "default",
+    VASP_INCAR_COPILOT: Literal["off", "critical", "standard", "aggressive"] = Field(
+        "standard",
         description=(
             """
             Controls VASP co-pilot mode for automated INCAR parameter handling.
             off: Do not use co-pilot mode. INCAR parameters will be unmodified.
-            light: Use co-pilot mode for only a subset of swaps. This will only modify INCAR flags not already set by the user.
-            default: Use co-pilot mode. This will only modify INCAR flags not already set by the user.
+            critical: Use co-pilot mode for only critical swaps. These will always be applied regardless of user settings.
+            standard: Use co-pilot mode. This will only modify INCAR flags not already set by the user.
             aggressive: Use co-pilot mode in aggressive mode. This will modify INCAR flags even if they are already set by the user.
             """
         ),

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -15,6 +15,7 @@ from ase.calculators.vasp import Vasp as Vasp_
 from ase.constraints import FixAtoms
 from ase.io import read
 from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet
+
 from quacc import change_settings, get_settings
 from quacc.calculators.vasp import Vasp, presets
 from quacc.calculators.vasp.params import MPtoASEConverter

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -15,7 +15,6 @@ from ase.calculators.vasp import Vasp as Vasp_
 from ase.constraints import FixAtoms
 from ase.io import read
 from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet
-
 from quacc import change_settings, get_settings
 from quacc.calculators.vasp import Vasp, presets
 from quacc.calculators.vasp.params import MPtoASEConverter
@@ -675,7 +674,7 @@ def test_kspacing():
     assert calc.parameters["ismear"] == -5
 
     calc = Vasp(atoms, kspacing=100, ismear=-5)
-    assert calc.parameters["ismear"] == -5
+    assert calc.parameters["ismear"] == 0
 
     calc = Vasp(atoms, kspacing=0.1, preset="DefaultSetGGA")
     assert calc.parameters["kspacing"] == 0.1

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from ase.build import bulk, molecule
 from monty.shutil import copy_r
-
 from quacc import change_settings
 from quacc.recipes.vasp.core import (
     ase_relax_job,
@@ -470,6 +469,7 @@ def test_mp_prerelax_job_metallic(patch_metallic_taskdoc):
     atoms = bulk("Al")
     output = mp_prerelax_job(atoms, ncore=None)
     assert output["structure_metadata"]["nsites"] == len(atoms)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-5,
@@ -571,10 +571,12 @@ def test_mp_metagga_relax_job_metallic(patch_metallic_taskdoc):
     ref_parameters2["magmom"] = [0.0]
 
     output = mp_metagga_relax_job(atoms, ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == ref_parameters
     assert output["structure_metadata"]["nsites"] == len(atoms)
 
     output = mp_metagga_relax_job(atoms, prev_dir=MOCKED_DIR / "metallic")
+    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"]["metagga"].lower() == "r2scan"
     assert output["parameters"]["ediffg"] == -0.02
@@ -590,6 +592,7 @@ def test_mp_metagga_relax_job_metallic(patch_metallic_taskdoc):
 def test_mp_metagga_relax_job_nonmetallic(patch_nonmetallic_taskdoc):
     atoms = bulk("Si")
     output = mp_metagga_relax_job(atoms, prev_dir=MOCKED_DIR / "nonmetallic")
+    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"]["metagga"].lower() == "r2scan"
     assert output["parameters"]["ediffg"] == -0.02
@@ -606,6 +609,7 @@ def test_mp_metagga_static_job(patch_metallic_taskdoc):
     atoms = bulk("Al")
 
     output = mp_metagga_static_job(atoms, ncore=None)
+    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"] == {
         "algo": "normal",
@@ -645,6 +649,7 @@ def test_mp_metagga_relax_flow_metallic(tmp_path, patch_metallic_taskdoc):
         copy_r(MOCKED_DIR / "metallic", tmp_path)
         atoms = bulk("Al")
         output = mp_metagga_relax_flow(atoms)
+        output["parameters"].pop("ncore")
         assert output["static"]["structure_metadata"]["nsites"] == len(atoms)
         assert output["prerelax"]["parameters"]["gga"] == "ps"
         assert output["prerelax"]["parameters"]["ismear"] == 0
@@ -670,6 +675,7 @@ def test_mp_metagga_relax_flow_nonmetallic(tmp_path, patch_nonmetallic_taskdoc):
         atoms = bulk("Si")
         atoms.set_initial_magnetic_moments([0.0, 0.0])
         output = mp_metagga_relax_flow(atoms)
+        output["parameters"].pop("ncore")
         assert output["prerelax"]["parameters"]["ismear"] == 0
         assert output["prerelax"]["parameters"]["pp"] == "pbe"
         assert output["prerelax"]["parameters"]["magmom"] == [0.0, 0.0]
@@ -690,6 +696,7 @@ def test_mp_metagga_relax_flow_nonmetallic(tmp_path, patch_nonmetallic_taskdoc):
         atoms.center(vacuum=10)
         atoms.pbc = True
         output = mp_metagga_relax_flow(atoms)
+        output["parameters"].pop("ncore")
         assert output["prerelax"]["parameters"]["ismear"] == 0
         assert output["prerelax"]["parameters"]["pp"] == "pbe"
         assert output["prerelax"]["parameters"]["magmom"] == [1.0, 0.0]
@@ -716,6 +723,7 @@ def test_mp_gga_relax_job(patch_nonmetallic_taskdoc):
     atoms[0].symbol = "O"
     del atoms.arrays["initial_magmoms"]
     output = mp_gga_relax_job(atoms, ncore=None)
+    output["parameters"].pop("ncore")
 
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"] == {
@@ -757,6 +765,7 @@ def test_mp_gga_static_job(patch_nonmetallic_taskdoc):
     atoms[0].symbol = "O"
     del atoms.arrays["initial_magmoms"]
     output = mp_gga_static_job(atoms, ncore=None)
+    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"] == {
         "algo": "fast",
@@ -797,7 +806,8 @@ def test_mp_gga_relax_flow(tmp_path, patch_nonmetallic_taskdoc):
         atoms = bulk("Ni") * (2, 1, 1)
         atoms[0].symbol = "O"
         del atoms.arrays["initial_magmoms"]
-        output = mp_gga_relax_flow(atoms, job_params={"all": {"ncore": None}})
+        output = mp_gga_relax_flow(atoms)
+        output["parameters"].pop("ncore")
         relax_params = {
             "algo": "fast",
             "ediff": 0.0001,
@@ -831,6 +841,9 @@ def test_mp_gga_relax_flow(tmp_path, patch_nonmetallic_taskdoc):
         relax2_params = relax_params.copy()
         relax2_params["magmom"] = [0.0, 0.0]
 
+        output["relax1"]["parameters"].pop("ncore")
+        output["relax2"]["parameters"].pop("ncore")
+        output["static"]["parameters"].pop("ncore")
         assert output["relax1"]["parameters"] == relax_params
         assert output["relax2"]["parameters"] == relax2_params
         assert output["static"]["parameters"] == {
@@ -908,6 +921,7 @@ def test_matpes(patch_metallic_taskdoc):
         use_improvements=True,
         write_extra_files=True,
     )
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -949,6 +963,7 @@ def test_matpes(patch_metallic_taskdoc):
         use_improvements=True,
         write_extra_files=True,
     )
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -982,6 +997,7 @@ def test_matpes(patch_metallic_taskdoc):
     }
 
     output = matpes_static_job(bulk("Al"), level="pbe", kspacing=0.4, ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
@@ -1011,6 +1027,7 @@ def test_matpes(patch_metallic_taskdoc):
     }
 
     output = matpes_static_job(bulk("Al"), level="r2scan", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
@@ -1046,6 +1063,7 @@ def test_matpes(patch_metallic_taskdoc):
         use_improvements=True,
         write_extra_files=True,
     )
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -1087,6 +1105,7 @@ def test_matpes(patch_metallic_taskdoc):
         use_improvements=True,
         write_extra_files=True,
     )
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
@@ -1121,6 +1140,7 @@ def test_matpes(patch_metallic_taskdoc):
     }
 
     output = matpes_static_job(atoms_no_mag, level="hse06", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
@@ -1158,6 +1178,7 @@ def test_matpes(patch_metallic_taskdoc):
 @pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
 def test_mof_off(patch_metallic_taskdoc):
     output = mof_off_static_job(bulk("Al"), level="pbe", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -1191,6 +1212,7 @@ def test_mof_off(patch_metallic_taskdoc):
     }
 
     output = mof_off_static_job(bulk("Al"), level="r2scan", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -1224,6 +1246,7 @@ def test_mof_off(patch_metallic_taskdoc):
     }
 
     output = mof_off_static_job(bulk("Al"), level="r2scan", dispersion="d4", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,
@@ -1262,6 +1285,7 @@ def test_mof_off(patch_metallic_taskdoc):
     }
 
     output = mof_off_static_job(bulk("Al"), level="pbe", dispersion="d3bj", ncore=None)
+    output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "algo": "all",
         "ediff": 1e-05,

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from ase.build import bulk, molecule
 from monty.shutil import copy_r
+
 from quacc import change_settings
 from quacc.recipes.vasp.core import (
     ase_relax_job,

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -576,7 +576,6 @@ def test_mp_metagga_relax_job_metallic(patch_metallic_taskdoc):
     assert output["structure_metadata"]["nsites"] == len(atoms)
 
     output = mp_metagga_relax_job(atoms, prev_dir=MOCKED_DIR / "metallic")
-    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"]["metagga"].lower() == "r2scan"
     assert output["parameters"]["ediffg"] == -0.02
@@ -592,7 +591,6 @@ def test_mp_metagga_relax_job_metallic(patch_metallic_taskdoc):
 def test_mp_metagga_relax_job_nonmetallic(patch_nonmetallic_taskdoc):
     atoms = bulk("Si")
     output = mp_metagga_relax_job(atoms, prev_dir=MOCKED_DIR / "nonmetallic")
-    output["parameters"].pop("ncore")
     assert output["structure_metadata"]["nsites"] == len(atoms)
     assert output["parameters"]["metagga"].lower() == "r2scan"
     assert output["parameters"]["ediffg"] == -0.02
@@ -649,7 +647,6 @@ def test_mp_metagga_relax_flow_metallic(tmp_path, patch_metallic_taskdoc):
         copy_r(MOCKED_DIR / "metallic", tmp_path)
         atoms = bulk("Al")
         output = mp_metagga_relax_flow(atoms)
-        output["parameters"].pop("ncore")
         assert output["static"]["structure_metadata"]["nsites"] == len(atoms)
         assert output["prerelax"]["parameters"]["gga"] == "ps"
         assert output["prerelax"]["parameters"]["ismear"] == 0
@@ -675,7 +672,6 @@ def test_mp_metagga_relax_flow_nonmetallic(tmp_path, patch_nonmetallic_taskdoc):
         atoms = bulk("Si")
         atoms.set_initial_magnetic_moments([0.0, 0.0])
         output = mp_metagga_relax_flow(atoms)
-        output["parameters"].pop("ncore")
         assert output["prerelax"]["parameters"]["ismear"] == 0
         assert output["prerelax"]["parameters"]["pp"] == "pbe"
         assert output["prerelax"]["parameters"]["magmom"] == [0.0, 0.0]
@@ -696,7 +692,6 @@ def test_mp_metagga_relax_flow_nonmetallic(tmp_path, patch_nonmetallic_taskdoc):
         atoms.center(vacuum=10)
         atoms.pbc = True
         output = mp_metagga_relax_flow(atoms)
-        output["parameters"].pop("ncore")
         assert output["prerelax"]["parameters"]["ismear"] == 0
         assert output["prerelax"]["parameters"]["pp"] == "pbe"
         assert output["prerelax"]["parameters"]["magmom"] == [1.0, 0.0]
@@ -807,7 +802,6 @@ def test_mp_gga_relax_flow(tmp_path, patch_nonmetallic_taskdoc):
         atoms[0].symbol = "O"
         del atoms.arrays["initial_magmoms"]
         output = mp_gga_relax_flow(atoms)
-        output["parameters"].pop("ncore")
         relax_params = {
             "algo": "fast",
             "ediff": 0.0001,


### PR DESCRIPTION
This PR achieves two goals:
1. It elevates a subset of the VASP parameter swaps to "critical" level that will override user choices by default. For instance, if ALGO = ALL and ISMEAR = -5 is set, it will switch ALGO to Normal.
2. It clarifies the logging with regards to VASP parameter swapping, highlighting which parameters have been added, swapped, and recommended but not changed. Closes https://github.com/Quantum-Accelerators/quacc/issues/3291.