### PR TITLE
docs: show @flow in silent workflow examples

### DIFF
--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -33,7 +33,7 @@ graph LR
         1. It is necessary to instantiate a Dask client before running Dask workflows. This command loads the default (local) client and only needs to be done once.
 
     ```python
-    from quacc import job
+    from quacc import flow, job
 
 
     @job  #  (1)!
@@ -46,6 +46,7 @@ graph LR
         return a * b
 
 
+    @flow
     def workflow(a, b, c):  #  (2)!
         output1 = add(a, b)
         output2 = mult(output1, c)
@@ -59,7 +60,7 @@ graph LR
 
     1. The `#!Python @job` decorator will be transformed into a Dask `#!Python @delayed`.
 
-    2. The `#!Python @flow` decorator doesn't actually do anything when using Dask, so we chose to not include it here for brevity.
+    2. The `#!Python @flow` decorator doesn't actually do anything when using Dask, but it is included here to make the workflow boundary explicit.
 
     3. This returns a `Delayed` object. A reference is returned.
 
@@ -84,7 +85,7 @@ graph LR
         1. It is necessary to instantiate a Parsl configuration before running Parsl workflows. This command loads the default (local) configuration and only needs to be done once.
 
     ```python
-    from quacc import job
+    from quacc import flow, job
 
 
     @job  #  (1)!
@@ -97,6 +98,7 @@ graph LR
         return a * b
 
 
+    @flow
     def workflow(a, b, c):  #  (2)!
         output1 = add(a, b)
         output2 = mult(output1, c)
@@ -110,7 +112,7 @@ graph LR
 
     1. The `#!Python @job` decorator will be transformed into a Parsl `#!Python @python_app`.
 
-    2. The `#!Python @flow` decorator doesn't actually do anything when using Parsl, so we chose to not include it here for brevity.
+    2. The `#!Python @flow` decorator doesn't actually do anything when using Parsl, but it is included here to make the workflow boundary explicit.
 
     3. This will create a `PythonApp` object that represents the workflow. At this point, the workflow has been dispatched, but only a reference is returned.
 
@@ -140,6 +142,7 @@ graph LR
         return a * b
 
 
+    @flow
     @flow
     def workflow(a, b, c):  #  (2)!
         output1 = add(a, b)
@@ -176,7 +179,7 @@ graph LR
         1. It is necessary to initialize Ray before submitting calculations. This command starts (or connects to) a local Ray cluster and only needs to be done once.
 
     ```python
-    from quacc import job
+    from quacc import flow, job
 
 
     @job  #  (1)!
@@ -189,6 +192,7 @@ graph LR
         return a * b
 
 
+    @flow
     def workflow(a, b, c):  #  (2)!
         output1 = add(a, b)
         output2 = mult(output1, c)
@@ -202,7 +206,7 @@ graph LR
 
     1. The `#!Python @job` decorator will be transformed into a Ray `#!Python @ray.remote`.
 
-    2. The `#!Python @flow` decorator doesn't actually do anything when using Ray, so we chose to not include it here for brevity.
+    2. The `#!Python @flow` decorator doesn't actually do anything when using Ray, but it is included here to make the workflow boundary explicit.
 
     3. This returns a `RayFuture` proxy wrapping a Ray `ObjectRef`. A reference is returned without blocking.
 
@@ -269,7 +273,7 @@ graph LR
 
     ```python
     import jobflow as jf
-    from quacc import job
+    from quacc import flow, job
 
 
     @job  #  (1)!

--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -143,7 +143,6 @@ graph LR
 
 
     @flow
-    @flow
     def workflow(a, b, c):  #  (2)!
         output1 = add(a, b)
         output2 = mult(output1, c)
@@ -273,7 +272,7 @@ graph LR
 
     ```python
     import jobflow as jf
-    from quacc import flow, job
+    from quacc import job
 
 
     @job  #  (1)!

--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -46,8 +46,8 @@ graph LR
         return a * b
 
 
-    @flow
-    def workflow(a, b, c):  #  (2)!
+    @flow  #  (2)!
+    def workflow(a, b, c):
         output1 = add(a, b)
         output2 = mult(output1, c)
         return output2
@@ -98,8 +98,8 @@ graph LR
         return a * b
 
 
-    @flow
-    def workflow(a, b, c):  #  (2)!
+    @flow  #  (2)!
+    def workflow(a, b, c):
         output1 = add(a, b)
         output2 = mult(output1, c)
         return output2
@@ -142,8 +142,8 @@ graph LR
         return a * b
 
 
-    @flow
-    def workflow(a, b, c):  #  (2)!
+    @flow  #  (2)!
+    def workflow(a, b, c):
         output1 = add(a, b)
         output2 = mult(output1, c)
         return output2
@@ -191,8 +191,8 @@ graph LR
         return a * b
 
 
-    @flow
-    def workflow(a, b, c):  #  (2)!
+    @flow  #  (2)!
+    def workflow(a, b, c):
         output1 = add(a, b)
         output2 = mult(output1, c)
         return output2


### PR DESCRIPTION
## Summary

- add `@flow` around `workflow` in the Dask, Parsl, and Ray examples
- import `flow` in those examples
- clarify that the decorator is shown to make the workflow boundary explicit even though it is a no-op for those engines

## Testing

- documentation-only change; verified the branch diff is limited to `docs/user/basics/wflow_syntax.md`