### PR TITLE
Complete VASP parameter test coverage

### DIFF
--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1417,6 +1417,9 @@ def test_bad_pmg_converter():
     with pytest.raises(ValueError, match="Either atoms or prev_dir must be provided"):
         MPtoASEConverter()
 
+    converter = MPtoASEConverter(prev_dir="previous-run")
+    assert converter.structure is None
+
 
 def test_pmg_input_set():
     atoms = bulk("Cu")


### PR DESCRIPTION
## Summary

- construct `MPtoASEConverter` from a previous-run directory without atoms
- verify the converter intentionally leaves its structure unset in that mode

## Why

Codecov reports one uncovered statement in `src/quacc/calculators/vasp/params.py`: the previous-directory-only initialization branch.

## Impact

No production behavior changes. Restart-oriented converter initialization gains regression coverage, and `calculators/vasp/params.py` should reach 100% file coverage.

## Validation

- focused pytest case passes
- Ruff check and format verification pass