### PR TITLE
Alphabetize workflow engine documentation tabs

### DIFF
--- a/docs/user/basics/wflow_decorators.md
+++ b/docs/user/basics/wflow_decorators.md
@@ -36,6 +36,20 @@ A `#!Python @subflow` in quacc is any workflow that returns a list of job output
 
     Technically, there are some subtle differences between the `#!Python @delayed` decorator and the `quacc` equivalents, but for the purposes of this tutorial, you can think of them as similar.
 
+=== "Jobflow"
+
+    Take a moment to read the Jobflow documentation's [Quick Start](https://materialsproject.github.io/jobflow/tutorials/1-quickstart.html) to get a sense of how Jobflow works. Namely, you should understand the concept of a `#!Python @job` and a `#!Python @flow`, which describe individual compute tasks and workflows, respectively.
+
+    <center>
+
+    | Quacc               | Jobflow          |
+    | ------------------- | ---------------- |
+    | `#!Python @job`     | `#!Python @job`  |
+    | `#!Python @flow`    | `#!Python @flow` |
+    | `#!Python @subflow` | `#!Python @job`  |
+
+    </center>
+
 === "Parsl"
 
     Take a moment to read the Parsl documentation's ["Quick Start"](https://parsl.readthedocs.io/en/stable/quickstart.html) to get a sense of how Parsl works. Namely, you should understand the concept of a [`#!Python python_app`](https://parsl.readthedocs.io/en/stable/1-parsl-introduction.html#Python-Apps) and [`#!Python join_app`](https://parsl.readthedocs.io/en/stable/1-parsl-introduction.html?highlight=join_app#Dynamic-workflows-with-apps-that-generate-other-apps), which describe individual compute tasks and dynamic job tasks, respectively.
@@ -91,20 +105,6 @@ A `#!Python @subflow` in quacc is any workflow that returns a list of job output
     | `#!Python @job`     | `#!Python @task` |
     | `#!Python @flow`    | `#!Python @task` |
     | `#!Python @subflow` | `#!Python @task` |
-
-    </center>
-
-=== "Jobflow"
-
-    Take a moment to read the Jobflow documentation's [Quick Start](https://materialsproject.github.io/jobflow/tutorials/1-quickstart.html) to get a sense of how Jobflow works. Namely, you should understand the concept of a `#!Python @job` and a `#!Python @flow`, which describe individual compute tasks and workflows, respectively.
-
-    <center>
-
-    | Quacc               | Jobflow          |
-    | ------------------- | ---------------- |
-    | `#!Python @job`     | `#!Python @job`  |
-    | `#!Python @flow`    | `#!Python @flow` |
-    | `#!Python @subflow` | `#!Python @job`  |
 
     </center>
 

--- a/docs/user/basics/wflow_overview.md
+++ b/docs/user/basics/wflow_overview.md
@@ -27,6 +27,20 @@ Everyone's computing needs are different, so we ensured that quacc is interopera
     - The documentation, while comprehensive, can be difficult to follow given the various Dask components
     - Calculations cannot be submitted remotely or across disparate compute resources
 
