### PR TITLE
Complete workflow decorator test coverage

### DIFF
--- a/tests/core/wflow/test_decorators.py
+++ b/tests/core/wflow/test_decorators.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
 
 from quacc import flow, job, subflow
 from quacc.wflow_tools.context import NodeType, tracked
@@ -111,3 +113,27 @@ def test_tracked_async_function():
         return a + b
 
     assert asyncio.run(add(1, 2)) == 3
+
+
+def test_ray_subflow_target_resolves_result(monkeypatch):
+    class FakeRemote:
+        def __init__(self, func):
+            self.func = func
+
+        def remote(self, *args, **kwargs):
+            return self.func(*args, **kwargs)
+
+    fake_ray = ModuleType("ray")
+    fake_ray.ObjectRef = type("ObjectRef", (), {})
+    fake_ray.get = lambda value: value
+    fake_ray.remote = FakeRemote
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(
+        "quacc.get_settings", lambda: SimpleNamespace(WORKFLOW_ENGINE="ray")
+    )
+
+    @subflow
+    def increment(value):
+        return value + 1
+
+    assert increment(1).result() == 2

--- a/tests/prefect/test_syntax.py
+++ b/tests/prefect/test_syntax.py
@@ -300,3 +300,19 @@ async def test_prefect_decorators3_async(tmp_path, monkeypatch):
         return await add_distributed(result2, c)
 
     assert (await dynamic_workflow(1, 2, 3)) == [6, 6, 6]
+
+
+@pytest.mark.asyncio
+async def test_prefect_flow_without_result_resolution():
+    with change_settings({"PREFECT_RESOLVE_FLOW_RESULTS": False}):
+
+        @flow
+        def sync_flow(value):
+            return value + 1
+
+        @flow
+        async def async_flow(value):
+            return value + 1
+
+        assert sync_flow(1) == 2
+        assert await async_flow(1) == 2


### PR DESCRIPTION
## Summary

- exercise the Ray subflow target closure in-process with a minimal remote executor
- test sync and async Prefect flows with automatic result resolution disabled
- keep cross-engine coverage focused on decorator behavior rather than backend execution

## Why

Codecov reports three uncovered statements in `src/quacc/wflow_tools/decorators.py`: one Ray worker closure and the sync/async Prefect no-resolution branches. These tests exercise all three.

## Impact

No production behavior changes. Cross-engine decorator behavior gains regression coverage, and `wflow_tools/decorators.py` should reach 100% file coverage.

## Validation

- `pytest -p no:cov tests/core/wflow/test_decorators.py` (5 passed)
- Ruff check and format verification on both changed files
- Prefect-specific execution deferred to the repository's dedicated CI shard