### PR TITLE
Cover final Codecov misses

### DIFF
--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -7,8 +7,6 @@ from ase.atoms import Atoms
 
 from quacc.calculators.espresso.espresso import Espresso, EspressoTemplate
 from quacc.calculators.espresso.utils import grid_copy_files, prepare_copy_files
-from quacc.recipes.espresso._base import prepare_copy
-from quacc.wflow_tools.job_argument import Copy
 
 
 def test_grid_copy_files_non_gamma():
@@ -53,12 +51,6 @@ def test_prepare_copy_files_postahc():
     to_copy = prepare_copy_files({}, binary="postahc")
 
     assert Path("pwscf.save", "data-file-schema.*") in to_copy
-
-
-def test_prepare_copy_preserves_copy_argument():
-    copy_files = Copy({Path("previous-run"): ["charge-density.dat"]})
-
-    assert prepare_copy(copy_files) is copy_files
 
 
 def test_espresso_kwargs_handler():

--- a/tests/core/recipes/espresso_recipes/test_base.py
+++ b/tests/core/recipes/espresso_recipes/test_base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from quacc.recipes.espresso._base import prepare_copy
+from quacc.wflow_tools.job_argument import Copy
+
+
+def test_prepare_copy_preserves_copy_argument():
+    copy_files = Copy({Path("previous-run"): ["charge-density.dat"]})
+
+    assert prepare_copy(copy_files) is copy_files

--- a/tests/core/recipes/torchsim_recipes/test_torchsim_recipes.py
+++ b/tests/core/recipes/torchsim_recipes/test_torchsim_recipes.py
@@ -77,6 +77,28 @@ def test_autobatcher_helpers(monkeypatch, ar_atoms):
     )
     assert process_binning_autobatcher_dict([ar_atoms], model, True) == (False, None)
 
+    class FakeBinningAutoBatcher:
+        memory_scales_with = "n_atoms"
+        max_memory_scaler = 1
+        max_atoms_to_try = 2
+        memory_scaling_factor = 3
+        max_memory_padding = 5
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    model.memory_scales_with = "n_atoms"
+    monkeypatch.setattr(_base, "BinningAutoBatcher", FakeBinningAutoBatcher)
+    autobatcher_dict = {"max_iterations": 4}
+
+    autobatcher, details = process_binning_autobatcher_dict(
+        [ar_atoms], model, autobatcher_dict
+    )
+
+    assert isinstance(autobatcher, FakeBinningAutoBatcher)
+    assert details["autobatcher"] == "FakeBinningAutoBatcher"
+    assert "max_iterations" not in autobatcher_dict
+
 
 def test_custom_trajectory_filenames(monkeypatch, tmp_path):
     class FakeReporter:


### PR DESCRIPTION
## Summary
- move the Espresso `Copy` passthrough regression into a dedicated, unskipped Espresso base-test module
- exercise TorchSim's dictionary-based binning autobatcher construction and metadata path
- target all six statements missing from Codecov's latest `main` report (99.86%)

## Why
The Espresso assertion already existed but was not producing coverage for the recipe helper in CI. The remaining five TorchSim statements belonged to the dictionary input branch, while the earlier test only exercised the boolean input branch.

## Validation
- focused Espresso tests: 20 passed
- Ruff: clean
- Python compile check: passed
- TorchSim runtime validation delegated to the dedicated optional-dependency CI shard