### PR TITLE
Add I/O-free MLIP relaxations

### DIFF
--- a/src/quacc/recipes/mlip/core.py
+++ b/src/quacc/recipes/mlip/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from quacc import job
+from quacc.atoms.core import get_final_atoms_from_dynamics
 from quacc.recipes.mlip._base import pick_calculator
 from quacc.runners.ase import Runner
 from quacc.schemas.ase import Summarize
@@ -61,6 +62,7 @@ def relax_job(
     library: Literal["fairchem", "matcalc", "rootstock"],
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
+    write_files: bool = True,
     additional_fields: dict[str, Any] | None = None,
     **calc_kwargs,
 ) -> OptSchema:
@@ -81,6 +83,9 @@ def relax_job(
     opt_params
         Dictionary of custom kwargs for the optimization process. For a list
         of available keys, refer to [quacc.runners.ase.Runner.run_opt][].
+    write_files
+        Whether to write optimizer log, restart, and trajectory files. Set to
+        `False` to avoid file I/O during the optimization.
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
@@ -97,8 +102,12 @@ def relax_job(
 
     calc = pick_calculator(library, **calc_kwargs)
 
-    dyn = Runner(atoms, calc).run_opt(relax_cell=relax_cell, **opt_flags)
+    dyn = Runner(atoms, calc).run_opt(
+        relax_cell=relax_cell, write_files=write_files, **opt_flags
+    )
+
+    trajectory = None if write_files else [get_final_atoms_from_dynamics(dyn)]
 
     return Summarize(
         additional_fields={"name": f"{library} Relax"} | (additional_fields or {})
-    ).opt(dyn)
+    ).opt(dyn, trajectory=trajectory)

--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import nullcontext
 from copy import deepcopy
 from importlib.util import find_spec
 from logging import getLogger
@@ -168,6 +169,7 @@ class Runner(BaseRunner):
         fn_hook: Callable | None = None,
         run_kwargs: dict[str, Any] | None = None,
         filter_kwargs: dict[str, Any] | None = None,
+        write_files: bool = True,
     ) -> Optimizer:
         """
         This is a wrapper around the optimizers in ASE.
@@ -198,6 +200,8 @@ class Runner(BaseRunner):
             Dictionary of kwargs for the `run()` method of the optimizer.
         filter_kwargs
             Dictionary of kwargs for the `FrechetCellFilter` if relax_cell is True.
+        write_files
+            Whether to write the optimizer log, restart, and trajectory files.
 
         Returns
         -------
@@ -207,8 +211,8 @@ class Runner(BaseRunner):
         # Set defaults
         merged_optimizer_kwargs = recursive_dict_merge(
             {
-                "logfile": self.tmpdir / "opt.log",
-                "restart": str(self.tmpdir / "opt.json"),
+                "logfile": self.tmpdir / "opt.log" if write_files else None,
+                "restart": str(self.tmpdir / "opt.json") if write_files else None,
             },
             optimizer_kwargs,
         )
@@ -233,8 +237,8 @@ class Runner(BaseRunner):
             self._set_sella_kwargs(merged_optimizer_kwargs)
 
         # Define the Trajectory object
-        traj_file = self.tmpdir / traj_filename
-        traj = Trajectory(traj_file, "w", atoms=self.atoms)
+        traj_file = self.tmpdir / traj_filename if write_files else None
+        traj = Trajectory(traj_file, "w", atoms=self.atoms) if traj_file else None
         merged_optimizer_kwargs["trajectory"] = traj
 
         # Set volume relaxation constraints, if relevant
@@ -248,7 +252,10 @@ class Runner(BaseRunner):
 
         # Run optimization
         try:
-            with traj, optimizer(self.atoms, **merged_optimizer_kwargs) as dyn:
+            with (
+                traj if traj is not None else nullcontext(),
+                optimizer(self.atoms, **merged_optimizer_kwargs) as dyn,
+            ):
                 if issubclass(optimizer, SciPyOptimizer):
                     # https://gitlab.com/ase/ase/-/issues/1475
                     dyn.run(**full_run_kwargs)
@@ -270,7 +277,8 @@ class Runner(BaseRunner):
 
         # Perform cleanup operations
         self.cleanup()
-        traj.filename = zpath(str(self.job_results_dir / traj_filename))
+        if traj is not None:
+            traj.filename = zpath(str(self.job_results_dir / traj_filename))
         dyn.trajectory = traj
 
         return dyn

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -158,11 +158,12 @@ class Summarize:
         )
 
         # Get trajectory
-        atoms_trajectory = (
-            trajectory or read(dyn.trajectory, index=":")
-            if isinstance(dyn.trajectory, (str, Path))
-            else read(dyn.trajectory.filename, index=":")
-        )
+        if trajectory is not None:
+            atoms_trajectory = trajectory
+        elif isinstance(dyn.trajectory, (str, Path)):
+            atoms_trajectory = read(dyn.trajectory, index=":")
+        else:
+            atoms_trajectory = read(dyn.trajectory.filename, index=":")
         trajectory_results = [atoms.calc.results for atoms in atoms_trajectory]
 
         initial_atoms = atoms_trajectory[0]

--- a/tests/core/recipes/mlip_recipes/test_io.py
+++ b/tests/core/recipes/mlip_recipes/test_io.py
@@ -1,0 +1,25 @@
+"""Tests for optional file I/O in MLIP recipes."""
+
+from __future__ import annotations
+
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from quacc.recipes.mlip.core import relax_job
+
+
+def test_relax_job_without_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "quacc.recipes.mlip.core.pick_calculator", lambda *_args, **_kwargs: EMT()
+    )
+
+    atoms = bulk("Cu") * (2, 1, 1)
+    atoms[0].position += 0.1
+    output = relax_job(atoms, library="matcalc", write_files=False)
+
+    assert len(output["trajectory"]) == 1
+    assert output["trajectory"][0] == output["atoms"]
+    assert not list(tmp_path.rglob("opt.log*"))
+    assert not list(tmp_path.rglob("opt.json*"))
+    assert not list(tmp_path.rglob("opt.traj*"))

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -225,6 +225,22 @@ def test_run_opt2(tmp_path, monkeypatch, copy_files):
     assert traj[-1].calc.results is not None
 
 
+def test_run_opt_without_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    atoms = bulk("Cu") * (2, 1, 1)
+    atoms[0].position += 0.1
+
+    dyn = Runner(atoms, EMT()).run_opt(write_files=False)
+    results_dir = Path(_find_results_dir())
+
+    assert dyn.trajectory is None
+    assert dyn.todict().get("logfile") is None
+    assert dyn.todict().get("restart") is None
+    assert not (results_dir / "opt.log.gz").exists()
+    assert not (results_dir / "opt.json.gz").exists()
+    assert not (results_dir / "opt.traj.gz").exists()
+
+
 def test_run_scipy_opt(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     atoms = bulk("Cu") * (2, 1, 1)


### PR DESCRIPTION
## Summary

- add a `write_files` option to MLIP relaxation recipes
- disable ASE optimizer log, restart, and trajectory writes when `write_files=False`
- preserve the standard optimization result schema by summarizing the final structure from memory
- honor explicitly supplied in-memory trajectories in `Summarize.opt`

## Motivation

MLIP relaxations can be fast enough that optimizer file I/O becomes meaningful overhead. This provides an opt-in path that avoids those writes while retaining the existing default behavior.

## Validation

- `python -m pytest tests/core/runners/test_ase.py tests/core/schemas/test_ase.py tests/core/recipes/mlip_recipes/test_io.py -q` (45 passed)
- Ruff lint and format checks on changed files

Closes #3284