### PR TITLE
Add MP-ALOE VASP static recipe

### DIFF
--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -1,0 +1,63 @@
+"""Materials Project ALOE-compatible VASP recipes."""
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+from monty.dev import requires
+
+from quacc import job
+from quacc.calculators.vasp.params import MPtoASEConverter
+from quacc.recipes.vasp._base import run_and_summarize
+
+has_atomate2 = bool(find_spec("atomate2"))
+
+if TYPE_CHECKING:
+    from ase.atoms import Atoms
+
+    from quacc.types import SourceDirectory, VaspSchema
+
+
+@job
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def mp_aloe_relax_job(
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+) -> VaspSchema:
+    """
+    Relax a structure with Materials Project ALOE settings.
+
+    The recipe uses the pymatgen MP24 relaxation settings with a plane-wave
+    cutoff of 680 eV and ``KSPACING = 0.2``.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+    prev_dir
+        A previous directory for a prior step in the workflow.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to ``None`` to
+        remove a pre-existing key entirely. User values take precedence over
+        the MP ALOE defaults.
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
+    """
+    from atomate2.vasp.jobs.mp import MP24RelaxMaker
+
+    calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
+        MP24RelaxMaker()
+    )
+    calc_defaults |= {"encut": 680, "kspacing": 0.2, "incar_copilot": "critical"}
+
+    return run_and_summarize(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        report_mp_corrections=True,
+        additional_fields={"name": "MP ALOE Relax"},
+        copy_files={prev_dir: ["CHGCAR*", "WAVECAR*"]} if prev_dir else None,
+    )

--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -45,11 +45,7 @@ def mp_aloe_static_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_input_set(
         MP24RelaxSet()
     )
-    calc_defaults |= {
-        "kspacing": 0.2,
-        "nsw": 0,
-        "incar_copilot": "critical",
-    }
+    calc_defaults |= {"kspacing": 0.2, "nsw": 0, "incar_copilot": "critical"}
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -1,4 +1,4 @@
-"""Materials Project ALOE-compatible VASP recipes."""
+"""MP-ALOE-compatible VASP recipes."""
 
 from __future__ import annotations
 
