### PR TITLE
Add MatterSim VASP static recipe

### DIFF
--- a/src/quacc/recipes/vasp/mattersim.py
+++ b/src/quacc/recipes/vasp/mattersim.py
@@ -1,0 +1,58 @@
+"""MatterSim-compatible VASP recipes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pymatgen.io.vasp.sets import MPRelaxSet
+
+from quacc import job
+from quacc.calculators.vasp.params import MPtoASEConverter
+from quacc.recipes.vasp._base import run_and_summarize
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ase.atoms import Atoms
+
+    from quacc.types import SourceDirectory, VaspSchema
+    from quacc.wflow_tools.job_argument import Copy
+
+
+@job
+def mattersim_relax_job(
+    atoms: Atoms,
+    copy_files: SourceDirectory | Copy | None = None,
+    additional_fields: dict[str, Any] | None = None,
+    **calc_kwargs,
+) -> VaspSchema:
+    """
+    Relax a structure with the VASP settings used for MatterSim.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+    copy_files
+        Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to `None` to remove a
+        pre-existing key entirely. All ASE Vasp calculator keyword arguments are
+        supported.
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
+    """
+    calc_defaults = MPtoASEConverter(atoms=atoms).convert_input_set(MPRelaxSet())
+
+    return run_and_summarize(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        additional_fields={"name": "MatterSim Relax"} | (additional_fields or {}),
+        copy_files=copy_files,
+    )

--- a/src/quacc/recipes/vasp/mattersim.py
+++ b/src/quacc/recipes/vasp/mattersim.py
@@ -20,14 +20,14 @@ if TYPE_CHECKING:
 
 
 @job
-def mattersim_relax_job(
+def mattersim_static_job(
     atoms: Atoms,
     copy_files: SourceDirectory | Copy | None = None,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> VaspSchema:
     """
-    Relax a structure with the VASP settings used for MatterSim.
+    Run a static calculation with the VASP settings used for MatterSim.
 
     Parameters
     ----------
