### PR TITLE
Complete defect utility test coverage

### DIFF
--- a/tests/core/atoms/test_defects.py
+++ b/tests/core/atoms/test_defects.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pymatgen.analysis.defects")
+
+from pymatgen.core import Lattice, Structure
+
+from quacc.atoms.defects import get_defect_entry_from_defect
+
+
+def test_get_defect_entry_requires_dummy_site():
+    defect_supercell = Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]])
+
+    with pytest.raises(ValueError, match="No dummy site found in defect supercell"):
+        get_defect_entry_from_defect(object(), defect_supercell, 0)


### PR DESCRIPTION
## Summary

- add an optional-extra test for defect supercells without a dummy site
- verify `get_defect_entry_from_defect` raises its intended validation error
- skip cleanly when the defects extra is not installed

## Why

Codecov reports one uncovered statement in `src/quacc/atoms/defects.py`: the malformed-supercell guard.

## Impact

No production behavior changes. Defect input validation gains regression coverage, and `atoms/defects.py` should reach 100% file coverage.

## Validation

- Ruff check and format verification pass
- local environment confirms the test skips cleanly without `quacc[defects]`
- execution is delegated to the repository's dedicated defects CI shard