### PR TITLE
Fix YAML parent preset inheritance

### DIFF
--- a/src/quacc/utils/files.py
+++ b/src/quacc/utils/files.py
@@ -238,18 +238,18 @@ def load_yaml_calc(yaml_path: str | Path) -> dict[str, Any]:
     # the child file.
     for config_arg in deepcopy(config):
         if "parent" in config_arg.lower():
-            if Path(config[config_arg]).suffix in (".yml", ".yaml"):
-                yaml_parent_path = config[config_arg]
-            else:
-                yaml_parent_path = yaml_path.parent / f"{config[config_arg]}.yaml"
+            yaml_parent_path = Path(config[config_arg]).expanduser()
+            if yaml_parent_path.suffix not in (".yml", ".yaml"):
+                yaml_parent_path = Path(f"{yaml_parent_path}.yaml")
+            if not yaml_parent_path.is_absolute():
+                yaml_parent_path = yaml_path.parent / yaml_parent_path
             parent_config = load_yaml_calc(yaml_parent_path)
 
             for k, v in parent_config.items():
                 if k not in config:
                     config[k] = v
-                else:
-                    v_new = parent_config.get(k, {})
-                    for kk, vv in v_new.items():
+                elif isinstance(config[k], dict) and isinstance(v, dict):
+                    for kk, vv in v.items():
                         if kk not in config[k]:
                             config[k][kk] = vv
 

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -262,6 +262,36 @@ def test_load_yaml_calc_with_explicit_parent_path(tmp_path):
     assert config == {"settings": {"child": True, "inherited": True}}
 
 
+@pytest.mark.parametrize(
+    ("parent_ref", "parent_name"),
+    [("parent.yaml", "parent.yaml"), ("parent.1", "parent.1.yaml")],
+)
+def test_load_yaml_calc_with_relative_parent_path(
+    tmp_path, monkeypatch, parent_ref, parent_name
+):
+    preset_dir = tmp_path / "presets"
+    preset_dir.mkdir()
+    (preset_dir / parent_name).write_text("settings:\n  inherited: true\n")
+    child = preset_dir / "child.yaml"
+    child.write_text(f"parent: {parent_ref}\nsettings:\n  child: true\n")
+    monkeypatch.chdir(tmp_path)
+
+    config = load_yaml_calc(child)
+
+    assert config == {"settings": {"child": True, "inherited": True}}
+
+
+def test_load_yaml_calc_child_scalar_overrides_parent(tmp_path):
+    parent = tmp_path / "parent.yaml"
+    parent.write_text("method: parent\n")
+    child = tmp_path / "child.yaml"
+    child.write_text("parent: parent.yaml\nmethod: child\n")
+
+    config = load_yaml_calc(child)
+
+    assert config == {"method": "child"}
+
+
 def test_safe_decompress_dir_skips_disappearing_files(tmp_path, monkeypatch, caplog):
     disappearing_file = tmp_path / "output.gz"
     disappearing_file.touch()


### PR DESCRIPTION
## Summary

- resolve relative YAML parent references from the child preset's directory
- preserve extensionless parent names containing dots, such as `sssp_1.3.0_pbe_efficiency`
- allow child scalar values to override parent scalar values without crashing
- add regression coverage for relative, dotted, and scalar-override cases

## Root cause

Parent references that already ended in `.yaml` or `.yml` were passed through as raw relative paths. That made their resolution depend on the process working directory instead of the child preset's directory. Separately, every conflicting parent/child key was assumed to contain mappings, so scalar overrides raised an `AttributeError` while iterating `.items()`.

## Impact

Calculator presets can now inherit sibling YAML files consistently regardless of the caller's working directory. Child presets can also intentionally override scalar parent settings while retaining the existing shallow merge behavior for nested mappings.

## Validation

- `pytest tests/core/utils tests/core/calculators/vasp/test_vasp.py tests/core/calculators/espresso/test_espresso.py -q` — 99 passed, 12 skipped
- `ruff check src/quacc/utils/files.py tests/core/utils/test_files.py`
- `ruff format --check src/quacc/utils/files.py tests/core/utils/test_files.py`
- full `tests/core` run was attempted and exceeded the 5-minute local timeout without surfacing an early failure