+=== "Jobflow"
+
+    [Jobflow](https://github.com/materialsproject/jobflow) is developed and maintained by the Materials Project team at Lawrence Berkeley National Laboratory and serves as a seamless interface to [FireWorks](https://github.com/materialsproject/fireworks) or [Jobflow Remote](https://github.com/Matgenix/jobflow-remote) for dispatching and monitoring compute jobs.
+
+    Pros:
+
+    - Native support for a variety of databases
+    - Directly compatible with Atomate2
+    - Designed with materials science workflows in mind
+    - Actively supported by the Materials Project team
+
+    Cons:
+
+    - Requires the use of a database like MongoDB, which may not be widely accessible
 === "Parsl"
 
     [Parsl](https://github.com/Parsl/parsl) is a workflow management solution out of Argonne National Laboratory, the University of Chicago, and the University of Illinois. It is well-adapted for running on virtually any HPC environment with a job scheduler.
@@ -101,18 +115,3 @@ Everyone's computing needs are different, so we ensured that quacc is interopera
     - No user-friendly GUI for job monitoring
     - Does not have a particularly active user community
     - Not updated frequently
-
-=== "Jobflow"
-
-    [Jobflow](https://github.com/materialsproject/jobflow) is developed and maintained by the Materials Project team at Lawrence Berkeley National Laboratory and serves as a seamless interface to [FireWorks](https://github.com/materialsproject/fireworks) or [Jobflow Remote](https://github.com/Matgenix/jobflow-remote) for dispatching and monitoring compute jobs.
-
-    Pros:
-
-    - Native support for a variety of databases
-    - Directly compatible with Atomate2
-    - Designed with materials science workflows in mind
-    - Actively supported by the Materials Project team
-
-    Cons:
-
-    - Requires the use of a database like MongoDB, which may not be widely accessible

--- a/docs/user/basics/wflow_syntax.md
+++ b/docs/user/basics/wflow_syntax.md
@@ -66,6 +66,54 @@ graph LR
 
     4. There are multiple ways to resolve a `Delayed` object. Here, `#!Python client.compute(delayed)` will return a `Future` object, which can be resolved with `.result()`. The `.result()` call will block until the workflow is complete and return the result. As an alternative, you could also use `#!Python delayed.compute()` to dispatch and resolve the `Delayed` object in one command. Similarly, you could use `#!Python dask.compute(delayed)[0]`, where the `[0]` indexing is needed because `#!Python dask.compute()` always returns a tuple.
 
+=== "Jobflow"
+
+    !!! Important
+
+        If you haven't done so yet, make sure you update the quacc `WORKFLOW_ENGINE` [configuration variable](../settings/settings.md):
+
+        ```bash
+        quacc set WORKFLOW_ENGINE jobflow
+        ```
+
+    ```python
+    import jobflow as jf
+    from quacc import flow, job
+
+
+    @job  #  (1)!
+    def add(a, b):
+        return a + b
+
+
+    @job
+    def mult(a, b):
+        return a * b
+
+
+    @flow  #  (2)!
+    def workflow(a, b, c):
+        return mult(add(a, b), c)
+
+
+    workflow_flow = workflow(1, 2, 3)  #  (3)!
+
+    responses = jf.run_locally(workflow_flow, ensure_success=True)  #  (4)!
+    final_job = workflow_flow.jobs[-1]
+    result = responses[final_job.uuid][1].output  #  (5)!
+    print(result)  # 9
+    ```
+
+    1. The `#!Python @job` decorator will be transformed into `#!Python @jf.job`.
+
+    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs returned by the decorated function. When a quacc-decorated job is passed to another quacc-decorated job, quacc automatically passes its output reference to Jobflow.
+
+    3. Calling the decorated function returns the Jobflow `#!Python Flow` that represents the workflow.
+
+    4. The workflow is run locally and the responses are returned in a dictionary.
+
+    5. The result is extracted from the dictionary by using the UUID of the final job in the workflow.
+
 === "Parsl"
 
     !!! Important
@@ -260,54 +308,6 @@ graph LR
 
     3. This command will submit the workflow to the Redun scheduler.
 
-=== "Jobflow"
-
-    !!! Important
-
-        If you haven't done so yet, make sure you update the quacc `WORKFLOW_ENGINE` [configuration variable](../settings/settings.md):
-
-        ```bash
-        quacc set WORKFLOW_ENGINE jobflow
-        ```
-
-    ```python
-    import jobflow as jf
-    from quacc import flow, job
-
-
-    @job  #  (1)!
-    def add(a, b):
-        return a + b
-
-
-    @job
-    def mult(a, b):
-        return a * b
-
-
-    @flow  #  (2)!
-    def workflow(a, b, c):
-        return mult(add(a, b), c)
-
-
-    workflow_flow = workflow(1, 2, 3)  #  (3)!
-
-    responses = jf.run_locally(workflow_flow, ensure_success=True)  #  (4)!
-    final_job = workflow_flow.jobs[-1]
-    result = responses[final_job.uuid][1].output  #  (5)!
-    print(result)  # 9
-    ```
-
-    1. The `#!Python @job` decorator will be transformed into `#!Python @jf.job`.
-
-    2. The `#!Python @flow` decorator will create a Jobflow `#!Python Flow` from the jobs returned by the decorated function. When a quacc-decorated job is passed to another quacc-decorated job, quacc automatically passes its output reference to Jobflow.
-
-    3. Calling the decorated function returns the Jobflow `#!Python Flow` that represents the workflow.
-
-    4. The workflow is run locally and the responses are returned in a dictionary.
-
-    5. The result is extracted from the dictionary by using the UUID of the final job in the workflow.
-
 ??? Tip "Stripping the Decorator from a Job"
 
     If you ever want to strip the decorator from a pre-decorated `#!Python @job` (e.g. to test out a calculation locally without changing your quacc settings), you can do so with [quacc.wflow_tools.customizers.strip_decorator][] as follows:
@@ -331,6 +331,9 @@ graph LR
 
     If you want to learn more about Dask, you can read the [Dask Delayed documentation](https://docs.dask.org/en/stable/delayed.html) to read more about the decorators and the [Dask Distributed documentation](https://distributed.dask.org/en/stable/) to read more about the distributed Dask cluster. Please refer to the [Dask Discourse page](https://discourse.dask.org/) for Dask-specific questions.
 
+=== "Jobflow"
+
+    If you want to learn more about Jobflow, you can read the [Jobflow Documentation](https://materialsproject.github.io/jobflow/). Please refer to the [Jobflow Discussions Board](https://github.com/materialsproject/jobflow/discussions) for Jobflow-specific questions.
 === "Parsl"
 
     If you want to learn more about Parsl, you can read the [Parsl Documentation](https://parsl.readthedocs.io/en/stable/#). Please refer to the [Parsl Slack Channel](http://parsl-project.org/support.html) for any Parsl-specific questions.
@@ -346,7 +349,3 @@ graph LR
 === "Redun"
 
     If you want to learn more about Redun, you can read the [Redun documentation](https://insitro.github.io/redun/index.html).
-
-=== "Jobflow"
-
-    If you want to learn more about Jobflow, you can read the [Jobflow Documentation](https://materialsproject.github.io/jobflow/). Please refer to the [Jobflow Discussions Board](https://github.com/materialsproject/jobflow/discussions) for Jobflow-specific questions.


### PR DESCRIPTION
## Summary

- move the Jobflow tab into alphabetical order on the workflow syntax page
- apply the same ordering to the workflow overview and decorator pages
- keep all existing workflow-engine documentation content unchanged

## Why

Jobflow was appended after Redun on these pages instead of appearing alphabetically with the other workflow engines. This makes the tab order consistent and easier to scan.

## Impact

Documentation-only change. The workflow-engine tabs now appear as Dask, Jobflow, Parsl, Prefect, Ray, and Redun.

## Checks

- `git diff --check`
- verified the tab headings and ordering in all three edited pages

The full Zensical documentation build was not run because the site builder is not installed in the local workspace.
