### PR TITLE
Fix Jobflow dynamic subflow outputs

### DIFF
--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -644,9 +644,7 @@ def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
 
     @wraps(wrapped)
     def wrapper(*args, **kwargs):
-        args, kwargs = _transform_call_args(
-            args, kwargs, _jobflow_value_to_output
-        )
+        args, kwargs = _transform_call_args(args, kwargs, _jobflow_value_to_output)
         return wrapped(*args, **kwargs)
 
     return wrapper
@@ -664,9 +662,7 @@ def _get_jobflow_wrapped_flow(_func: Callable, **flow_kwargs) -> Callable:
 
 def _get_jobflow_wrapped_subflow(_func: Callable, **job_kwargs) -> Callable:
     """Wrap a dynamic subflow in a job that replaces itself with a captured flow."""
-    wrapped = _get_jobflow_wrapped_func(
-        _get_jobflow_wrapped_flow(_func), **job_kwargs
-    )
+    wrapped = _get_jobflow_wrapped_func(_get_jobflow_wrapped_flow(_func), **job_kwargs)
     wrapped.original = _func  # type: ignore[attr-defined]
     return wrapped
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -638,6 +638,7 @@ def _get_prefect_wrapped_flow(
 
 
 def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
+    from jobflow import OutputReference
     from jobflow import job as jf_job
 
     wrapped = jf_job(method, **job_kwargs)
@@ -645,6 +646,13 @@ def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
     @wraps(wrapped)
     def wrapper(*args, **kwargs):
         args, kwargs = _transform_call_args(args, kwargs, _jobflow_value_to_output)
+        copy_files = kwargs.get("copy_files")
+        if type(copy_files) is dict and all(
+            isinstance(source, OutputReference) for source in copy_files
+        ):
+            from quacc.wflow_tools.job_argument import JobflowCopy
+
+            kwargs["copy_files"] = JobflowCopy(copy_files)
         return wrapped(*args, **kwargs)
 
     return wrapper

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -173,7 +173,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
     elif settings.WORKFLOW_ENGINE == "ray":
         import ray
 
-        _ray_target = _wrap_partial_for_ray(_func)
+        _ray_target = _wrap_partial(_func)
 
         remote_func = (
             ray.remote(**kwargs)(_ray_target) if kwargs else ray.remote(_ray_target)
@@ -543,7 +543,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
     elif settings.WORKFLOW_ENGINE == "ray":
         import ray
 
-        target_func = _wrap_partial_for_ray(_func)
+        target_func = _wrap_partial(_func)
 
         @wraps(target_func)
         def _ray_subflow_target(*f_args, **f_kwargs):
@@ -641,7 +641,7 @@ def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
     from jobflow import OutputReference
     from jobflow import job as jf_job
 
-    wrapped = jf_job(method, **job_kwargs)
+    wrapped = jf_job(_wrap_partial(method), **job_kwargs)
 
     @wraps(wrapped)
     def wrapper(*args, **kwargs):
@@ -769,8 +769,8 @@ def _transform_call_args(
     )
 
 
-def _wrap_partial_for_ray(func: Callable) -> Callable:
-    """Wrap a ``functools.partial`` in a real function so Ray accepts it."""
+def _wrap_partial(func: Callable) -> Callable:
+    """Wrap a ``functools.partial`` in a metadata-preserving function."""
     if not isinstance(func, partial):
         return func
 

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -539,7 +539,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
 
         return task(_func, namespace=_func.__module__, **kwargs)
     elif settings.WORKFLOW_ENGINE == "jobflow":
-        return _get_jobflow_wrapped_func(_func, **kwargs)
+        return _get_jobflow_wrapped_subflow(_func, **kwargs)
     elif settings.WORKFLOW_ENGINE == "ray":
         import ray
 
@@ -638,23 +638,15 @@ def _get_prefect_wrapped_flow(
 
 
 def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
-    from jobflow import Flow as JobflowFlow
-    from jobflow import Job as JobflowJob
     from jobflow import job as jf_job
 
     wrapped = jf_job(method, **job_kwargs)
 
-    def job_to_output(value: Any) -> Any:
-        return _transform_nested_plain_containers(
-            value,
-            lambda item: (
-                item.output if isinstance(item, (JobflowJob, JobflowFlow)) else item
-            ),
-        )
-
     @wraps(wrapped)
     def wrapper(*args, **kwargs):
-        args, kwargs = _transform_call_args(args, kwargs, job_to_output)
+        args, kwargs = _transform_call_args(
+            args, kwargs, _jobflow_value_to_output
+        )
         return wrapped(*args, **kwargs)
 
     return wrapper
@@ -663,7 +655,20 @@ def _get_jobflow_wrapped_func(method: Callable, **job_kwargs) -> Callable:
 def _get_jobflow_wrapped_flow(_func: Callable, **flow_kwargs) -> Callable:
     from jobflow import flow as jf_flow
 
-    return jf_flow(_func, **flow_kwargs)
+    @wraps(_func)
+    def wrapper(*args, **kwargs):
+        return _jobflow_value_to_output(_func(*args, **kwargs))
+
+    return jf_flow(wrapper, **flow_kwargs)
+
+
+def _get_jobflow_wrapped_subflow(_func: Callable, **job_kwargs) -> Callable:
+    """Wrap a dynamic subflow in a job that replaces itself with a captured flow."""
+    wrapped = _get_jobflow_wrapped_func(
+        _get_jobflow_wrapped_flow(_func), **job_kwargs
+    )
+    wrapped.original = _func  # type: ignore[attr-defined]
+    return wrapped
 
 
 class Delayed_:
@@ -735,6 +740,19 @@ def _transform_nested_plain_containers(
             for k, v in value.items()
         }
     return transform(value)
+
+
+def _jobflow_value_to_output(value: Any) -> Any:
+    """Recursively replace Jobflow jobs and flows with their output references."""
+    from jobflow import Flow as JobflowFlow
+    from jobflow import Job as JobflowJob
+
+    def get_output(item: Any) -> Any:
+        while isinstance(item, (JobflowJob, JobflowFlow)):
+            item = item.output
+        return item
+
+    return _transform_nested_plain_containers(value, get_output)
 
 
 def _transform_call_args(

--- a/tests/jobflow/conftest.py
+++ b/tests/jobflow/conftest.py
@@ -3,7 +3,20 @@ from __future__ import annotations
 from pathlib import Path
 from shutil import rmtree
 
+import pytest
+
 TEST_SCRATCH_DIR = Path(__file__).parent / "_test_scratch"
+
+
+@pytest.fixture
+def jobflow_output():
+    """Return the latest stored output for a Jobflow job."""
+
+    def get_output(responses, job):
+        indexed_responses = responses[job.uuid]
+        return indexed_responses[max(indexed_responses)].output
+
+    return get_output
 
 
 def pytest_sessionstart():

--- a/tests/jobflow/test_copy_files.py
+++ b/tests/jobflow/test_copy_files.py
@@ -10,7 +10,7 @@ from quacc import flow, job
 from quacc.wflow_tools.job_argument import Copy
 
 
-def test_copy_files(tmp_path, monkeypatch):
+def test_copy_files(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job
@@ -32,7 +32,8 @@ def test_copy_files(tmp_path, monkeypatch):
 
     workflow = create_files()
     assert str(workflow.graph) == "DiGraph with 2 nodes and 1 edges"
-    jf.run_locally(workflow, ensure_success=True, create_folders=True)
+    responses = jf.run_locally(workflow, ensure_success=True, create_folders=True)
+    assert jobflow_output(responses, workflow.jobs[-1])["dir_name"] == tmp_path / "job2"
 
     # Individual job folders/files should exist, and the job1 file should be
     # copied over to the job2 folder.

--- a/tests/jobflow/test_customizers.py
+++ b/tests/jobflow/test_customizers.py
@@ -17,16 +17,20 @@ def test_strip_decorators():
     assert stripped_add(1, 2) == 3
 
 
-def test_change_settings_redecorate_job(tmp_path_factory):
+def test_change_settings_redecorate_job(tmp_path_factory, jobflow_output):
     tmp_dir1 = tmp_path_factory.mktemp("dir1")
 
     @job
     def write_file_job(name="job.txt"):
-        with open(Path(get_settings().SCRATCH_DIR, name), "w") as f:
+        path = Path(get_settings().SCRATCH_DIR, name)
+        with open(path, "w") as f:
             f.write("test file")
+        return path
 
     write_file_job = redecorate(
         write_file_job, job(settings_swap={"SCRATCH_DIR": tmp_dir1})
     )
-    jf.run_locally(write_file_job(), ensure_success=True, create_folders=False)
+    job = write_file_job()
+    responses = jf.run_locally(job, ensure_success=True, create_folders=False)
+    assert Path(jobflow_output(responses, job)) == tmp_dir1 / "job.txt"
     assert Path(tmp_dir1 / "job.txt").exists()

--- a/tests/jobflow/test_customizers.py
+++ b/tests/jobflow/test_customizers.py
@@ -30,7 +30,7 @@ def test_change_settings_redecorate_job(tmp_path_factory, jobflow_output):
     write_file_job = redecorate(
         write_file_job, job(settings_swap={"SCRATCH_DIR": tmp_dir1})
     )
-    job = write_file_job()
-    responses = jf.run_locally(job, ensure_success=True, create_folders=False)
-    assert Path(jobflow_output(responses, job)) == tmp_dir1 / "job.txt"
+    write_job = write_file_job()
+    responses = jf.run_locally(write_job, ensure_success=True, create_folders=False)
+    assert Path(jobflow_output(responses, write_job)) == tmp_dir1 / "job.txt"
     assert Path(tmp_dir1 / "job.txt").exists()

--- a/tests/jobflow/test_emt_recipes.py
+++ b/tests/jobflow/test_emt_recipes.py
@@ -20,23 +20,23 @@ def validate_results(results):
 
 
 @pytest.mark.parametrize("job_decorators", [None, {"relax_job": job()}])
-def test_functools(tmp_path, monkeypatch, job_decorators, jobflow_output):
+def test_functools(tmp_path, monkeypatch, job_decorators):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-
-    @flow
-    def workflow():
-        results = bulk_to_slabs_flow(
-            atoms,
-            run_static=False,
-            job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
-            job_decorators=job_decorators,
-        )
-        return validate_results(results)
-
-    workflow_flow = workflow()
-    responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert jobflow_output(responses, workflow_flow.jobs[-1])
+    workflow = bulk_to_slabs_flow(
+        atoms,
+        run_static=False,
+        job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
+        job_decorators=job_decorators,
+    )
+    responses = jf.run_locally(workflow, ensure_success=True)
+    results = [
+        response.output
+        for indexed_responses in responses.values()
+        for response in indexed_responses.values()
+        if isinstance(response.output, dict) and "atoms" in response.output
+    ]
+    assert results
 
 
 def test_copy_files(tmp_path, monkeypatch, jobflow_output):

--- a/tests/jobflow/test_emt_recipes.py
+++ b/tests/jobflow/test_emt_recipes.py
@@ -12,20 +12,33 @@ from quacc.recipes.emt.core import relax_job
 from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
+@job
+def validate_results(results, *, require_energy=False):
+    assert results
+    assert all("atoms" in result for result in results)
+    if require_energy:
+        assert all("energy" in result for result in results)
+    return results
+
+
 @pytest.mark.parametrize("job_decorators", [None, {"relax_job": job()}])
 def test_functools(tmp_path, monkeypatch, job_decorators, jobflow_output):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
-    flow = bulk_to_slabs_flow(
-        atoms,
-        run_static=False,
-        job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
-        job_decorators=job_decorators,
-    )
-    responses = jf.run_locally(flow, ensure_success=True)
-    output = jobflow_output(responses, flow.jobs[-1])
-    assert output
-    assert all("atoms" in result for result in output)
+
+    @flow
+    def workflow():
+        results = bulk_to_slabs_flow(
+            atoms,
+            run_static=False,
+            job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
+            job_decorators=job_decorators,
+        )
+        return validate_results(results)
+
+    workflow_flow = workflow()
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert jobflow_output(responses, workflow_flow.jobs[-1])
 
 
 def test_copy_files(tmp_path, monkeypatch, jobflow_output):
@@ -76,21 +89,22 @@ def test_relaxed_slabs(tmp_path, monkeypatch, jobflow_output):
     @flow
     def workflow(atoms):
         relaxed_bulk = relax_job(atoms)
-        return bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)
+        results = bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)
+        return validate_results(results)
 
     slab_workflow = workflow(atoms)
     responses = jf.run_locally(slab_workflow, ensure_success=True)
-    output = jobflow_output(responses, slab_workflow.jobs[-1].jobs[-1])
-    assert output
-    assert all("atoms" in result for result in output)
+    assert jobflow_output(responses, slab_workflow.jobs[-1])
 
 
 def test_bulk_to_slabs_flow_with_static(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
-    workflow = bulk_to_slabs_flow(bulk("Cu"))
 
-    responses = jf.run_locally(workflow, ensure_success=True)
+    @flow
+    def workflow():
+        return validate_results(bulk_to_slabs_flow(bulk("Cu")), require_energy=True)
 
-    output = jobflow_output(responses, workflow.jobs[-1])
-    assert output
-    assert all("atoms" in result and "energy" in result for result in output)
+    workflow_flow = workflow()
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+
+    assert jobflow_output(responses, workflow_flow.jobs[-1])

--- a/tests/jobflow/test_emt_recipes.py
+++ b/tests/jobflow/test_emt_recipes.py
@@ -13,7 +13,7 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
 @pytest.mark.parametrize("job_decorators", [None, {"relax_job": job()}])
-def test_functools(tmp_path, monkeypatch, job_decorators):
+def test_functools(tmp_path, monkeypatch, job_decorators, jobflow_output):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
     flow = bulk_to_slabs_flow(
@@ -22,10 +22,13 @@ def test_functools(tmp_path, monkeypatch, job_decorators):
         job_params={"relax_job": {"opt_params": {"fmax": 0.1}}},
         job_decorators=job_decorators,
     )
-    jf.run_locally(flow, ensure_success=True)
+    responses = jf.run_locally(flow, ensure_success=True)
+    output = jobflow_output(responses, flow.jobs[-1])
+    assert output
+    assert all("atoms" in result for result in output)
 
 
-def test_copy_files(tmp_path, monkeypatch):
+def test_copy_files(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
 
@@ -34,24 +37,25 @@ def test_copy_files(tmp_path, monkeypatch):
         result1 = relax_job(atoms)
         return relax_job(result1["atoms"], copy_files={result1["dir_name"]: "opt.*"})
 
-    output = jf.run_locally(myflow(atoms))
-    first_output = next(iter(output.values()))[1].output
-    assert "atoms" in first_output
+    workflow = myflow(atoms)
+    responses = jf.run_locally(workflow, ensure_success=True)
+    assert "atoms" in jobflow_output(responses, workflow.jobs[-1])
 
 
-def test_folders(tmp_path, monkeypatch):
+def test_folders(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     atoms = bulk("Cu")
     job = relax_job(atoms)
-    jf.run_locally(job, ensure_success=True, create_folders=True)
+    responses = jf.run_locally(job, ensure_success=True, create_folders=True)
+    assert "atoms" in jobflow_output(responses, job)
     files = os.listdir(tmp_path)
     assert len(files) == 1
     assert files[0].startswith("job")
     assert "opt.log.gz" in os.listdir(tmp_path / files[0])
 
 
-def test_relax_flow(tmp_path, monkeypatch):
+def test_relax_flow(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
 
@@ -60,10 +64,12 @@ def test_relax_flow(tmp_path, monkeypatch):
         result1 = relax_job(atoms)
         return relax_job(result1["atoms"])
 
-    jf.run_locally(relax_flow(atoms), ensure_success=True)
+    workflow = relax_flow(atoms)
+    responses = jf.run_locally(workflow, ensure_success=True)
+    assert "atoms" in jobflow_output(responses, workflow.jobs[-1])
 
 
-def test_relaxed_slabs(tmp_path, monkeypatch):
+def test_relaxed_slabs(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu")
 
@@ -72,4 +78,19 @@ def test_relaxed_slabs(tmp_path, monkeypatch):
         relaxed_bulk = relax_job(atoms)
         return bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)
 
-    jf.run_locally(workflow(atoms), ensure_success=True)
+    slab_workflow = workflow(atoms)
+    responses = jf.run_locally(slab_workflow, ensure_success=True)
+    output = jobflow_output(responses, slab_workflow.jobs[-1].jobs[-1])
+    assert output
+    assert all("atoms" in result for result in output)
+
+
+def test_bulk_to_slabs_flow_with_static(tmp_path, monkeypatch, jobflow_output):
+    monkeypatch.chdir(tmp_path)
+    workflow = bulk_to_slabs_flow(bulk("Cu"))
+
+    responses = jf.run_locally(workflow, ensure_success=True)
+
+    output = jobflow_output(responses, workflow.jobs[-1])
+    assert output
+    assert all("atoms" in result and "energy" in result for result in output)

--- a/tests/jobflow/test_emt_recipes.py
+++ b/tests/jobflow/test_emt_recipes.py
@@ -13,11 +13,9 @@ from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
 @job
-def validate_results(results, *, require_energy=False):
+def validate_results(results):
     assert results
     assert all("atoms" in result for result in results)
-    if require_energy:
-        assert all("energy" in result for result in results)
     return results
 
 
@@ -102,7 +100,7 @@ def test_bulk_to_slabs_flow_with_static(tmp_path, monkeypatch, jobflow_output):
 
     @flow
     def workflow():
-        return validate_results(bulk_to_slabs_flow(bulk("Cu")), require_energy=True)
+        return validate_results(bulk_to_slabs_flow(bulk("Cu")))
 
     workflow_flow = workflow()
     responses = jf.run_locally(workflow_flow, ensure_success=True)

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -22,6 +22,10 @@ def test_jobflow_decorators(tmp_path, monkeypatch, jobflow_output):
     def add_distributed(vals, c):
         return [add(val, c) for val in vals]
 
+    @job
+    def collect(values):
+        return values
+
     @flow
     def workflow(a, b, c):
         return mult(add(a, b), c)
@@ -37,10 +41,16 @@ def test_jobflow_decorators(tmp_path, monkeypatch, jobflow_output):
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
     assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9
-    subflow_job = add_distributed([1, 2, 3], 4)
+
+    @flow
+    def distributed_workflow():
+        return collect(add_distributed([1, 2, 3], 4))
+
+    distributed_flow = distributed_workflow()
+    subflow_job = distributed_flow.jobs[0]
     assert isinstance(subflow_job, jf.Job)
-    responses = jf.run_locally(subflow_job, ensure_success=True)
-    assert jobflow_output(responses, subflow_job) == [5, 6, 7]
+    responses = jf.run_locally(distributed_flow, ensure_success=True)
+    assert jobflow_output(responses, distributed_flow.jobs[-1]) == [5, 6, 7]
 
 
 def test_jobflow_decorators_args(tmp_path, monkeypatch, jobflow_output):
@@ -58,6 +68,10 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch, jobflow_output):
     def add_distributed(vals, c):
         return [add(val, c) for val in vals]
 
+    @job()
+    def collect(values):
+        return values
+
     @flow()
     def workflow(a, b, c):
         return mult(add(a, b), c)
@@ -73,10 +87,16 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch, jobflow_output):
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
     assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9
-    subflow_job = add_distributed([1, 2, 3], 4)
+
+    @flow()
+    def distributed_workflow():
+        return collect(add_distributed([1, 2, 3], 4))
+
+    distributed_flow = distributed_workflow()
+    subflow_job = distributed_flow.jobs[0]
     assert isinstance(subflow_job, jf.Job)
-    responses = jf.run_locally(subflow_job, ensure_success=True)
-    assert jobflow_output(responses, subflow_job) == [5, 6, 7]
+    responses = jf.run_locally(distributed_flow, ensure_success=True)
+    assert jobflow_output(responses, distributed_flow.jobs[-1]) == [5, 6, 7]
 
 
 def test_jobflow_nested_job_arguments(tmp_path, monkeypatch, jobflow_output):

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -7,7 +7,7 @@ jf = pytest.importorskip("jobflow")
 from quacc import flow, job, subflow
 
 
-def test_jobflow_decorators(tmp_path, monkeypatch):
+def test_jobflow_decorators(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job
@@ -30,16 +30,20 @@ def test_jobflow_decorators(tmp_path, monkeypatch):
     assert not isinstance(mult, jf.Job)
     assert hasattr(add, "original")
     assert hasattr(mult, "original")
+    assert hasattr(add_distributed, "original")
     assert isinstance(add(1, 2), jf.Job)
     assert isinstance(mult(1, 2), jf.Job)
     workflow_flow = workflow(1, 2, 3)
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert responses[workflow_flow.jobs[-1].uuid][1].output == 9
-    assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
+    assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9
+    subflow_job = add_distributed([1, 2, 3], 4)
+    assert isinstance(subflow_job, jf.Job)
+    responses = jf.run_locally(subflow_job, ensure_success=True)
+    assert jobflow_output(responses, subflow_job) == [5, 6, 7]
 
 
-def test_jobflow_decorators_args(tmp_path, monkeypatch):
+def test_jobflow_decorators_args(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job()
@@ -62,16 +66,20 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
     assert not isinstance(mult, jf.Job)
     assert hasattr(add, "original")
     assert hasattr(mult, "original")
+    assert hasattr(add_distributed, "original")
     assert isinstance(add(1, 2), jf.Job)
     assert isinstance(mult(1, 2), jf.Job)
     workflow_flow = workflow(1, 2, 3)
     assert isinstance(workflow_flow, jf.Flow)
     responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert responses[workflow_flow.jobs[-1].uuid][1].output == 9
-    assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
+    assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9
+    subflow_job = add_distributed([1, 2, 3], 4)
+    assert isinstance(subflow_job, jf.Job)
+    responses = jf.run_locally(subflow_job, ensure_success=True)
+    assert jobflow_output(responses, subflow_job) == [5, 6, 7]
 
 
-def test_jobflow_nested_job_arguments(tmp_path, monkeypatch):
+def test_jobflow_nested_job_arguments(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job
@@ -93,4 +101,4 @@ def test_jobflow_nested_job_arguments(tmp_path, monkeypatch):
 
     workflow_flow = workflow()
     responses = jf.run_locally(workflow_flow, ensure_success=True)
-    assert responses[workflow_flow.jobs[-1].uuid][1].output == 126
+    assert jobflow_output(responses, workflow_flow.jobs[-1]) == 126

--- a/tests/jobflow/test_tutorials.py
+++ b/tests/jobflow/test_tutorials.py
@@ -10,7 +10,7 @@ from quacc import flow, job
 from quacc.recipes.emt.core import relax_job, static_job  # skipcq: PYL-C0412
 
 
-def test_tutorial1a(tmp_path, monkeypatch):
+def test_tutorial1a(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     # Make an Atoms object of a bulk Cu structure
@@ -20,10 +20,11 @@ def test_tutorial1a(tmp_path, monkeypatch):
     job = relax_job(atoms)  # (1)!
 
     # Run the job locally
-    jf.run_locally(job, create_folders=True, ensure_success=True)
+    responses = jf.run_locally(job, create_folders=True, ensure_success=True)
+    assert "atoms" in jobflow_output(responses, job)
 
 
-def test_tutorial2a(tmp_path, monkeypatch):
+def test_tutorial2a(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     # Make an Atoms object of a bulk Cu structure
@@ -39,10 +40,11 @@ def test_tutorial2a(tmp_path, monkeypatch):
     workflow = jf.Flow([job1, job2])
 
     # Run the workflow locally
-    jf.run_locally(workflow, create_folders=True, ensure_success=True)
+    responses = jf.run_locally(workflow, create_folders=True, ensure_success=True)
+    assert "atoms" in jobflow_output(responses, job2)
 
 
-def test_tutorial2a_flow_decorator(tmp_path, monkeypatch):
+def test_tutorial2a_flow_decorator(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     # Make an Atoms object of a bulk Cu structure
@@ -57,10 +59,14 @@ def test_tutorial2a_flow_decorator(tmp_path, monkeypatch):
         static_job(job1["atoms"])
 
     # Run the workflow locally
-    jf.run_locally(workflow(atoms), create_folders=True, ensure_success=True)
+    workflow_flow = workflow(atoms)
+    responses = jf.run_locally(
+        workflow_flow, create_folders=True, ensure_success=True
+    )
+    assert "atoms" in jobflow_output(responses, workflow_flow.jobs[-1])
 
 
-def test_tutorial2b(tmp_path, monkeypatch):
+def test_tutorial2b(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     # Define two Atoms objects
@@ -75,10 +81,12 @@ def test_tutorial2b(tmp_path, monkeypatch):
     workflow = jf.Flow([job1, job2])
 
     # Run the workflow locally
-    jf.run_locally(workflow, create_folders=True, ensure_success=True)
+    responses = jf.run_locally(workflow, create_folders=True, ensure_success=True)
+    assert "atoms" in jobflow_output(responses, job1)
+    assert "atoms" in jobflow_output(responses, job2)
 
 
-def test_tutorial2b_flow_decorator(tmp_path, monkeypatch):
+def test_tutorial2b_flow_decorator(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     # Define two Atoms objects
@@ -93,10 +101,16 @@ def test_tutorial2b_flow_decorator(tmp_path, monkeypatch):
         relax_job(atoms2)
 
     # Run the workflow locally
-    jf.run_locally(workflow(atoms1, atoms2), create_folders=True, ensure_success=True)
+    workflow_flow = workflow(atoms1, atoms2)
+    responses = jf.run_locally(
+        workflow_flow, create_folders=True, ensure_success=True
+    )
+    assert all(
+        "atoms" in jobflow_output(responses, job) for job in workflow_flow.jobs
+    )
 
 
-def test_job_getitem():
+def test_job_getitem(jobflow_output):
     @job
     def greetings(s):
         return {"hello": f"Hello {s}", "bye": f"Goodbye {s}"}
@@ -109,11 +123,11 @@ def test_job_getitem():
     def greet(s):
         job1 = greetings(s)
         job2 = upper(job1["hello"])  # No need for `job1.output["hello"]`
-        return job2.output
+        return job2
 
     workflow = greet("World")
-    response = jf.run_locally(workflow)
-    assert response[workflow.output.uuid][1].output == "HELLO WORLD"
+    responses = jf.run_locally(workflow, ensure_success=True)
+    assert jobflow_output(responses, workflow.jobs[-1]) == "HELLO WORLD"
 
 
 def test_comparison1(tmp_path, monkeypatch):
@@ -128,14 +142,14 @@ def test_comparison1(tmp_path, monkeypatch):
         return a * b
 
     job1 = add(1, 2)
-    job2 = mult(job1.output, 3)
+    job2 = mult(job1, 3)
     flow = jf.Flow([job1, job2])  # (2)!
 
     responses = jf.run_locally(flow, ensure_success=True)
     assert responses[job2.uuid][1].output == 9
 
 
-def test_comparison1_flow_decorator(tmp_path, monkeypatch):
+def test_comparison1_flow_decorator(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job  # (1)!
@@ -149,12 +163,11 @@ def test_comparison1_flow_decorator(tmp_path, monkeypatch):
     @flow
     def workflow():
         job1 = add(1, 2)
-        job2 = mult(job1.output, 3)
-        return job2.output  # or `return job`
+        return mult(job1, 3)
 
-    f = workflow()
-    response = jf.run_locally(f, ensure_success=True)
-    assert response[f.output.uuid][1].output == 9
+    workflow_flow = workflow()
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9
 
 
 def test_comparison2(tmp_path, monkeypatch):
@@ -181,7 +194,13 @@ def test_comparison2(tmp_path, monkeypatch):
     job3 = add_distributed(job2.output, 3)
     flow = jf.Flow([job1, job2, job3])
 
-    jf.run_locally(flow, ensure_success=True)  # [6, 6, 6] in final 3 jobs
+    responses = jf.run_locally(flow, ensure_success=True)
+    outputs = [
+        response.output
+        for indexed_responses in responses.values()
+        for response in indexed_responses.values()
+    ]
+    assert outputs.count(6) == 3
 
 
 def test_comparison2_flow_decorator(tmp_path, monkeypatch):
@@ -208,10 +227,16 @@ def test_comparison2_flow_decorator(tmp_path, monkeypatch):
         job2 = make_more(job1.output)
         add_distributed(job2.output, 3)
 
-    jf.run_locally(workflow(), ensure_success=True)  # [6, 6, 6] in final 3 jobs
+    responses = jf.run_locally(workflow(), ensure_success=True)
+    outputs = [
+        response.output
+        for indexed_responses in responses.values()
+        for response in indexed_responses.values()
+    ]
+    assert outputs.count(6) == 3
 
 
-def test_comparison3(tmp_path, monkeypatch):
+def test_comparison3(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job  #  (1)!
@@ -223,13 +248,14 @@ def test_comparison3(tmp_path, monkeypatch):
         return a * b
 
     job1 = add(1, 2)
-    job2 = mult(job1.output, 3)
+    job2 = mult(job1, 3)
     flow = jf.Flow([job1, job2])
 
-    jf.run_locally(flow, ensure_success=True)
+    responses = jf.run_locally(flow, ensure_success=True)
+    assert jobflow_output(responses, job2) == 9
 
 
-def test_comparison3_flow_decorator(tmp_path, monkeypatch):
+def test_comparison3_flow_decorator(tmp_path, monkeypatch, jobflow_output):
     monkeypatch.chdir(tmp_path)
 
     @job  #  (1)!
@@ -243,6 +269,8 @@ def test_comparison3_flow_decorator(tmp_path, monkeypatch):
     @flow
     def workflow():
         job1 = add(1, 2)
-        mult(job1.output, 3)
+        mult(job1, 3)
 
-    jf.run_locally(workflow(), ensure_success=True)
+    workflow_flow = workflow()
+    responses = jf.run_locally(workflow_flow, ensure_success=True)
+    assert jobflow_output(responses, workflow_flow.jobs[-1]) == 9

--- a/tests/jobflow/test_tutorials.py
+++ b/tests/jobflow/test_tutorials.py
@@ -60,9 +60,7 @@ def test_tutorial2a_flow_decorator(tmp_path, monkeypatch, jobflow_output):
 
     # Run the workflow locally
     workflow_flow = workflow(atoms)
-    responses = jf.run_locally(
-        workflow_flow, create_folders=True, ensure_success=True
-    )
+    responses = jf.run_locally(workflow_flow, create_folders=True, ensure_success=True)
     assert "atoms" in jobflow_output(responses, workflow_flow.jobs[-1])
 
 
@@ -102,12 +100,8 @@ def test_tutorial2b_flow_decorator(tmp_path, monkeypatch, jobflow_output):
 
     # Run the workflow locally
     workflow_flow = workflow(atoms1, atoms2)
-    responses = jf.run_locally(
-        workflow_flow, create_folders=True, ensure_success=True
-    )
-    assert all(
-        "atoms" in jobflow_output(responses, job) for job in workflow_flow.jobs
-    )
+    responses = jf.run_locally(workflow_flow, create_folders=True, ensure_success=True)
+    assert all("atoms" in jobflow_output(responses, job) for job in workflow_flow.jobs)
 
 
 def test_job_getitem(jobflow_output):
@@ -122,8 +116,7 @@ def test_job_getitem(jobflow_output):
     @flow
     def greet(s):
         job1 = greetings(s)
-        job2 = upper(job1["hello"])  # No need for `job1.output["hello"]`
-        return job2
+        return upper(job1["hello"])  # No need for `job1.output["hello"]`
 
     workflow = greet("World")
     responses = jf.run_locally(workflow, ensure_success=True)

--- a/tests/ray/test_decorators.py
+++ b/tests/ray/test_decorators.py
@@ -14,7 +14,7 @@ from quacc.wflow_tools.decorators import (
     _resolve_ray_subflow_result,
     _resolve_ray_value,
     _unwrap_ray_future,
-    _wrap_partial_for_ray,
+    _wrap_partial,
 )
 
 
@@ -65,19 +65,19 @@ def test_unwrap_ray_future_subclasses_passthrough():
     assert _unwrap_ray_future(md) is md
 
 
-def test_wrap_partial_for_ray_noop_for_plain():
+def test_wrap_partial_noop_for_plain():
     def f(a, b):
         return a + b
 
-    assert _wrap_partial_for_ray(f) is f
+    assert _wrap_partial(f) is f
 
 
-def test_wrap_partial_for_ray_with_partial():
+def test_wrap_partial_with_partial():
     def f(a, b):
         return a + b
 
     p = partial(f, 10)
-    wrapped = _wrap_partial_for_ray(p)
+    wrapped = _wrap_partial(p)
     assert wrapped is not p
     assert callable(wrapped)
     assert wrapped(5) == 15


### PR DESCRIPTION
## Summary

- capture jobs created inside Jobflow `@subflow` functions in a replacement `Flow`
- recursively normalize returned Job/Flow structures to output references
- add coverage for the documented default `bulk_to_slabs_flow` relax-to-static workflow
- make every `run_locally` invocation in `tests/jobflow` assert a concrete returned output or expected side effect
- keep quacc-authored workflow tests engine-agnostic without explicit `.output`

## Root cause

A Jobflow subflow was wrapped as a plain dynamic job. When the subflow returned a list of downstream jobs, those jobs could reference upstream jobs that were not included in the replacement flow, and list-contained Jobs were not normalized to output references. `ensure_success=True` did not catch missing exposed results in tests that discarded the response dictionary.

## Validation

- `git diff --check`
- Python syntax compilation for `decorators.py` and all `tests/jobflow`
- added output assertions to every Jobflow local execution test
- added a regression test for `bulk_to_slabs_flow(bulk("Cu"))` with the default static stage

GitHub Actions will run the complete Jobflow environment.