@@ -21,11 +21,11 @@ if TYPE_CHECKING:
 
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
-def mp_aloe_relax_job(
+def mp_aloe_static_job(
     atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
 ) -> VaspSchema:
     """
-    Relax a structure with Materials Project ALOE settings.
+    Run a static calculation with MP-ALOE settings.
 
     The recipe uses the pymatgen MP24 relaxation settings with a plane-wave
     cutoff of 680 eV and ``KSPACING = 0.2``.
@@ -39,7 +39,7 @@ def mp_aloe_relax_job(
     **calc_kwargs
         Custom kwargs for the Vasp calculator. Set a value to ``None`` to
         remove a pre-existing key entirely. User values take precedence over
-        the MP ALOE defaults.
+        the MP-ALOE defaults.
 
     Returns
     -------
@@ -51,13 +51,18 @@ def mp_aloe_relax_job(
     calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
         MP24RelaxMaker()
     )
-    calc_defaults |= {"encut": 680, "kspacing": 0.2, "incar_copilot": "critical"}
+    calc_defaults |= {
+        "encut": 680,
+        "kspacing": 0.2,
+        "nsw": 0,
+        "incar_copilot": "critical",
+    }
 
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
         report_mp_corrections=True,
-        additional_fields={"name": "MP ALOE Relax"},
+        additional_fields={"name": "MP-ALOE Static"},
         copy_files={prev_dir: ["CHGCAR*", "WAVECAR*"]} if prev_dir else None,
     )

--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-from importlib.util import find_spec
 from typing import TYPE_CHECKING
-
-from monty.dev import requires
 
 from quacc import job
 from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
-
-has_atomate2 = bool(find_spec("atomate2"))
 
 if TYPE_CHECKING:
     from ase.atoms import Atoms
@@ -20,7 +15,6 @@ if TYPE_CHECKING:
 
 
 @job
-@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_aloe_static_job(
     atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
 ) -> VaspSchema:
@@ -46,13 +40,12 @@ def mp_aloe_static_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
     """
-    from atomate2.vasp.jobs.mp import MP24RelaxMaker
+    from pymatgen.io.vasp.sets import MP24RelaxSet
 
-    calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_maker(
-        MP24RelaxMaker()
+    calc_defaults = MPtoASEConverter(atoms=atoms, prev_dir=prev_dir).convert_input_set(
+        MP24RelaxSet()
     )
     calc_defaults |= {
-        "encut": 680,
         "kspacing": 0.2,
         "nsw": 0,
         "incar_copilot": "critical",

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -20,6 +20,7 @@ from quacc.recipes.vasp.core import (
 from quacc.recipes.vasp.matpes import matpes_static_job
 from quacc.recipes.vasp.md import md_job
 from quacc.recipes.vasp.mof_off import mof_off_static_job
+from quacc.recipes.vasp.mp_aloe import mp_aloe_relax_job
 from quacc.recipes.vasp.mp24 import (
     mp_metagga_relax_flow,
     mp_metagga_relax_job,
@@ -50,6 +51,21 @@ has_fairchem_oc = (
 )
 FILE_DIR = Path(__file__).parent
 MOCKED_DIR = FILE_DIR / "mocked_vasp_runs"
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 is not installed")
+def test_mp_aloe_relax_job(patch_metallic_taskdoc):
+    atoms = bulk("Al")
+
+    output = mp_aloe_relax_job(atoms)
+    assert output["structure_metadata"]["nsites"] == len(atoms)
+    assert output["parameters"]["encut"] == 680
+    assert output["parameters"]["kspacing"] == 0.2
+    assert output["parameters"]["nsw"] > 0
+
+    output = mp_aloe_relax_job(atoms, encut=700, kspacing=0.25)
+    assert output["parameters"]["encut"] == 700
+    assert output["parameters"]["kspacing"] == 0.25
 
 
 def test_static_job(patch_metallic_taskdoc):

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -20,13 +20,13 @@ from quacc.recipes.vasp.core import (
 from quacc.recipes.vasp.matpes import matpes_static_job
 from quacc.recipes.vasp.md import md_job
 from quacc.recipes.vasp.mof_off import mof_off_static_job
-from quacc.recipes.vasp.mp_aloe import mp_aloe_relax_job
 from quacc.recipes.vasp.mp24 import (
     mp_metagga_relax_flow,
     mp_metagga_relax_job,
     mp_metagga_static_job,
     mp_prerelax_job,
 )
+from quacc.recipes.vasp.mp_aloe import mp_aloe_relax_job
 from quacc.recipes.vasp.mp_legacy import (
     mp_gga_relax_flow,
     mp_gga_relax_job,

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -26,7 +26,7 @@ from quacc.recipes.vasp.mp24 import (
     mp_metagga_static_job,
     mp_prerelax_job,
 )
-from quacc.recipes.vasp.mp_aloe import mp_aloe_relax_job
+from quacc.recipes.vasp.mp_aloe import mp_aloe_static_job
 from quacc.recipes.vasp.mp_legacy import (
     mp_gga_relax_flow,
     mp_gga_relax_job,
@@ -54,18 +54,54 @@ MOCKED_DIR = FILE_DIR / "mocked_vasp_runs"
 
 
 @pytest.mark.skipif(not has_atomate2, reason="atomate2 is not installed")
-def test_mp_aloe_relax_job(patch_metallic_taskdoc):
+def test_mp_aloe_static_job(patch_metallic_taskdoc):
     atoms = bulk("Al")
+    ref_parameters = {
+        "algo": "normal",
+        "ediff": 1e-5,
+        "encut": 680.0,
+        "gga_compat": False,
+        "isif": 3,
+        "ismear": 0,
+        "ispin": 2,
+        "kspacing": 0.2,
+        "laechg": True,
+        "lasph": True,
+        "lcharg": True,
+        "lelf": False,
+        "lmaxmix": 6,
+        "lmixtau": True,
+        "lorbit": 11,
+        "lreal": False,
+        "lvtot": True,
+        "lwave": True,
+        "magmom": [0.6],
+        "metagga": "r2scan",
+        "nelm": 200,
+        "nsw": 0,
+        "prec": "accurate",
+        "sigma": 0.05,
+        "pp": "pbe",
+        "pp_version": "64",
+        "setups": {"Al": ""},
+    }
 
-    output = mp_aloe_relax_job(atoms)
+    output = mp_aloe_static_job(atoms, ncore=None)
     assert output["structure_metadata"]["nsites"] == len(atoms)
-    assert output["parameters"]["encut"] == 680
-    assert output["parameters"]["kspacing"] == 0.2
-    assert output["parameters"]["nsw"] > 0
+    assert isinstance(output["parameters"].pop("ncore"), int)
+    assert output["parameters"] == ref_parameters
 
-    output = mp_aloe_relax_job(atoms, encut=700, kspacing=0.25)
-    assert output["parameters"]["encut"] == 700
-    assert output["parameters"]["kspacing"] == 0.25
+    output = mp_aloe_static_job(
+        atoms, encut=700, kspacing=0.25, ncore=None, nsw=1
+    )
+    assert isinstance(output["parameters"].pop("ncore"), int)
+    assert output["parameters"] == ref_parameters | {
+        "ediffg": -0.02,
+        "encut": 700,
+        "ibrion": 2,
+        "kspacing": 0.25,
+        "nsw": 1,
+    }
 
 
 def test_static_job(patch_metallic_taskdoc):

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -53,7 +53,6 @@ FILE_DIR = Path(__file__).parent
 MOCKED_DIR = FILE_DIR / "mocked_vasp_runs"
 
 
-@pytest.mark.skipif(not has_atomate2, reason="atomate2 is not installed")
 def test_mp_aloe_static_job(patch_metallic_taskdoc):
     atoms = bulk("Al")
     ref_parameters = {
@@ -74,7 +73,7 @@ def test_mp_aloe_static_job(patch_metallic_taskdoc):
         "lorbit": 11,
         "lreal": False,
         "lvtot": True,
-        "lwave": True,
+        "lwave": False,
         "magmom": [0.6],
         "metagga": "r2scan",
         "nelm": 200,

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -91,9 +91,7 @@ def test_mp_aloe_static_job(patch_metallic_taskdoc):
     assert isinstance(output["parameters"].pop("ncore"), int)
     assert output["parameters"] == ref_parameters
 
-    output = mp_aloe_static_job(
-        atoms, encut=700, kspacing=0.25, ncore=None, nsw=1
-    )
+    output = mp_aloe_static_job(atoms, encut=700, kspacing=0.25, ncore=None, nsw=1)
     assert isinstance(output["parameters"].pop("ncore"), int)
     assert output["parameters"] == ref_parameters | {
         "ediffg": -0.02,


### PR DESCRIPTION
## Summary

- add an `mp_aloe_static_job` VASP recipe using pymatgen’s `MP24RelaxSet` directly
- inherit `ENCUT = 680 eV` from the pymatgen MP24 YAML
- apply the MP-ALOE-specific defaults of `KSPACING = 0.2 Å⁻¹` and `NSW = 0`
- preserve calculator overrides, Materials Project correction reporting, and prior-run `CHGCAR`/`WAVECAR` reuse
- validate every returned VASP parameter for both the default job and an override case

## Why

This provides a reusable quacc recipe matching the VASP methodology used for the MP-ALOE dataset without requiring atomate2.

## Validation

- targeted mocked test passes: `1 passed, 36 deselected`
- the test compares the complete returned `parameters` mapping; environment-derived `NCORE` is validated separately
- the test runs without atomate2 installed
- `compileall` passes for the new module
- `git diff --check` passes

Closes #3390