### PR TITLE
Remove 'enaug' parameter from test assertions

### DIFF
--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -476,7 +476,6 @@ def test_mp_prerelax_job_metallic(patch_metallic_taskdoc):
         "algo": "normal",
         "ediff": 1e-5,
         "ediffg": -0.02,
-        "enaug": 1360,
         "encut": 680.0,
         "gga": "ps",
         "gga_compat": False,
@@ -541,7 +540,6 @@ def test_mp_metagga_relax_job_metallic(patch_metallic_taskdoc):
         "algo": "normal",
         "ediff": 1e-5,
         "ediffg": -0.02,
-        "enaug": 1360,
         "encut": 680.0,
         "gga_compat": False,
         "ibrion": 2,
@@ -614,7 +612,6 @@ def test_mp_metagga_static_job(patch_metallic_taskdoc):
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
-        "enaug": 1360,
         "encut": 680.0,
         "gga_compat": False,
         "ismear": -5,
@@ -997,7 +994,6 @@ def test_matpes(patch_metallic_taskdoc):
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
-        "enaug": 1360,
         "encut": 680.0,
         "gga": "PE",
         "ismear": 0,
@@ -1027,7 +1023,6 @@ def test_matpes(patch_metallic_taskdoc):
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
-        "enaug": 1360,
         "encut": 680.0,
         "ismear": 0,
         "ispin": 2,
@@ -1140,7 +1135,6 @@ def test_matpes(patch_metallic_taskdoc):
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-05,
-        "enaug": 1360,
         "encut": 680.0,
         "gga": "PE",
         "hfscreen": 0.2,
@@ -1357,7 +1351,6 @@ def test_fairchem_omc(patch_metallic_taskdoc):
     assert output["parameters"] == {
         "algo": "normal",
         "ediff": 1e-06,
-        "enaug": 1360,
         "encut": 520.0,
         "isif": 0,
         "ismear": 0,


### PR DESCRIPTION
Removed 'enaug' parameter from multiple assertions in test cases.

## Summary of Changes

\>> Provide context and a description of your changes here. Make sure to reference any associated issues. <<

### Requirements

- [ ] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [ ] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [ ] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).

Note: If you are an external contributor, you will see a comment from [@buildbot-princeton](https://github.com/buildbot-princeton). This is solely for the maintainers.
