### PR TITLE
Use AIMD-specific VASP handlers

### DIFF
--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -33,6 +33,17 @@ if TYPE_CHECKING:
     from quacc.types import DefaultSetting
 
 
+AIMD_CUSTODIAN_HANDLERS = [
+    "VaspErrorHandler",
+    "MeshSymmetryErrorHandler",
+    "PositiveEnergyErrorHandler",
+    "FrozenJobErrorHandler",
+    "StdErrHandler",
+    "LargeSigmaHandler",
+    "IncorrectSmearingHandler",
+]
+
+
 class Vasp(Vasp_):
     """This is a wrapper around the ASE Vasp calculator that adjusts INCAR parameters
     on-the-fly, allows for ASE to run VASP via Custodian, and supports several automatic
@@ -337,7 +348,10 @@ class Vasp(Vasp_):
             directory = self.directory
 
         if self.use_custodian:
-            run_custodian(directory=directory)
+            custodian_kwargs = {"directory": directory}
+            if self.int_params.get("ibrion") == 0 and self.int_params.get("nsw", 0) > 0:
+                custodian_kwargs["vasp_custodian_handlers"] = AIMD_CUSTODIAN_HANDLERS
+            run_custodian(**custodian_kwargs)
             return 0, None
 
         result = subprocess.run(

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1257,9 +1257,7 @@ def test_run_aimd_custodian_handlers(monkeypatch, tmp_path):
     def mock_run_custodian(**kwargs):
         custodian_kwargs.update(kwargs)
 
-    monkeypatch.setattr(
-        "quacc.calculators.vasp.vasp.run_custodian", mock_run_custodian
-    )
+    monkeypatch.setattr("quacc.calculators.vasp.vasp.run_custodian", mock_run_custodian)
 
     calc = Vasp(bulk("Cu"), ibrion=0, nsw=10)
     calc._run(directory=tmp_path)

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1249,3 +1249,30 @@ def test_run(monkeypatch, tmp_path):
     calc = Vasp(atoms, xc="PBE", use_custodian=True)
     with pytest.raises(FileNotFoundError):
         calc._run()
+
+
+def test_run_aimd_custodian_handlers(monkeypatch, tmp_path):
+    custodian_kwargs = {}
+
+    def mock_run_custodian(**kwargs):
+        custodian_kwargs.update(kwargs)
+
+    monkeypatch.setattr(
+        "quacc.calculators.vasp.vasp.run_custodian", mock_run_custodian
+    )
+
+    calc = Vasp(bulk("Cu"), ibrion=0, nsw=10)
+    calc._run(directory=tmp_path)
+
+    assert custodian_kwargs == {
+        "directory": tmp_path,
+        "vasp_custodian_handlers": [
+            "VaspErrorHandler",
+            "MeshSymmetryErrorHandler",
+            "PositiveEnergyErrorHandler",
+            "FrozenJobErrorHandler",
+            "StdErrHandler",
+            "LargeSigmaHandler",
+            "IncorrectSmearingHandler",
+        ],
+    }


### PR DESCRIPTION
## Summary

- detect VASP AIMD runs from `IBRION = 0` and a positive `NSW`
- override the global Custodian error-handler selection with the AIMD-specific handlers used by atomate2
- preserve the existing Custodian behavior for non-AIMD calculations

## Why

The default VASP handler set includes handlers such as `PotimErrorHandler`, `NonConvergingErrorHandler`, and `UnconvergedErrorHandler` that do not apply cleanly to molecular-dynamics runs. Passing an explicit handler list from the calculator ensures AIMD jobs use only the appropriate error corrections while leaving the separate wall-time behavior unchanged.

## Validation

- `python -m pytest tests/core/calculators/vasp/test_vasp.py -k "run_aimd_custodian_handlers or test_run" -q` (2 passed)
- `git diff --check`

Ruff was also run on the touched files. It reported two pre-existing findings in `vasp.py` at lines 56 and 200; neither is introduced by this change.
