### PR TITLE
Complete Espresso recipe base test coverage

### DIFF
--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -7,12 +7,20 @@ from ase.atoms import Atoms
 
 from quacc.calculators.espresso.espresso import Espresso, EspressoTemplate
 from quacc.calculators.espresso.utils import prepare_copy_files
+from quacc.recipes.espresso._base import prepare_copy
+from quacc.wflow_tools.job_argument import Copy
 
 
 def test_prepare_copy_files_postahc():
     to_copy = prepare_copy_files({}, binary="postahc")
 
     assert Path("pwscf.save", "data-file-schema.*") in to_copy
+
+
+def test_prepare_copy_preserves_copy_argument():
+    copy_files = Copy({Path("previous-run"): ["charge-density.dat"]})
+
+    assert prepare_copy(copy_files) is copy_files
 
 
 def test_espresso_kwargs_handler():


### PR DESCRIPTION
## Summary
- verify `prepare_copy` preserves an existing ASE `Copy` argument
- cover the final uncovered statement in the Espresso recipe base helper
- make no production behavior changes

## Validation
- focused Espresso tests: 2 passed
- Ruff: clean