### PR TITLE
Fail clearly for unsupported NEB cell relaxation

### DIFF
--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -404,7 +404,17 @@ class Runner(BaseRunner):
         -------
         Dynamics
             The ASE Dynamics object following an NEB calculation.
+
+        Raises
+        ------
+        ValueError
+            If cell relaxation is requested because ASE NEB images do not support
+            cell filters.
         """
+        if relax_cell:
+            msg = "Cell relaxation is not supported for NEB calculations."
+            raise ValueError(msg)
+
         images = self.atoms
         run_kwargs = run_kwargs or {}
         neb_kwargs = neb_kwargs or {}
@@ -441,12 +451,6 @@ class Runner(BaseRunner):
         # Define the Trajectory object
         traj_file = neb_tmpdir / traj_filename
         traj = Trajectory(traj_file, "w", atoms=neb)
-
-        # Set volume relaxation constraints, if relevant
-        if relax_cell:
-            for i in range(len(images)):
-                if images[i].pbc.any():
-                    images[i] = FrechetCellFilter(images[i])
 
         dyn = optimizer(neb, **optimizer_kwargs)
         dyn.attach(traj.write)

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -19,7 +19,6 @@ from ase import Atoms
 from ase.build import bulk, molecule
 from ase.calculators.emt import EMT
 from ase.calculators.lj import LennardJones
-from ase.filters import FrechetCellFilter
 from ase.io import read, write
 from ase.mep.neb import NEBOptimizer
 from ase.optimize import BFGS, BFGSLineSearch
@@ -365,31 +364,13 @@ def test_run_neb(monkeypatch, tmp_path):
     assert not os.path.exists(tmp_path / "opt.log")
 
 
-def test_run_neb_relax_cell(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-
-    class NoOpOptimizer:
-        def __init__(self, atoms, **kwargs):
-            self.atoms = atoms
-
-        def attach(self, *args):
-            pass
-
-        def run(self, *args):
-            pass
-
+def test_run_neb_relax_cell():
     images = read(test_files_path / "neb_path.xyz", index=":")
-    for image in images:
-        image.set_cell([20, 20, 20])
-        image.set_pbc(True)
 
-    dyn = Runner(images, EMT()).run_neb(
-        relax_cell=True,
-        optimizer=NoOpOptimizer,
-        neb_kwargs={"method": "aseneb", "precon": None},
-    )
-
-    assert all(isinstance(image, FrechetCellFilter) for image in dyn.atoms.images)
+    with pytest.raises(
+        ValueError, match="Cell relaxation is not supported for NEB calculations"
+    ):
+        Runner(images, EMT()).run_neb(relax_cell=True)
 
 
 def test_run_neb2():


### PR DESCRIPTION
## Summary
- reject `relax_cell=True` for NEB calculations before any calculation directories are staged
- document the unsupported mode and its explicit `ValueError`
- replace the mock-only test with a regression test for the public behavior

## Bug
ASE NEB expects each image to expose atomic properties such as `.cell` directly. Wrapping images in `FrechetCellFilter` caused a runtime `AttributeError` once a real NEB optimizer evaluated the path.

## Validation
- `tests/core/runners/test_ase.py`: 25 passed
- Ruff: clean