@@ -48,11 +48,12 @@ def mattersim_relax_job(
         Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
     """
     calc_defaults = MPtoASEConverter(atoms=atoms).convert_input_set(MPRelaxSet())
+    calc_defaults["nsw"] = 0
 
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,
         calc_swaps=calc_kwargs,
-        additional_fields={"name": "MatterSim Relax"} | (additional_fields or {}),
+        additional_fields={"name": "MatterSim Static"} | (additional_fields or {}),
         copy_files=copy_files,
     )

--- a/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
@@ -7,38 +7,41 @@ from ase.build import bulk
 from quacc.recipes.vasp.mattersim import mattersim_static_job
 
 
-def test_mattersim_static_job(monkeypatch):
-    atoms = bulk("Al")
+def test_mattersim_static_job(patch_nonmetallic_taskdoc):
+    atoms = bulk("Ni") * (2, 1, 1)
+    atoms[0].symbol = "O"
+    del atoms.arrays["initial_magmoms"]
 
-    monkeypatch.setattr(
-        "quacc.recipes.vasp.mattersim.run_and_summarize",
-        lambda atoms, **kwargs: {"atoms": atoms, **kwargs},
-    )
+    output = mattersim_static_job(atoms, ncore=1)
 
-    output = mattersim_static_job(atoms, encut=600)
-
-    assert output["calc_defaults"] == {
-        "algo": "Fast",
-        "ediff": 5e-05,
-        "encut": 520.0,
+    assert output["parameters"] == {
+        "algo": "fast",
+        "ediff": 0.0001,
+        "encut": 520,
         "gamma": True,
-        "ibrion": 2,
         "isif": 3,
         "ismear": -5,
         "ispin": 2,
-        "kpts": (9, 9, 9),
+        "kpts": (5, 11, 11),
         "lasph": True,
+        "ldau": True,
+        "ldauj": [0, 0],
+        "ldaul": [0, 2],
+        "ldauprint": 1,
+        "ldautype": 2,
+        "ldauu": [0, 6.2],
+        "lmaxmix": 4,
         "lorbit": 11,
-        "lreal": "Auto",
+        "lreal": "auto",
         "lwave": False,
-        "magmom": [0.6],
+        "magmom": [0.6, 5],
         "nelm": 100,
+        "ncore": 1,
         "nsw": 0,
-        "pp": "PBE",
+        "pp": "pbe",
         "pp_version": "original",
-        "prec": "Accurate",
-        "setups": {"Al": ""},
+        "prec": "accurate",
+        "setups": {"Ni": "_pv", "O": ""},
         "sigma": 0.05,
     }
-    assert output["calc_swaps"] == {"encut": 600}
-    assert output["additional_fields"] == {"name": "MatterSim Static"}
+    assert output["name"] == "MatterSim Static"

--- a/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from ase.build import bulk
 
-from quacc.recipes.vasp.mattersim import mattersim_relax_job
+from quacc.recipes.vasp.mattersim import mattersim_static_job
 
 
-def test_mattersim_relax_job(monkeypatch):
+def test_mattersim_static_job(monkeypatch):
     atoms = bulk("Al")
 
     monkeypatch.setattr(
@@ -15,7 +15,7 @@ def test_mattersim_relax_job(monkeypatch):
         lambda atoms, **kwargs: {"atoms": atoms, **kwargs},
     )
 
-    output = mattersim_relax_job(atoms, encut=600)
+    output = mattersim_static_job(atoms, encut=600)
 
     assert output["calc_defaults"] == {
         "algo": "Fast",
@@ -33,7 +33,7 @@ def test_mattersim_relax_job(monkeypatch):
         "lwave": False,
         "magmom": [0.6],
         "nelm": 100,
-        "nsw": 99,
+        "nsw": 0,
         "pp": "PBE",
         "pp_version": "original",
         "prec": "Accurate",
@@ -41,4 +41,4 @@ def test_mattersim_relax_job(monkeypatch):
         "sigma": 0.05,
     }
     assert output["calc_swaps"] == {"encut": 600}
-    assert output["additional_fields"] == {"name": "MatterSim Relax"}
+    assert output["additional_fields"] == {"name": "MatterSim Static"}

--- a/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_mattersim.py
@@ -1,0 +1,44 @@
+"""Tests for the MatterSim-compatible VASP recipes."""
+
+from __future__ import annotations
+
+from ase.build import bulk
+
+from quacc.recipes.vasp.mattersim import mattersim_relax_job
+
+
+def test_mattersim_relax_job(monkeypatch):
+    atoms = bulk("Al")
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.mattersim.run_and_summarize",
+        lambda atoms, **kwargs: {"atoms": atoms, **kwargs},
+    )
+
+    output = mattersim_relax_job(atoms, encut=600)
+
+    assert output["calc_defaults"] == {
+        "algo": "Fast",
+        "ediff": 5e-05,
+        "encut": 520.0,
+        "gamma": True,
+        "ibrion": 2,
+        "isif": 3,
+        "ismear": -5,
+        "ispin": 2,
+        "kpts": (9, 9, 9),
+        "lasph": True,
+        "lorbit": 11,
+        "lreal": "Auto",
+        "lwave": False,
+        "magmom": [0.6],
+        "nelm": 100,
+        "nsw": 99,
+        "pp": "PBE",
+        "pp_version": "original",
+        "prec": "Accurate",
+        "setups": {"Al": ""},
+        "sigma": 0.05,
+    }
+    assert output["calc_swaps"] == {"encut": 600}
+    assert output["additional_fields"] == {"name": "MatterSim Relax"}


### PR DESCRIPTION
## Summary

- add a MatterSim-compatible VASP static recipe backed by `MPRelaxSet`
- override `NSW` to `0` so the calculation is static
- support calculator overrides, copied input files, and additional result fields
- add a unit test that checks every generated VASP parameter and recipe metadata

## Why

MatterSim benchmarking uses the Materials Project settings, so this provides a small first-class quacc recipe for generating compatible static VASP calculations.

## Validation

- `pytest tests/core/recipes/vasp_recipes/mocked/test_mattersim.py -q` (`1 passed`)
- `git diff --check`

Closes #3386