### PR TITLE
Complete Espresso utility test coverage

### DIFF
--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -12,9 +12,7 @@ from quacc.calculators.espresso.utils import grid_copy_files, prepare_copy_files
 def test_grid_copy_files_non_gamma():
     directory = Path("previous")
 
-    files = grid_copy_files(
-        {"inputph": {}}, directory, 1, (0.5, 0.0, 0.0)
-    )[directory]
+    files = grid_copy_files({"inputph": {}}, directory, 1, (0.5, 0.0, 0.0))[directory]
 
     assert Path("_ph0", "pwscf.wfc*") in files
 
@@ -34,21 +32,14 @@ def test_prepare_copy_files_with_wavefunctions(binary):
 
 
 def test_prepare_copy_files_pp_wavefunctions():
-    to_copy = prepare_copy_files(
-        {"input_data": {"plot_num": 3}}, binary="pp"
-    )
+    to_copy = prepare_copy_files({"input_data": {"plot_num": 3}}, binary="pp")
 
     assert Path("pwscf.save", "wfc*.*") in to_copy
 
 
 def test_prepare_copy_files_ph_interpolation():
     parameters = {
-        "input_data": {
-            "inputph": {
-                "lqdir": True,
-                "ldvscf_interpolate": True,
-            }
-        }
+        "input_data": {"inputph": {"lqdir": True, "ldvscf_interpolate": True}}
     }
 
     to_copy = prepare_copy_files(parameters, binary="ph")

--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -6,7 +6,54 @@ import pytest
 from ase.atoms import Atoms
 
 from quacc.calculators.espresso.espresso import Espresso, EspressoTemplate
-from quacc.calculators.espresso.utils import prepare_copy_files
+from quacc.calculators.espresso.utils import grid_copy_files, prepare_copy_files
+
+
+def test_grid_copy_files_non_gamma():
+    directory = Path("previous")
+
+    files = grid_copy_files(
+        {"inputph": {}}, directory, 1, (0.5, 0.0, 0.0)
+    )[directory]
+
+    assert Path("_ph0", "pwscf.wfc*") in files
+
+
+@pytest.mark.parametrize("binary", ["dos", "fs"])
+def test_prepare_copy_files_density_only(binary):
+    to_copy = prepare_copy_files({}, binary=binary)
+
+    assert Path("pwscf.save", "charge-density.*") in to_copy
+
+
+@pytest.mark.parametrize("binary", ["projwfc", "bands"])
+def test_prepare_copy_files_with_wavefunctions(binary):
+    to_copy = prepare_copy_files({}, binary=binary)
+
+    assert Path("pwscf.save", "wfc*.*") in to_copy
+
+
+def test_prepare_copy_files_pp_wavefunctions():
+    to_copy = prepare_copy_files(
+        {"input_data": {"plot_num": 3}}, binary="pp"
+    )
+
+    assert Path("pwscf.save", "wfc*.*") in to_copy
+
+
+def test_prepare_copy_files_ph_interpolation():
+    parameters = {
+        "input_data": {
+            "inputph": {
+                "lqdir": True,
+                "ldvscf_interpolate": True,
+            }
+        }
+    }
+
+    to_copy = prepare_copy_files(parameters, binary="ph")
+
+    assert Path("_ph*", "pwscf.q_*", "pwscf.dvscf*") in to_copy
 
 
 def test_prepare_copy_files_postahc():


### PR DESCRIPTION
## Summary
- cover non-gamma phonon grid copy inputs
- verify DOS/FS and projected-band copy requirements
- verify PP wavefunction and phonon interpolation copy paths
- cover all six statements currently reported missing in `espresso/utils.py`

## Validation
- focused Espresso calculator tests: 16 passed
- Ruff: clean