### PR TITLE
Complete slab utility test coverage

### DIFF
--- a/tests/core/atoms/test_slabs.py
+++ b/tests/core/atoms/test_slabs.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from ase.build import bulk, fcc100, molecule
 from ase.io import read
+from pymatgen.core import Structure
 
 from quacc.atoms.slabs import (
     flip_atoms,
@@ -41,6 +42,9 @@ def test_flip_atoms():
     assert np.all(new_atoms.get_initial_magnetic_moments()[Zn_idx] == 2.0)
     assert np.all(new_atoms.get_initial_magnetic_moments()[Te_idx] == 1.0)
     assert new_atoms.info.get("test", None) == "hi"
+
+    flipped_structure = flip_atoms(atoms, return_struct=True)
+    assert isinstance(flipped_structure, Structure)
 
 
 def test_make_slabs_from_bulk(atoms_mag):
@@ -133,6 +137,13 @@ def test_make_adsorbate_structures():
     assert new_atoms[0].get_initial_magnetic_moments().tolist() == [*mags, 0, 0, 0]
     new_atoms = make_adsorbate_structures(atoms, h2o, modes=["ontop"])
     assert len(new_atoms) == 1
+
+    atoms_with_adsorbate_history = atoms.copy()
+    atoms_with_adsorbate_history.info["adsorbates"] = [{"existing": True}]
+    new_atoms = make_adsorbate_structures(
+        atoms_with_adsorbate_history, h2o, modes=["ontop"]
+    )
+    assert len(new_atoms[0].info["adsorbates"]) == 2
 
     new_atoms = make_adsorbate_structures(
         atoms, h2o, allowed_surface_symbols=["Cu", "Fe"]


### PR DESCRIPTION
## Summary

- test returning a pymatgen `Structure` from `flip_atoms`
- test extending pre-existing adsorbate history when generating new adsorption structures
- isolate the history case on a copied slab to preserve existing test scenarios

## Why

Codecov reports two uncovered statements in `src/quacc/atoms/slabs.py`. These cases exercise both.

## Impact

No production behavior changes. Structure conversion and adsorbate-history preservation gain regression coverage, and `atoms/slabs.py` should reach 100% file coverage.

## Validation

- `pytest -p no:cov tests/core/atoms/test_slabs.py` (5 passed)
- `ruff check tests/core/atoms/test_slabs.py`
- `ruff format --check tests/core/atoms/test_slabs.py`