### PR TITLE
Remove unreachable Espresso copy branch

### DIFF
--- a/src/quacc/recipes/espresso/_base.py
+++ b/src/quacc/recipes/espresso/_base.py
@@ -244,9 +244,6 @@ def prepare_copy(
     dict
         Dictionary of files to copy.
     """
-    if isinstance(copy_files, Copy):
-        return copy_files
-
     if isinstance(copy_files, str | Path):
         copy_files = [copy_files]
 


### PR DESCRIPTION
## Summary
- remove the unreachable `isinstance(copy_files, Copy)` branch from `prepare_copy`
- retain the existing passthrough behavior through the function's final return
- eliminate the sole remaining missed statement in Codecov's fresh `main` report (99.97%)

## Root cause
`Copy` is an abstract factory: constructing it returns an engine-specific implementation such as `DictCopy`, `DaskCopy`, or `JobflowCopy`. Those objects are not instances of `Copy`, so the branch could never execute. Non-list and non-path copy arguments already pass through unchanged at the end of the function.

## Validation
- focused Espresso tests: 20 passed
- Ruff: clean