### PR TITLE
Make Jobflow job chaining engine agnostic

### DIFF
--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -287,27 +287,26 @@ graph LR
 
     @flow  #  (2)!
     def workflow(a, b, c):
-        job1 = add(a, b)
-        job2 = mult(job1.output, c)
-        return job2.output
+        return mult(add(a, b), c)
 
 
     workflow_flow = workflow(1, 2, 3)  #  (3)!
 
     responses = jf.run_locally(workflow_flow, ensure_success=True)  #  (4)!
-    result = responses[workflow_flow.output.uuid][1].output  #  (5)!
+    final_job = workflow_flow.jobs[-1]
+    result = responses[final_job.uuid][1].output  #  (5)!
     print(result)  # 9
     ```
 
     1. The `#!Python @job` decorator will be transformed into `#!Python @jf.job`.
 
-    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs created by the decorated function and use the returned output reference as the flow output.
+    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs returned by the decorated function. When a quacc-decorated job is passed to another quacc-decorated job, quacc automatically passes its output reference to Jobflow.
 
     3. Calling the decorated function returns the Jobflow `#!Python Flow` that represents the workflow.
 
     4. The workflow is run locally and the responses are returned in a dictionary.
 
-    5. The result is extracted from the dictionary by using the UUID of the job referenced by the flow output.
+    5. The result is extracted from the dictionary by using the UUID of the final job in the workflow.
 
 ??? Tip "Stripping the Decorator from a Job"
 

--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -287,26 +287,27 @@ graph LR
 
     @flow  #  (2)!
     def workflow(a, b, c):
-        return mult(add(a, b), c)
+        job1 = add(a, b)
+        job2 = mult(job1.output, c)
+        return job2.output
 
 
     workflow_flow = workflow(1, 2, 3)  #  (3)!
 
     responses = jf.run_locally(workflow_flow, ensure_success=True)  #  (4)!
-    final_job = workflow_flow.jobs[-1]
-    result = responses[final_job.uuid][1].output  #  (5)!
+    result = responses[workflow_flow.output.uuid][1].output  #  (5)!
     print(result)  # 9
     ```
 
     1. The `#!Python @job` decorator will be transformed into `#!Python @jf.job`.
 
-    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs returned by the decorated function.
+    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs created by the decorated function and use the returned output reference as the flow output.
 
     3. Calling the decorated function returns the Jobflow `#!Python Flow` that represents the workflow.
 
     4. The workflow is run locally and the responses are returned in a dictionary.
 
-    5. The result is extracted from the dictionary by using the UUID of the final job in the workflow.
+    5. The result is extracted from the dictionary by using the UUID of the job referenced by the flow output.
 
 ??? Tip "Stripping the Decorator from a Job"
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -162,15 +162,14 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
         from prefect import task
 
         if settings.PREFECT_AUTO_SUBMIT:
+            decorated = task(_func, **kwargs)
 
             @wraps(_func)
             def wrapper(*f_args, **f_kwargs):
-                decorated = task(_func, **kwargs)
                 return decorated.submit(*f_args, **f_kwargs)
 
             return wrapper
-        else:
-            return task(_func, **kwargs)
+        return task(_func, **kwargs)
     elif settings.WORKFLOW_ENGINE == "ray":
         import ray
 
@@ -182,14 +181,13 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
 
         @wraps(_ray_target)
         def wrapper(*f_args, **f_kwargs):
-            f_args = tuple(_unwrap_ray_future(a) for a in f_args)
-            f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
+            f_args, f_kwargs = _transform_call_args(
+                f_args, f_kwargs, _unwrap_ray_future
+            )
             return RayFuture(remote_func.remote(*f_args, **f_kwargs))
 
         return wrapper
-    else:
-        _func = tracked(NodeType.JOB)(_func)
-        return _func
+    return tracked(NodeType.JOB)(_func)
 
 
 def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
@@ -559,14 +557,13 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
 
         @wraps(target_func)
         def wrapper(*f_args, **f_kwargs):
-            f_args = tuple(_unwrap_ray_future(a) for a in f_args)
-            f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
+            f_args, f_kwargs = _transform_call_args(
+                f_args, f_kwargs, _unwrap_ray_future
+            )
             return RayFuture(remote_subflow.remote(*f_args, **f_kwargs))
 
         return wrapper
