### PR TITLE
Fix TorchSim intro tutorial link

### DIFF
--- a/docs/user/miscellaneous/torchsim.md
+++ b/docs/user/miscellaneous/torchsim.md
@@ -10,7 +10,7 @@ Before using the TorchSim recipes, you need to install TorchSim and at least one
 pip install quacc[torchsim] mace-torch
 ```
 
-You should also be familiar with [ASE Atoms objects](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) and have read the [Intro to Jobs](recipes_intro.md) tutorial.
+You should also be familiar with [ASE Atoms objects](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) and have read the [Intro to Jobs](../recipes/recipes_intro.md) tutorial.
 
 !!! Note
 


### PR DESCRIPTION
## Summary

- fix the TorchSim tutorial's relative link to the Intro to Jobs page

## Root cause

`torchsim.md` is under `docs/user/miscellaneous`, while `recipes_intro.md` is under `docs/user/recipes`. The link incorrectly treated the target as a sibling file.

## Impact

The documentation build no longer reports the Intro to Jobs page as missing, and readers can follow the link successfully.

## Validation

- `zensical build --clean` — completed with `No issues found`
- `git diff --check`
