### PR TITLE
Complete MRCC calculator test coverage

### DIFF
--- a/tests/core/calculators/mrcc/test_mrcc.py
+++ b/tests/core/calculators/mrcc/test_mrcc.py
@@ -4,7 +4,15 @@ import pytest
 from ase.atoms import Atoms
 
 from quacc import get_settings
-from quacc.calculators.mrcc.mrcc import MRCC, MrccProfile, _get_version_from_mrcc_header
+from quacc.calculators.mrcc import mrcc
+from quacc.calculators.mrcc.mrcc import (
+    MRCC,
+    MrccProfile,
+    MrccTemplate,
+    _get_version_from_mrcc_header,
+)
+
+MRCC_EXECUTE = MrccTemplate.execute
 
 
 def test_mrcc_version_from_string():
@@ -16,6 +24,37 @@ def test_mrcc_version_from_string():
  """
     version = _get_version_from_mrcc_header(reference_outputfile)
     assert version == "August 28, 2023"
+
+
+def test_mrcc_profile(monkeypatch):
+    header = "Release date: August 28, 2023\n"
+    monkeypatch.setattr(mrcc, "read_stdout", lambda command: header)
+    profile = MrccProfile(command="dmrcc")
+
+    assert profile.version() == "August 28, 2023"
+    assert profile.get_calculator_command("MINP") == ["MINP"]
+
+
+def test_mrcc_template_execute(tmp_path):
+    class Profile:
+        def run(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    profile = Profile()
+    MRCC_EXECUTE(MrccTemplate(), tmp_path, profile)
+
+    assert profile.args == (tmp_path, "MINP", "mrcc.out")
+    assert profile.kwargs == {"errorfile": "mrcc.err"}
+
+
+def test_mrcc_template_load_profile(monkeypatch):
+    expected = object()
+    monkeypatch.setattr(
+        MrccProfile, "from_config", lambda cfg, name, **kwargs: expected
+    )
+
+    assert MrccTemplate().load_profile(object()) is expected
 
 
 def test_mrcc_singlepoint(tmp_path):


### PR DESCRIPTION
## Summary
- verify MRCC version probing and input command construction
- exercise the real template execution contract
- cover profile loading from ASE configuration
- cover all five statements currently reported missing in `mrcc.py`

## Validation
- focused MRCC calculator tests: 5 passed
- Ruff: clean