-    else:
-        _func = tracked(NodeType.SUBFLOW)(_func)
-        return _func
+    return tracked(NodeType.SUBFLOW)(_func)
 
 
 def _get_parsl_wrapped_func(
@@ -617,40 +614,49 @@ def _get_prefect_wrapped_flow(
     from prefect.futures import resolve_futures_to_results
     from prefect.utilities.asyncutils import is_async_fn
 
+    if not settings.PREFECT_RESOLVE_FLOW_RESULTS:
+        return prefect_flow(_func, validate_parameters=False, **kwargs)
+
     if is_async_fn(_func):
-        if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
-            @wraps(_func)
-            async def async_wrapper(*f_args, **f_kwargs):
-                result = await _func(*f_args, **f_kwargs)
-                return resolve_futures_to_results(result)
+        @wraps(_func)
+        async def async_wrapper(*f_args, **f_kwargs):
+            result = await _func(*f_args, **f_kwargs)
+            return resolve_futures_to_results(result)
 
-            return prefect_flow(async_wrapper, validate_parameters=False, **kwargs)
-
-        else:
-            return prefect_flow(_func, validate_parameters=False, **kwargs)
+        wrapped = async_wrapper
     else:
-        if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
-            @wraps(_func)
-            def sync_wrapper(*f_args, **f_kwargs):
-                result = _func(*f_args, **f_kwargs)
-                return resolve_futures_to_results(result)
+        @wraps(_func)
+        def sync_wrapper(*f_args, **f_kwargs):
+            result = _func(*f_args, **f_kwargs)
+            return resolve_futures_to_results(result)
 
-            return prefect_flow(sync_wrapper, validate_parameters=False, **kwargs)
-        else:
-            return prefect_flow(_func, validate_parameters=False, **kwargs)
+        wrapped = sync_wrapper
+
+    return prefect_flow(wrapped, validate_parameters=False, **kwargs)
 
 
 def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
+    from jobflow import Flow as JobflowFlow
+    from jobflow import Job as JobflowJob
     from jobflow import job as jf_job
 
     wrapped = jf_job(method, **job_kwargs)
 
+    def job_to_output(value: Any) -> Any:
+        return _transform_nested_plain_containers(
+            value,
+            lambda item: (
+                item.output
+                if isinstance(item, (JobflowJob, JobflowFlow))
+                else item
+            ),
+        )
+
     @wraps(wrapped)
     def wrapper(*args, **kwargs):
-        args = tuple(_jobflow_job_to_output(arg) for arg in args)
-        kwargs = {key: _jobflow_job_to_output(val) for key, val in kwargs.items()}
+        args, kwargs = _transform_call_args(args, kwargs, job_to_output)
         return wrapped(*args, **kwargs)
 
     return wrapper
@@ -717,19 +723,6 @@ def _unwrap_ray_future(value: Any) -> Any:
     )
 
 
-def _jobflow_job_to_output(value: Any) -> Any:
-    """Convert Jobflow jobs used as inputs to their output references."""
-    from jobflow import Flow as JobflowFlow
-    from jobflow import Job as JobflowJob
-
-    return _transform_nested_plain_containers(
-        value,
-        lambda item: (
-            item.output if isinstance(item, (JobflowJob, JobflowFlow)) else item
-        ),
-    )
-
-
 def _transform_nested_plain_containers(
     value: Any, transform: Callable[[Any], Any]
 ) -> Any:
@@ -744,6 +737,18 @@ def _transform_nested_plain_containers(
             for k, v in value.items()
         }
     return transform(value)
+
+
+def _transform_call_args(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    transform: Callable[[Any], Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Apply an engine-specific transform to positional and keyword arguments."""
+    return (
+        tuple(transform(arg) for arg in args),
+        {key: transform(value) for key, value in kwargs.items()},
+    )
 
 
 def _wrap_partial_for_ray(func: Callable) -> Callable:

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -199,7 +199,7 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
 
     | Quacc  | Parsl     | Dask      | Prefect | Redun  | Jobflow   |
     | ------ | --------- | --------- | ------- | ------ | --------- |
-    | `flow` | No effect | No effect | `flow`  | `task` | No effect |
+    | `flow` | No effect | No effect | `flow`  | `task` | `flow`    |
 
     All `#!Python @flow`-decorated functions are transformed into their corresponding
     decorator.
@@ -299,9 +299,23 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
 
     === "Jobflow"
 
-        !!! Warning
+        ```python
+        import jobflow as jf
 
-            This decorator is not meant to be used with Jobflow at this time.
+
+        @jf.job
+        def add(a, b):
+            return a + b
+
+
+        @jf.flow
+        def workflow(a, b, c):
+            job1 = add(a, b)
+            return add(job1.output, c)
+
+
+        workflow(1, 2, 3)
+        ```
 
     Parameters
     ----------
@@ -329,7 +343,7 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
     elif settings.WORKFLOW_ENGINE == "prefect":
         return _get_prefect_wrapped_flow(_func, settings, **kwargs)
     elif settings.WORKFLOW_ENGINE == "jobflow":
-        return _get_jobflow_wrapped_flow(_func)
+        return _get_jobflow_wrapped_flow(_func, **kwargs)
     else:
         return tracked(NodeType.FLOW)(_func)
 
@@ -340,7 +354,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
 
     | Quacc     | Parsl      | Dask      | Prefect | Redun  | Jobflow   |
     | --------- | ---------- | --------- | ------- |------- | --------- |
-    | `subflow` | `join_app` | `delayed` | `flow`  | `task` | No effect |
+    | `subflow` | `join_app` | `delayed` | `flow`  | `task` | `job`     |
 
     All `#!Python @subflow`-decorated functions are transformed into their corresponding
     decorator.
@@ -478,9 +492,9 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
 
     === "Jobflow"
 
-        !!! Warning
-
-            This decorator is not meant to be used with Jobflow at this time.
+        Jobflow implements dynamic workflows by returning jobs or flows from a job.
+        Accordingly, quacc transforms `#!Python @subflow` into a Jobflow
+        `#!Python @job`.
 
     Parameters
     ----------
@@ -628,7 +642,7 @@ def _get_prefect_wrapped_flow(
             return prefect_flow(_func, validate_parameters=False, **kwargs)
 
 
-def _get_jobflow_wrapped_func(method=None, **job_kwargs):
+def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
     from jobflow import job as jf_job
 
     wrapped = jf_job(method, **job_kwargs)
@@ -642,10 +656,10 @@ def _get_jobflow_wrapped_func(method=None, **job_kwargs):
     return wrapper
 
 
-def _get_jobflow_wrapped_flow(_func: Callable) -> Callable:
+def _get_jobflow_wrapped_flow(_func: Callable, **flow_kwargs) -> Callable:
     from jobflow import flow as jf_flow
 
-    return jf_flow(_func)
+    return jf_flow(_func, **flow_kwargs)
 
 
 class Delayed_:
@@ -698,15 +712,9 @@ def _unwrap_ray_future(value: Any) -> Any:
     ``tuple`` and ``dict`` containers are traversed; subclasses pass through
     unchanged so engine-specific objects (e.g. ``DictCopy``) keep their type.
     """
-    if isinstance(value, RayFuture):
-        return value._ref
-    if type(value) is list:
-        return [_unwrap_ray_future(v) for v in value]
-    if type(value) is tuple:
-        return tuple(_unwrap_ray_future(v) for v in value)
-    if type(value) is dict:
-        return {k: _unwrap_ray_future(v) for k, v in value.items()}
-    return value
+    return _transform_nested_plain_containers(
+        value, lambda item: item._ref if isinstance(item, RayFuture) else item
+    )
 
 
 def _jobflow_job_to_output(value: Any) -> Any:
@@ -714,15 +722,28 @@ def _jobflow_job_to_output(value: Any) -> Any:
     from jobflow import Flow as JobflowFlow
     from jobflow import Job as JobflowJob
 
-    if isinstance(value, (JobflowJob, JobflowFlow)):
-        return value.output
+    return _transform_nested_plain_containers(
+        value,
+        lambda item: (
+            item.output if isinstance(item, (JobflowJob, JobflowFlow)) else item
+        ),
+    )
+
+
+def _transform_nested_plain_containers(
+    value: Any, transform: Callable[[Any], Any]
+) -> Any:
+    """Apply a leaf transform recursively without changing container subclasses."""
     if type(value) is list:
-        return [_jobflow_job_to_output(v) for v in value]
+        return [_transform_nested_plain_containers(v, transform) for v in value]
     if type(value) is tuple:
-        return tuple(_jobflow_job_to_output(v) for v in value)
+        return tuple(_transform_nested_plain_containers(v, transform) for v in value)
     if type(value) is dict:
-        return {k: _jobflow_job_to_output(v) for k, v in value.items()}
-    return value
+        return {
+            k: _transform_nested_plain_containers(v, transform)
+            for k, v in value.items()
+        }
+    return transform(value)
 
 
 def _wrap_partial_for_ray(func: Callable) -> Callable:
@@ -755,10 +776,6 @@ def _resolve_ray_value(value: Any, ray_mod: Any) -> Any:
 
 def _resolve_ray_subflow_result(result: Any, ray_mod: Any) -> Any:
     """Recursively resolve futures returned from a ray subflow body."""
-    if type(result) is list:
-        return [_resolve_ray_value(r, ray_mod) for r in result]
-    if type(result) is tuple:
-        return tuple(_resolve_ray_value(r, ray_mod) for r in result)
-    if type(result) is dict:
-        return {k: _resolve_ray_value(v, ray_mod) for k, v in result.items()}
-    return _resolve_ray_value(result, ray_mod)
+    return _transform_nested_plain_containers(
+        result, lambda value: _resolve_ray_value(value, ray_mod)
+    )

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -631,7 +631,15 @@ def _get_prefect_wrapped_flow(
 def _get_jobflow_wrapped_func(method=None, **job_kwargs):
     from jobflow import job as jf_job
 
-    return jf_job(method, **job_kwargs)
+    wrapped = jf_job(method, **job_kwargs)
+
+    @wraps(wrapped)
+    def wrapper(*args, **kwargs):
+        args = tuple(_jobflow_job_to_output(arg) for arg in args)
+        kwargs = {key: _jobflow_job_to_output(val) for key, val in kwargs.items()}
+        return wrapped(*args, **kwargs)
+
+    return wrapper
 
 
 def _get_jobflow_wrapped_flow(_func: Callable) -> Callable:
@@ -698,6 +706,22 @@ def _unwrap_ray_future(value: Any) -> Any:
         return tuple(_unwrap_ray_future(v) for v in value)
     if type(value) is dict:
         return {k: _unwrap_ray_future(v) for k, v in value.items()}
+    return value
+
+
+def _jobflow_job_to_output(value: Any) -> Any:
+    """Convert Jobflow jobs used as inputs to their output references."""
+    from jobflow import Flow as JobflowFlow
+    from jobflow import Job as JobflowJob
+
+    if isinstance(value, (JobflowJob, JobflowFlow)):
+        return value.output
+    if type(value) is list:
+        return [_jobflow_job_to_output(v) for v in value]
+    if type(value) is tuple:
+        return tuple(_jobflow_job_to_output(v) for v in value)
+    if type(value) is dict:
+        return {k: _jobflow_job_to_output(v) for k, v in value.items()}
     return value
 
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -648,9 +648,7 @@ def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
         return _transform_nested_plain_containers(
             value,
             lambda item: (
-                item.output
-                if isinstance(item, (JobflowJob, JobflowFlow))
-                else item
+                item.output if isinstance(item, (JobflowJob, JobflowFlow)) else item
             ),
         )
 
@@ -740,9 +738,7 @@ def _transform_nested_plain_containers(
 
 
 def _transform_call_args(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    transform: Callable[[Any], Any],
+    args: tuple[Any, ...], kwargs: dict[str, Any], transform: Callable[[Any], Any]
 ) -> tuple[tuple[Any, ...], dict[str, Any]]:
     """Apply an engine-specific transform to positional and keyword arguments."""
     return (

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -24,7 +24,7 @@ def test_jobflow_decorators(tmp_path, monkeypatch):
 
     @flow
     def workflow(a, b, c):
-        return mult(add(a, b), c)
+        return mult(add(a, b), c).output
 
     assert not isinstance(add, jf.Job)
     assert not isinstance(mult, jf.Job)
@@ -32,7 +32,10 @@ def test_jobflow_decorators(tmp_path, monkeypatch):
     assert hasattr(mult, "original")
     assert isinstance(add(1, 2), jf.Job)
     assert isinstance(mult(1, 2), jf.Job)
-    assert isinstance(workflow(1, 2, 3), jf.Flow)
+    workflow_flow = workflow(1, 2, 3)
+    assert isinstance(workflow_flow, jf.Flow)
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert responses[workflow_flow.output.uuid][1].output == 9
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
 
 
@@ -53,7 +56,7 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
 
     @flow()
     def workflow(a, b, c):
-        return mult(add(a, b), c)
+        return mult(add(a, b), c).output
 
     assert not isinstance(add, jf.Job)
     assert not isinstance(mult, jf.Job)
@@ -61,5 +64,8 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
     assert hasattr(mult, "original")
     assert isinstance(add(1, 2), jf.Job)
     assert isinstance(mult(1, 2), jf.Job)
-    assert isinstance(workflow(1, 2, 3), jf.Flow)
+    workflow_flow = workflow(1, 2, 3)
+    assert isinstance(workflow_flow, jf.Flow)
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert responses[workflow_flow.output.uuid][1].output == 9
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -24,7 +24,7 @@ def test_jobflow_decorators(tmp_path, monkeypatch):
 
     @flow
     def workflow(a, b, c):
-        return mult(add(a, b), c).output
+        return mult(add(a, b), c)
 
     assert not isinstance(add, jf.Job)
     assert not isinstance(mult, jf.Job)
@@ -35,7 +35,7 @@ def test_jobflow_decorators(tmp_path, monkeypatch):
     workflow_flow = workflow(1, 2, 3)
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert responses[workflow_flow.output.uuid][1].output == 9
+    assert responses[workflow_flow.jobs[-1].uuid][1].output == 9
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
 
 
@@ -56,7 +56,7 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
 
     @flow()
     def workflow(a, b, c):
-        return mult(add(a, b), c).output
+        return mult(add(a, b), c)
 
     assert not isinstance(add, jf.Job)
     assert not isinstance(mult, jf.Job)
@@ -67,5 +67,5 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
     workflow_flow = workflow(1, 2, 3)
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert responses[workflow_flow.output.uuid][1].output == 9
+    assert responses[workflow_flow.jobs[-1].uuid][1].output == 9
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -69,3 +69,28 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
     responses = jf.run_locally(workflow_flow, ensure_success=True)
     assert responses[workflow_flow.jobs[-1].uuid][1].output == 9
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
+
+
+def test_jobflow_nested_job_arguments(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    @job
+    def add(a, b):
+        return a + b
+
+    @job
+    def combine(values, factor):
+        return sum(values["items"]) * factor
+
+    @flow
+    def inner_workflow():
+        return add(5, 6)
+
+    @flow
+    def workflow():
+        values = {"items": [add(1, 2), add(3, 4), inner_workflow()]}
+        return combine(values, factor=add(2, 4))
+
+    workflow_flow = workflow()
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert responses[workflow_flow.jobs[-1].uuid][1].output == 126


### PR DESCRIPTION
## Summary

- make quacc's Jobflow `@job` adapter automatically translate upstream `Job` and `Flow` arguments into Jobflow output references
- recursively support jobs passed through plain lists, tuples, dictionaries, positional arguments, and keyword arguments
- keep workflow definitions engine-agnostic, such as `mult(add(a, b), c)`, without `.output`
- update the Jobflow syntax example and execute both `@flow` decorator forms in regression tests
- consolidate shared nested-value and call-argument transformation used by Jobflow and Ray
- make Ray subflow result resolution genuinely recursive
- construct auto-submitted Prefect tasks once per decorated function instead of once per invocation
- simplify Prefect flow wrapping and direct-execution fallbacks
- pass Jobflow `@flow` keyword arguments through to the underlying decorator
- correct stale module documentation that described Jobflow flows and subflows as unsupported

## Why

Requiring users to write `job1.output` leaks Jobflow-specific syntax into quacc workflows and prevents the same `@flow` definition from being used across workflow engines. The adapter now performs this translation internally. The wrapper cleanup removes duplicated traversal and argument-normalization code while retaining behavior-sensitive engine boundaries such as Parsl's scheduler-visible resource parameters.

## Validation

- `git diff --check`
- Python syntax compilation for the changed implementation and tests
- regression coverage executes engine-agnostic chaining for both `@flow` and `@flow()`
- additional coverage exercises positional, keyword, nested-container, and nested-flow Jobflow arguments
- the engine-agnostic Jobflow revision passed Jobflow tests, docs, and pre-commit; updated CI is running for the cleanup revisions