### PR TITLE
Add MatPES static flows

### DIFF
--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -14,18 +14,26 @@ from typing import TYPE_CHECKING
 
 from monty.dev import requires
 
-from quacc import job
+from quacc import flow, job
 from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
+from quacc.wflow_tools.customizers import customize_funcs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from collections.abc import Callable
+    from typing import Any, Literal, TypedDict
 
     from ase.atoms import Atoms
 
     from quacc.types import SourceDirectory, VaspSchema
+
+    class MatPESStaticFlowSchema(TypedDict):
+        """Type hint associated with the MatPES static flow."""
+
+        pbe: VaspSchema
+        r2scan: VaspSchema
 
 
 @job
@@ -121,3 +129,47 @@ def matpes_static_job(
         additional_fields={"name": f"MatPES {level} Static"},
         copy_files={prev_dir: ["WAVECAR*"]} if prev_dir else None,
     )
+
+
+@flow
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def matpes_static_flow(
+    atoms: Atoms,
+    job_params: dict[str, dict[str, Any]] | None = None,
+    job_decorators: dict[str, Callable | None] | None = None,
+) -> MatPESStaticFlowSchema:
+    """Run consecutive MatPES-compatible PBE and r2SCAN static calculations.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+    job_params
+        Custom parameters for the ``pbe_static_job`` and ``r2scan_static_job``
+        steps. Use the ``all`` key to customize both steps.
+    job_decorators
+        Custom decorators for the ``pbe_static_job`` and ``r2scan_static_job``
+        steps. Use the ``all`` key to customize both steps.
+
+    Returns
+    -------
+    MatPESStaticFlowSchema
+        Dictionary containing the PBE and r2SCAN results.
+    """
+    pbe_static_job, r2scan_static_job = customize_funcs(
+        ["pbe_static_job", "r2scan_static_job"],
+        [matpes_static_job, matpes_static_job],
+        param_defaults={
+            "pbe_static_job": {"level": "PBE"},
+            "r2scan_static_job": {"level": "r2SCAN"},
+        },
+        param_swaps=job_params,
+        decorators=job_decorators,
+    )
+
+    pbe_results = pbe_static_job(atoms)
+    r2scan_results = r2scan_static_job(
+        pbe_results["atoms"], prev_dir=pbe_results["dir_name"]
+    )
+
+    return {"pbe": pbe_results, "r2scan": r2scan_results}

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -94,6 +94,7 @@ def mof_off_static_job(
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mof_off_static_flow(
     atoms: Atoms,
+    dispersion: Literal["D3BJ", "D4"] | None = None,
     job_params: dict[str, dict[str, Any]] | None = None,
     job_decorators: dict[str, Callable | None] | None = None,
 ) -> MOFOffStaticFlowSchema:
@@ -103,6 +104,9 @@ def mof_off_static_flow(
     ----------
     atoms
         Atoms object.
+    dispersion
+        Dispersion correction to apply to both static calculations: None,
+        "D3BJ", or "D4".
     job_params
         Custom parameters for the ``pbe_static_job`` and ``r2scan_static_job``
         steps. Use the ``all`` key to customize both steps.
@@ -119,8 +123,8 @@ def mof_off_static_flow(
         ["pbe_static_job", "r2scan_static_job"],
         [mof_off_static_job, mof_off_static_job],
         param_defaults={
-            "pbe_static_job": {"level": "PBE"},
-            "r2scan_static_job": {"level": "r2SCAN"},
+            "pbe_static_job": {"level": "PBE", "dispersion": dispersion},
+            "r2scan_static_job": {"level": "r2SCAN", "dispersion": dispersion},
         },
         param_swaps=job_params,
         decorators=job_decorators,

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -10,18 +10,26 @@ from typing import TYPE_CHECKING
 from ase.units import Bohr
 from monty.dev import requires
 
-from quacc import job
+from quacc import flow, job
 from quacc.recipes.vasp.matpes import matpes_static_job
 from quacc.utils.dicts import recursive_dict_merge
+from quacc.wflow_tools.customizers import customize_funcs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from collections.abc import Callable
+    from typing import Any, Literal, TypedDict
 
     from ase.atoms import Atoms
 
     from quacc.types import SourceDirectory, VaspSchema
+
+    class MOFOffStaticFlowSchema(TypedDict):
+        """Type hint associated with the MOF-off static flow."""
+
+        pbe: VaspSchema
+        r2scan: VaspSchema
 
 
 @job
@@ -80,3 +88,47 @@ def mof_off_static_job(
     return matpes_static_job(
         atoms, level=level, auto_ispin=True, prev_dir=prev_dir, **calc_flags
     )
+
+
+@flow
+@requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
+def mof_off_static_flow(
+    atoms: Atoms,
+    job_params: dict[str, dict[str, Any]] | None = None,
+    job_decorators: dict[str, Callable | None] | None = None,
+) -> MOFOffStaticFlowSchema:
+    """Run consecutive MOF-off-compatible PBE and r2SCAN static calculations.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+    job_params
+        Custom parameters for the ``pbe_static_job`` and ``r2scan_static_job``
+        steps. Use the ``all`` key to customize both steps.
+    job_decorators
+        Custom decorators for the ``pbe_static_job`` and ``r2scan_static_job``
+        steps. Use the ``all`` key to customize both steps.
+
+    Returns
+    -------
+    MOFOffStaticFlowSchema
+        Dictionary containing the PBE and r2SCAN results.
+    """
+    pbe_static_job, r2scan_static_job = customize_funcs(
+        ["pbe_static_job", "r2scan_static_job"],
+        [mof_off_static_job, mof_off_static_job],
+        param_defaults={
+            "pbe_static_job": {"level": "PBE"},
+            "r2scan_static_job": {"level": "r2SCAN"},
+        },
+        param_swaps=job_params,
+        decorators=job_decorators,
+    )
+
+    pbe_results = pbe_static_job(atoms)
+    r2scan_results = r2scan_static_job(
+        pbe_results["atoms"], prev_dir=pbe_results["dir_name"]
+    )
+
+    return {"pbe": pbe_results, "r2scan": r2scan_results}

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1381,7 +1381,7 @@ def test_mof_off_static_flow(tmp_path, patch_metallic_taskdoc):
     with change_settings({"CREATE_UNIQUE_DIR": False, "RESULTS_DIR": tmp_path}):
         copy_r(MOCKED_DIR / "metallic", tmp_path)
         output = mof_off_static_flow(
-            bulk("Al"), job_params={"all": {"dispersion": "D4", "ncore": None}}
+            bulk("Al"), dispersion="D4", job_params={"all": {"ncore": None}}
         )
     assert output["pbe"]["parameters"]["xc"] == "pbe"
     assert output["pbe"]["parameters"]["lwave"] is True

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -17,9 +17,9 @@ from quacc.recipes.vasp.core import (
     relax_job,
     static_job,
 )
-from quacc.recipes.vasp.matpes import matpes_static_job
+from quacc.recipes.vasp.matpes import matpes_static_flow, matpes_static_job
 from quacc.recipes.vasp.md import md_job
-from quacc.recipes.vasp.mof_off import mof_off_static_job
+from quacc.recipes.vasp.mof_off import mof_off_static_flow, mof_off_static_job
 from quacc.recipes.vasp.mp24 import (
     mp_metagga_relax_flow,
     mp_metagga_relax_job,
@@ -1216,6 +1216,18 @@ def test_matpes(patch_metallic_taskdoc):
 
 
 @pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_matpes_static_flow(patch_metallic_taskdoc):
+    output = matpes_static_flow(
+        bulk("Al"), job_params={"all": {"ncore": None, "kspacing": 0.4}}
+    )
+    assert output["pbe"]["parameters"]["xc"] == "pbe"
+    assert output["pbe"]["parameters"]["lwave"] is True
+    assert output["r2scan"]["parameters"]["xc"] == "r2scan"
+    assert output["r2scan"]["parameters"]["metagga"] == "R2SCAN"
+    assert output["r2scan"]["parameters"]["kspacing"] == 0.4
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
 def test_mof_off(patch_metallic_taskdoc):
     output = mof_off_static_job(bulk("Al"), level="pbe", ncore=None)
     output["parameters"].pop("ncore")
@@ -1360,6 +1372,19 @@ def test_mof_off(patch_metallic_taskdoc):
         "sdftd3_damping": "rational",
         "xc": "pbe",
     }
+
+
+@pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
+def test_mof_off_static_flow(patch_metallic_taskdoc):
+    output = mof_off_static_flow(
+        bulk("Al"), job_params={"all": {"dispersion": "D4", "ncore": None}}
+    )
+    assert output["pbe"]["parameters"]["xc"] == "pbe"
+    assert output["pbe"]["parameters"]["lwave"] is True
+    assert output["pbe"]["parameters"]["ivdw"] == 13
+    assert output["r2scan"]["parameters"]["xc"] == "r2scan"
+    assert output["r2scan"]["parameters"]["metagga"] == "R2SCAN"
+    assert output["r2scan"]["parameters"]["ivdw"] == 13
 
 
 @pytest.mark.skipif(not has_fairchem_omat, reason="fairchem not installed")

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1216,10 +1216,12 @@ def test_matpes(patch_metallic_taskdoc):
 
 
 @pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
-def test_matpes_static_flow(patch_metallic_taskdoc):
-    output = matpes_static_flow(
-        bulk("Al"), job_params={"all": {"ncore": None, "kspacing": 0.4}}
-    )
+def test_matpes_static_flow(tmp_path, patch_metallic_taskdoc):
+    with change_settings({"CREATE_UNIQUE_DIR": False, "RESULTS_DIR": tmp_path}):
+        copy_r(MOCKED_DIR / "metallic", tmp_path)
+        output = matpes_static_flow(
+            bulk("Al"), job_params={"all": {"ncore": None, "kspacing": 0.4}}
+        )
     assert output["pbe"]["parameters"]["xc"] == "pbe"
     assert output["pbe"]["parameters"]["lwave"] is True
     assert output["r2scan"]["parameters"]["xc"] == "r2scan"
@@ -1375,10 +1377,12 @@ def test_mof_off(patch_metallic_taskdoc):
 
 
 @pytest.mark.skipif(not has_atomate2, reason="atomate2 not installed")
-def test_mof_off_static_flow(patch_metallic_taskdoc):
-    output = mof_off_static_flow(
-        bulk("Al"), job_params={"all": {"dispersion": "D4", "ncore": None}}
-    )
+def test_mof_off_static_flow(tmp_path, patch_metallic_taskdoc):
+    with change_settings({"CREATE_UNIQUE_DIR": False, "RESULTS_DIR": tmp_path}):
+        copy_r(MOCKED_DIR / "metallic", tmp_path)
+        output = mof_off_static_flow(
+            bulk("Al"), job_params={"all": {"dispersion": "D4", "ncore": None}}
+        )
     assert output["pbe"]["parameters"]["xc"] == "pbe"
     assert output["pbe"]["parameters"]["lwave"] is True
     assert output["pbe"]["parameters"]["ivdw"] == 13


### PR DESCRIPTION
## Summary

- add `matpes_static_flow` with consecutive PBE and r2SCAN static calculations
- add `mof_off_static_flow` with the same two-step sequence using the MOF-off static recipe
- pass the PBE atoms and output directory into r2SCAN so the second step can reuse the PBE wavefunction
- support per-step `job_params` and `job_decorators`, including shared `all` overrides
- add focused mocked-recipe coverage for both flows

## Impact

Users can run the standard PBE → r2SCAN static sequence for MatPES and MOF-off through a single flow while retaining quacc's normal per-job customization hooks.

## Validation

- Ruff lint: passed
- Ruff formatting check: passed
- Python compilation: passed
- Focused pytest selection: 2 tests discovered and skipped because `atomate2` is unavailable in the local test environment