### PR TITLE
Fix ASE documentation inventory URL

### DIFF
--- a/_zensical.toml
+++ b/_zensical.toml
@@ -166,7 +166,7 @@ default_handler = "python"
 [project.plugins.mkdocstrings.handlers.python]
 inventories = [
     "https://docs.python.org/3/objects.inv",
-    "https://ase-lib.org/objects.inv",
+    "https://docs.ase-lib.org/objects.inv",
     "https://pymatgen.org/objects.inv",
     "https://materialsproject.github.io/pymatgen-analysis-defects/objects.inv",
     "https://materialsproject.github.io/emmet/objects.inv",


### PR DESCRIPTION
## Summary

- update the mkdocstrings ASE inventory URL to `https://docs.ase-lib.org/objects.inv`

## Why

ASE's inventory is no longer available at the bare `ase-lib.org` path, causing documentation builds to report an HTTP 404 while loading the Python handler inventory.

## Impact

Documentation builds can load ASE's intersphinx inventory again, restoring external API cross-references.

## Validation

- confirmed the new inventory endpoint returns HTTP 200
- confirmed the old endpoint returns HTTP 404
- ran `git diff --check`