### PR TITLE
Complete VASP Custodian test coverage

### DIFF
--- a/tests/core/calculators/vasp/test_vasp_custodian.py
+++ b/tests/core/calculators/vasp/test_vasp_custodian.py
@@ -33,6 +33,10 @@ def test_run_vasp_custodian(monkeypatch):
     run_custodian()
 
     run_custodian(vasp_custodian_wall_time=1)
+    run_custodian(
+        vasp_custodian_handlers=None,
+        vasp_custodian_validators=None,
+    )
 
     with pytest.raises(ValueError, match="Unknown VASP error handler"):
         run_custodian(vasp_custodian_handlers="cow")

--- a/tests/core/calculators/vasp/test_vasp_custodian.py
+++ b/tests/core/calculators/vasp/test_vasp_custodian.py
@@ -33,10 +33,7 @@ def test_run_vasp_custodian(monkeypatch):
     run_custodian()
 
     run_custodian(vasp_custodian_wall_time=1)
-    run_custodian(
-        vasp_custodian_handlers=None,
-        vasp_custodian_validators=None,
-    )
+    run_custodian(vasp_custodian_handlers=None, vasp_custodian_validators=None)
 
     with pytest.raises(ValueError, match="Unknown VASP error handler"):
         run_custodian(vasp_custodian_handlers="cow")


### PR DESCRIPTION
## Summary
- verify explicit `None` handler and validator arguments are normalized to empty lists
- cover both statements currently reported missing in `vasp_custodian.py`

## Validation
- focused VASP Custodian test: passed
- Ruff: clean