### PR TITLE
Improve type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ lint.select = [
 ]
 lint.ignore = [
   "A005",  # Module shadows
+  "ANN401",  # Dynamically typed expressions
   "E501",   # Line too long
   "ISC001",   # single-line-implicit-string-concatenation
   "PLR",    # Design related pylint codes

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -142,9 +142,9 @@ if _settings.WORKFLOW_ENGINE == "prefect":
     from prefect.client.schemas import State
     from prefect.futures import PrefectFuture
 
-    def _patched_getitem(self, index: Any) -> Any:
+    def _patched_getitem(self: PrefectFuture | State, index: object) -> object:
         @job
-        def _getitem(future, index_):
+        def _getitem(future: PrefectFuture | State, index_: object) -> object:
             return future[index_]
 
         return _getitem(self, index)

--- a/src/quacc/atoms/defects.py
+++ b/src/quacc/atoms/defects.py
@@ -18,6 +18,8 @@ if has_pmg_defects:
 
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
     from numpy.typing import NDArray
     from pymatgen.core.structure import Structure
@@ -54,7 +56,7 @@ def make_defects_from_bulk(
     max_atoms: int = 240,
     min_length: float = 10.0,
     force_diagonal: bool = False,
-    **defect_gen_kwargs,
+    **defect_gen_kwargs: Any,
 ) -> list[Atoms]:
     """
     Function to make defects from a bulk atoms object.

--- a/src/quacc/atoms/slabs.py
+++ b/src/quacc/atoms/slabs.py
@@ -15,7 +15,7 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from quacc.atoms.core import copy_atoms
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Any, Literal
 
     from ase.atoms import Atoms
 
@@ -81,7 +81,7 @@ def make_slabs_from_bulk(
     z_fix: float | None = 2.0,
     flip_asymmetric: bool = True,
     allowed_surface_symbols: list[str] | None = None,
-    **slabgen_kwargs,
+    **slabgen_kwargs: Any,
 ) -> list[Atoms]:
     """
     Function to make slabs from a bulk atoms object.

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -360,7 +360,7 @@ class Espresso(GenericFileIOCalculator):
         input_atoms: Atoms | None = None,
         preset: str | Path | None = None,
         template: EspressoTemplate | None = None,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """
         Initialize the Espresso calculator.

--- a/src/quacc/calculators/espresso/espresso.py
+++ b/src/quacc/calculators/espresso/espresso.py
@@ -360,7 +360,7 @@ class Espresso(GenericFileIOCalculator):
         input_atoms: Atoms | None = None,
         preset: str | Path | None = None,
         template: EspressoTemplate | None = None,
-        **kwargs: object,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize the Espresso calculator.

--- a/src/quacc/calculators/mrcc/mrcc.py
+++ b/src/quacc/calculators/mrcc/mrcc.py
@@ -177,7 +177,7 @@ class MrccTemplate(CalculatorTemplate):
         """
         return read_mrcc_outputs(output_file_path=directory / self.outputname)
 
-    def load_profile(self, cfg: Config, **kwargs: object) -> MrccProfile:
+    def load_profile(self, cfg: Config, **kwargs: Any) -> MrccProfile:
         return MrccProfile.from_config(cfg, self.name, **kwargs)
 
 
@@ -191,7 +191,7 @@ class MRCC(GenericFileIOCalculator):
         *,
         profile: MrccProfile | None = None,
         directory: str | Path = ".",
-        **kwargs: object,
+        **kwargs: Any,
     ) -> None:
         """
         Construct MRCC-calculator object.

--- a/src/quacc/calculators/mrcc/mrcc.py
+++ b/src/quacc/calculators/mrcc/mrcc.py
@@ -177,7 +177,7 @@ class MrccTemplate(CalculatorTemplate):
         """
         return read_mrcc_outputs(output_file_path=directory / self.outputname)
 
-    def load_profile(self, cfg: Config, **kwargs) -> MrccProfile:
+    def load_profile(self, cfg: Config, **kwargs: object) -> MrccProfile:
         return MrccProfile.from_config(cfg, self.name, **kwargs)
 
 
@@ -187,7 +187,11 @@ class MRCC(GenericFileIOCalculator):
     """
 
     def __init__(
-        self, *, profile: MrccProfile = None, directory: str | Path = ".", **kwargs
+        self,
+        *,
+        profile: MrccProfile | None = None,
+        directory: str | Path = ".",
+        **kwargs: object,
     ) -> None:
         """
         Construct MRCC-calculator object.

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -50,7 +50,7 @@ class QChem(FileIOCalculator):
         svp: dict | None = None,
         pcm_nonels: dict | None = None,
         qchem_dict_set_params: dict[str, Any] | None = None,
-        **fileiocalculator_kwargs,
+        **fileiocalculator_kwargs: object,
     ) -> None:
         """
         Initialize the Q-Chem calculator. Most of the input parameters here are used to

--- a/src/quacc/calculators/qchem/qchem.py
+++ b/src/quacc/calculators/qchem/qchem.py
@@ -50,7 +50,7 @@ class QChem(FileIOCalculator):
         svp: dict | None = None,
         pcm_nonels: dict | None = None,
         qchem_dict_set_params: dict[str, Any] | None = None,
-        **fileiocalculator_kwargs: object,
+        **fileiocalculator_kwargs: Any,
     ) -> None:
         """
         Initialize the Q-Chem calculator. Most of the input parameters here are used to

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -642,7 +642,7 @@ class MPtoASEConverter:
         return full_input_params
 
 
-def _params_differ(a, b) -> bool:
+def _params_differ(a: object, b: object) -> bool:
     """Compare two parameter values, handling NumPy arrays."""
     if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
         return not np.array_equal(a, b)

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -70,7 +70,7 @@ class Vasp(Vasp_):
             | None
         ) = None,
         auto_dipole: bool | None = None,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """
         Initialize the VASP calculator.

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -70,7 +70,7 @@ class Vasp(Vasp_):
             | None
         ) = None,
         auto_dipole: bool | None = None,
-        **kwargs: object,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize the VASP calculator.

--- a/src/quacc/recipes/aims/core.py
+++ b/src/quacc/recipes/aims/core.py
@@ -58,7 +58,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
     agnostic_params: bool = False,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with FHI-aims.
@@ -141,7 +141,7 @@ def relax_job(
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
     agnostic_params: bool = False,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with FHI-aims internal optimizer.

--- a/src/quacc/recipes/aims/core.py
+++ b/src/quacc/recipes/aims/core.py
@@ -58,7 +58,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
     agnostic_params: bool = False,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with FHI-aims.
@@ -141,7 +141,7 @@ def relax_job(
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
     agnostic_params: bool = False,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with FHI-aims internal optimizer.

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -22,7 +22,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     kpts: tuple | list[tuple] | dict | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -75,7 +75,7 @@ def relax_job(
     relax_cell: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a structure relaxation.

--- a/src/quacc/recipes/dftb/core.py
+++ b/src/quacc/recipes/dftb/core.py
@@ -22,7 +22,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     kpts: tuple | list[tuple] | dict | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -75,7 +75,7 @@ def relax_job(
     relax_cell: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a structure relaxation.

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -27,7 +27,7 @@ def static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a static calculation.
@@ -66,7 +66,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Carry out a geometry optimization.

--- a/src/quacc/recipes/emt/core.py
+++ b/src/quacc/recipes/emt/core.py
@@ -27,7 +27,7 @@ def static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a static calculation.
@@ -66,7 +66,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Carry out a geometry optimization.

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -35,7 +35,7 @@ def md_job(
     md_params: MDParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> DynSchema:
     """
     Carry out a Molecular Dynamics calculation.

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -35,7 +35,7 @@ def md_job(
     md_params: MDParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> DynSchema:
     """
     Carry out a Molecular Dynamics calculation.

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -36,7 +36,7 @@ def bands_pw_job(
     force_gamma: bool = True,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic bandstructure calculation with pw.x.
@@ -115,7 +115,7 @@ def bands_pp_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to re-order bands and computes bands-related properties with bands.x.
@@ -166,7 +166,7 @@ def fermi_surface_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to retrieve the fermi surface with fs.x

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -36,7 +36,7 @@ def bands_pw_job(
     force_gamma: bool = True,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic bandstructure calculation with pw.x.
@@ -115,7 +115,7 @@ def bands_pp_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to re-order bands and computes bands-related properties with bands.x.
@@ -166,7 +166,7 @@ def fermi_surface_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to retrieve the fermi surface with fs.x

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -46,7 +46,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with pw.x.
@@ -105,7 +105,7 @@ def relax_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with pw.x.
@@ -169,7 +169,7 @@ def ase_relax_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with pw.x using ASE
@@ -240,7 +240,7 @@ def post_processing_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic pp.x calculation (post-processing).
@@ -301,7 +301,7 @@ def non_scf_job(
     preset: str | None = "sssp_1.3.0_pbe_efficiency",
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic NSCF calculation with pw.x.

--- a/src/quacc/recipes/espresso/core.py
+++ b/src/quacc/recipes/espresso/core.py
@@ -46,7 +46,7 @@ def static_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with pw.x.
@@ -105,7 +105,7 @@ def relax_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with pw.x.
@@ -169,7 +169,7 @@ def ase_relax_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with pw.x using ASE
@@ -240,7 +240,7 @@ def post_processing_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic pp.x calculation (post-processing).
@@ -301,7 +301,7 @@ def non_scf_job(
     preset: str | None = "sssp_1.3.0_pbe_efficiency",
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic NSCF calculation with pw.x.

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -32,7 +32,7 @@ def dos_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic dos.x calculation (density of states).
@@ -81,7 +81,7 @@ def projwfc_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic projwfc.x calculation.

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -32,7 +32,7 @@ def dos_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic dos.x calculation (density of states).
@@ -81,7 +81,7 @@ def projwfc_job(
     prev_outdir: SourceDirectory | None = None,
     test_run: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic projwfc.x calculation.

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -41,7 +41,7 @@ def phonon_job(
     test_run: bool = False,
     use_phcg: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic ph.x calculation. It should allow you to
@@ -113,7 +113,7 @@ def phonon_job(
 def q2r_job(
     copy_files: CopyFiles,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic q2r.x calculation. It should allow you to
@@ -154,7 +154,7 @@ def q2r_job(
 def matdyn_job(
     copy_files: CopyFiles,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic `matdyn.x` calculation. It should allow you to use
@@ -483,7 +483,7 @@ def dvscf_q2r_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic dvscf_q2r calculation allowing phonon potential
@@ -552,7 +552,7 @@ def postahc_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic postahc calculation. It should allow you to

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -41,7 +41,7 @@ def phonon_job(
     test_run: bool = False,
     use_phcg: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic ph.x calculation. It should allow you to
@@ -113,7 +113,7 @@ def phonon_job(
 def q2r_job(
     copy_files: CopyFiles,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic q2r.x calculation. It should allow you to
@@ -154,7 +154,7 @@ def q2r_job(
 def matdyn_job(
     copy_files: CopyFiles,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic `matdyn.x` calculation. It should allow you to use
@@ -483,7 +483,7 @@ def dvscf_q2r_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic dvscf_q2r calculation allowing phonon potential
@@ -552,7 +552,7 @@ def postahc_job(
     copy_files: CopyFiles | None = None,
     prev_outdir: SourceDirectory | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic postahc calculation. It should allow you to

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -26,7 +26,7 @@ def static_job(
     basis: str = "def2tzvp",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -93,7 +93,7 @@ def relax_job(
     freq: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a geometry optimization.

--- a/src/quacc/recipes/gaussian/core.py
+++ b/src/quacc/recipes/gaussian/core.py
@@ -26,7 +26,7 @@ def static_job(
     basis: str = "def2tzvp",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -93,7 +93,7 @@ def relax_job(
     freq: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a geometry optimization.

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -35,7 +35,7 @@ def run_and_summarize(
     option_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Base job function for GULP recipes.

--- a/src/quacc/recipes/gulp/_base.py
+++ b/src/quacc/recipes/gulp/_base.py
@@ -35,7 +35,7 @@ def run_and_summarize(
     option_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Base job function for GULP recipes.

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -24,9 +24,7 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms,
-    additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: Any,
+    atoms: Atoms, additional_fields: dict[str, Any] | None = None, **calc_kwargs: Any
 ) -> RunSchema:
     """
     Function to carry out a static calculation.

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def static_job(
     atoms: Atoms,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a static calculation.
@@ -59,7 +59,7 @@ def relax_job(
     atoms: Atoms,
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Function to carry out a geometry optimization.
@@ -102,7 +102,7 @@ def freq_job(
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/lj/core.py
+++ b/src/quacc/recipes/lj/core.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
 
 @job
 def static_job(
-    atoms: Atoms, additional_fields: dict[str, Any] | None = None, **calc_kwargs
+    atoms: Atoms,
+    additional_fields: dict[str, Any] | None = None,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a static calculation.
@@ -57,7 +59,7 @@ def relax_job(
     atoms: Atoms,
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Function to carry out a geometry optimization.
@@ -100,7 +102,7 @@ def freq_job(
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/mlip/_base.py
+++ b/src/quacc/recipes/mlip/_base.py
@@ -14,7 +14,7 @@ has_torch = bool(find_spec("torch"))
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Literal
+    from typing import Any, Literal
 
     from ase.calculators.calculator import BaseCalculator
 
@@ -42,7 +42,7 @@ def freezeargs(func: Callable) -> Callable:
     from frozendict import frozendict
 
     @wraps(func)
-    def wrapped(*args: object, **kwargs: object) -> object:
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
         args = (frozendict(arg) if isinstance(arg, dict) else arg for arg in args)
         kwargs = {
             k: frozendict(v) if isinstance(v, dict) else v for k, v in kwargs.items()
@@ -55,7 +55,7 @@ def freezeargs(func: Callable) -> Callable:
 @freezeargs
 @lru_cache
 def pick_calculator(
-    library: Literal["fairchem", "matcalc", "rootstock"], **calc_kwargs: object
+    library: Literal["fairchem", "matcalc", "rootstock"], **calc_kwargs: Any
 ) -> BaseCalculator:
     """
 

--- a/src/quacc/recipes/mlip/_base.py
+++ b/src/quacc/recipes/mlip/_base.py
@@ -42,7 +42,7 @@ def freezeargs(func: Callable) -> Callable:
     from frozendict import frozendict
 
     @wraps(func)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: object, **kwargs: object) -> object:
         args = (frozendict(arg) if isinstance(arg, dict) else arg for arg in args)
         kwargs = {
             k: frozendict(v) if isinstance(v, dict) else v for k, v in kwargs.items()
@@ -55,7 +55,7 @@ def freezeargs(func: Callable) -> Callable:
 @freezeargs
 @lru_cache
 def pick_calculator(
-    library: Literal["fairchem", "matcalc", "rootstock"], **calc_kwargs
+    library: Literal["fairchem", "matcalc", "rootstock"], **calc_kwargs: object
 ) -> BaseCalculator:
     """
 

--- a/src/quacc/recipes/mlip/core.py
+++ b/src/quacc/recipes/mlip/core.py
@@ -24,7 +24,7 @@ def static_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -64,7 +64,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     write_files: bool = True,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Relax a structure.

--- a/src/quacc/recipes/mlip/core.py
+++ b/src/quacc/recipes/mlip/core.py
@@ -24,7 +24,7 @@ def static_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -64,7 +64,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     write_files: bool = True,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Relax a structure.

--- a/src/quacc/recipes/mrcc/core.py
+++ b/src/quacc/recipes/mrcc/core.py
@@ -21,7 +21,7 @@ def static_job(
     method: str = "pbe",
     basis: str = "def2-tzvp",
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.

--- a/src/quacc/recipes/mrcc/core.py
+++ b/src/quacc/recipes/mrcc/core.py
@@ -8,6 +8,8 @@ from quacc import job
 from quacc.recipes.mrcc._base import run_and_summarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import CopyFiles, RunSchema
@@ -21,7 +23,7 @@ def static_job(
     method: str = "pbe",
     basis: str = "def2-tzvp",
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.

--- a/src/quacc/recipes/onetep/core.py
+++ b/src/quacc/recipes/onetep/core.py
@@ -32,7 +32,7 @@ def static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with ONETEP.
@@ -72,7 +72,7 @@ def ase_relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with ONETEP using ASE

--- a/src/quacc/recipes/onetep/core.py
+++ b/src/quacc/recipes/onetep/core.py
@@ -32,7 +32,7 @@ def static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a basic SCF calculation with ONETEP.
@@ -72,7 +72,7 @@ def ase_relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a structure relaxation with ONETEP using ASE

--- a/src/quacc/recipes/orca/_base.py
+++ b/src/quacc/recipes/orca/_base.py
@@ -34,7 +34,7 @@ def run_and_summarize(
     block_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Base job function for ORCA recipes.
@@ -98,7 +98,7 @@ def run_and_summarize_opt(
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Base job function for ORCA recipes with ASE optimizer.
@@ -159,7 +159,7 @@ def prep_calculator(
     default_blocks: list[str] | None = None,
     input_swaps: list[str] | None = None,
     block_swaps: list[str] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> ORCA:
     """
     Prepare the ORCA calculator.

--- a/src/quacc/recipes/orca/_base.py
+++ b/src/quacc/recipes/orca/_base.py
@@ -34,7 +34,7 @@ def run_and_summarize(
     block_swaps: list[str] | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Base job function for ORCA recipes.
@@ -98,7 +98,7 @@ def run_and_summarize_opt(
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Base job function for ORCA recipes with ASE optimizer.
@@ -159,7 +159,7 @@ def prep_calculator(
     default_blocks: list[str] | None = None,
     input_swaps: list[str] | None = None,
     block_swaps: list[str] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> ORCA:
     """
     Prepare the ORCA calculator.

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -30,7 +30,7 @@ def static_job(
     basis: str = "def2-tzvp",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Function to carry out a single-point calculation.

--- a/src/quacc/recipes/psi4/core.py
+++ b/src/quacc/recipes/psi4/core.py
@@ -30,7 +30,7 @@ def static_job(
     basis: str = "def2-tzvp",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Function to carry out a single-point calculation.

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -45,7 +45,7 @@ def static_job(
     basis: str | None = "def2-tzvpd",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -103,7 +103,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Optimize aka "relax" a molecular structure with an ASE optimizer.
@@ -166,7 +166,7 @@ def freq_job(
     basis: str = "def2-svpd",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Perform a frequency calculation on a molecular structure.

--- a/src/quacc/recipes/qchem/core.py
+++ b/src/quacc/recipes/qchem/core.py
@@ -45,7 +45,7 @@ def static_job(
     basis: str | None = "def2-tzvpd",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -103,7 +103,7 @@ def relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Optimize aka "relax" a molecular structure with an ASE optimizer.
@@ -166,7 +166,7 @@ def freq_job(
     basis: str = "def2-svpd",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Perform a frequency calculation on a molecular structure.

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -35,7 +35,7 @@ def ts_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     TS optimize a molecular structure.
@@ -104,7 +104,7 @@ def irc_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     IRC optimize a molecular structure.
@@ -181,7 +181,7 @@ def quasi_irc_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Quasi-IRC to optimize a reaction endpoint from a transition-state with known vibrational frequency modes.

--- a/src/quacc/recipes/qchem/ts.py
+++ b/src/quacc/recipes/qchem/ts.py
@@ -35,7 +35,7 @@ def ts_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     TS optimize a molecular structure.
@@ -104,7 +104,7 @@ def irc_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     IRC optimize a molecular structure.
@@ -181,7 +181,7 @@ def quasi_irc_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Quasi-IRC to optimize a reaction endpoint from a transition-state with known vibrational frequency modes.

--- a/src/quacc/recipes/tblite/core.py
+++ b/src/quacc/recipes/tblite/core.py
@@ -28,7 +28,7 @@ def static_job(
     atoms: Atoms,
     method: Literal["GFN1-xTB", "GFN2-xTB", "IPEA1-xTB"] = "GFN2-xTB",
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -72,7 +72,7 @@ def relax_job(
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> OptSchema:
     """
     Relax a structure.
@@ -124,7 +124,7 @@ def freq_job(
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/tblite/core.py
+++ b/src/quacc/recipes/tblite/core.py
@@ -28,7 +28,7 @@ def static_job(
     atoms: Atoms,
     method: Literal["GFN1-xTB", "GFN2-xTB", "IPEA1-xTB"] = "GFN2-xTB",
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> RunSchema:
     """
     Carry out a single-point calculation.
@@ -72,7 +72,7 @@ def relax_job(
     relax_cell: bool = False,
     opt_params: OptParams | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> OptSchema:
     """
     Relax a structure.
@@ -124,7 +124,7 @@ def freq_job(
     pressure: float = 1.0,
     vib_kwargs: VibKwargs | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -39,7 +39,7 @@ def static_job(
     preset: str | None = "DefaultSetGGA",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a single-point calculation. If you want high quality forces,
@@ -94,7 +94,7 @@ def relax_job(
     relax_cell: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Relax a structure.
@@ -207,7 +207,7 @@ def ase_relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspASEOptSchema:
     """
     Relax a structure.
@@ -263,7 +263,7 @@ def non_scf_job(
     line_kpt_density: float = 20,
     calculate_optics: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a non-self-consistent field (NSCF) calculation.
@@ -358,7 +358,7 @@ def freq_job(
     thermo_method: Literal["harmonic", "ideal_gas"] = "harmonic",
     vib_kwargs: VibKwargs | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/vasp/core.py
+++ b/src/quacc/recipes/vasp/core.py
@@ -39,7 +39,7 @@ def static_job(
     preset: str | None = "DefaultSetGGA",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a single-point calculation. If you want high quality forces,
@@ -94,7 +94,7 @@ def relax_job(
     relax_cell: bool = False,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Relax a structure.
@@ -207,7 +207,7 @@ def ase_relax_job(
     opt_params: OptParams | None = None,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspASEOptSchema:
     """
     Relax a structure.
@@ -263,7 +263,7 @@ def non_scf_job(
     line_kpt_density: float = 20,
     calculate_optics: bool = False,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a non-self-consistent field (NSCF) calculation.
@@ -358,7 +358,7 @@ def freq_job(
     thermo_method: Literal["harmonic", "ideal_gas"] = "harmonic",
     vib_kwargs: VibKwargs | None = None,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VibThermoSchema:
     """
     Run a frequency job and calculate thermochemistry.

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -36,7 +36,7 @@ def omat_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OMat settings.
@@ -81,7 +81,7 @@ def omc_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OMC settings.
@@ -178,7 +178,7 @@ def odac_static_job(
     kpts: tuple = (1, 1, 1),
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a static calculation with ODAC settings.
@@ -255,7 +255,7 @@ def oc20_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OC20 settings.

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -36,7 +36,7 @@ def omat_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OMat settings.
@@ -81,7 +81,7 @@ def omc_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OMC settings.
@@ -178,7 +178,7 @@ def odac_static_job(
     kpts: tuple = (1, 1, 1),
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a static calculation with ODAC settings.
@@ -255,7 +255,7 @@ def oc20_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Carry out a static calculation with OC20 settings.

--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -47,7 +47,7 @@ def matpes_static_job(
     write_extra_files: bool = False,
     auto_ispin: bool = False,
     prev_dir: SourceDirectory | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Function to run a MatPES-compatible static calculation.

--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -47,7 +47,7 @@ def matpes_static_job(
     write_extra_files: bool = False,
     auto_ispin: bool = False,
     prev_dir: SourceDirectory | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Function to run a MatPES-compatible static calculation.

--- a/src/quacc/recipes/vasp/mattersim.py
+++ b/src/quacc/recipes/vasp/mattersim.py
@@ -23,7 +23,7 @@ def mattersim_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Run a static calculation with the VASP settings used for MatterSim.

--- a/src/quacc/recipes/vasp/mattersim.py
+++ b/src/quacc/recipes/vasp/mattersim.py
@@ -23,7 +23,7 @@ def mattersim_static_job(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Run a static calculation with the VASP settings used for MatterSim.

--- a/src/quacc/recipes/vasp/md.py
+++ b/src/quacc/recipes/vasp/md.py
@@ -26,7 +26,7 @@ def md_job(
     pressure: float = 1.0,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Run a VASP ab initio molecular dynamics calculation.

--- a/src/quacc/recipes/vasp/md.py
+++ b/src/quacc/recipes/vasp/md.py
@@ -26,7 +26,7 @@ def md_job(
     pressure: float = 1.0,
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Run a VASP ab initio molecular dynamics calculation.

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -40,7 +40,7 @@ def mof_off_static_job(
     level: Literal["PBE", "r2SCAN"],
     dispersion: Literal["D3BJ", "D4"] | None = None,
     prev_dir: SourceDirectory | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Function to run a MOF-Off-compatible static calculation.

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -40,7 +40,7 @@ def mof_off_static_job(
     level: Literal["PBE", "r2SCAN"],
     dispersion: Literal["D3BJ", "D4"] | None = None,
     prev_dir: SourceDirectory | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Function to run a MOF-Off-compatible static calculation.

--- a/src/quacc/recipes/vasp/mp24.py
+++ b/src/quacc/recipes/vasp/mp24.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_prerelax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Function to pre-relax a structure with Materials Project r2SCAN workflow settings. By default, this
@@ -79,7 +79,7 @@ def mp_prerelax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_metagga_relax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Function to relax a structure with Materials Project r2SCAN workflow settings. By default, this uses
@@ -123,7 +123,7 @@ def mp_metagga_relax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_metagga_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Function to run a static calculation on a structure with r2SCAN workflow Materials Project settings.

--- a/src/quacc/recipes/vasp/mp24.py
+++ b/src/quacc/recipes/vasp/mp24.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_prerelax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Function to pre-relax a structure with Materials Project r2SCAN workflow settings. By default, this
@@ -79,7 +79,7 @@ def mp_prerelax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_metagga_relax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Function to relax a structure with Materials Project r2SCAN workflow settings. By default, this uses
@@ -123,7 +123,7 @@ def mp_metagga_relax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_metagga_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Function to run a static calculation on a structure with r2SCAN workflow Materials Project settings.

--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 @job
 def mp_aloe_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Run a static calculation with MP-ALOE settings.

--- a/src/quacc/recipes/vasp/mp_aloe.py
+++ b/src/quacc/recipes/vasp/mp_aloe.py
@@ -9,6 +9,8 @@ from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import SourceDirectory, VaspSchema
@@ -16,7 +18,7 @@ if TYPE_CHECKING:
 
 @job
 def mp_aloe_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Run a static calculation with MP-ALOE settings.

--- a/src/quacc/recipes/vasp/mp_legacy.py
+++ b/src/quacc/recipes/vasp/mp_legacy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_gga_relax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Function to relax a structure with the original Materials Project GGA(+U) settings.
@@ -76,7 +76,7 @@ def mp_gga_relax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_gga_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Function to run a static calculation on a structure with the original Materials Project GGA(+U) settings.

--- a/src/quacc/recipes/vasp/mp_legacy.py
+++ b/src/quacc/recipes/vasp/mp_legacy.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_gga_relax_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Function to relax a structure with the original Materials Project GGA(+U) settings.
@@ -76,7 +76,7 @@ def mp_gga_relax_job(
 @job
 @requires(has_atomate2, "atomate2 is not installed. Run `pip install quacc[mp]`")
 def mp_gga_static_job(
-    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: object
+    atoms: Atoms, prev_dir: SourceDirectory | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Function to run a static calculation on a structure with the original Materials Project GGA(+U) settings.

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -16,6 +16,8 @@ from quacc import job
 from quacc.recipes.vasp._base import run_and_summarize, run_and_summarize_opt
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from ase.atoms import Atoms
 
     from quacc.types import CopyFiles, OptSchema, VaspSchema
@@ -38,7 +40,7 @@ def qmof_relax_job(
     relax_cell: bool = True,
     run_prerelax: bool = True,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> QMOFRelaxSchema:
     """
     Relax a structure in a multi-step process for increased computational efficiency.
@@ -119,7 +121,7 @@ def qmof_relax_job(
 
 
 def _prerelax(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: Any
 ) -> OptSchema:
     """
     A "pre-relaxation" with BFGSLineSearch to resolve very high forces.
@@ -164,7 +166,7 @@ def _prerelax(
 
 
 def _loose_relax_positions(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Position relaxation with default ENCUT and coarse k-point grid.
@@ -210,7 +212,7 @@ def _loose_relax_positions(
 
 
 def _loose_relax_cell(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Volume relaxation with coarse k-point grid.
@@ -257,7 +259,7 @@ def _double_relax(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     relax_cell: bool = True,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> list[VaspSchema]:
     """
     Double relaxation using production-quality settings.
@@ -322,7 +324,7 @@ def _double_relax(
 
 
 def _static(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: Any
 ) -> VaspSchema:
     """
     Static calculation using production-quality settings.

--- a/src/quacc/recipes/vasp/qmof.py
+++ b/src/quacc/recipes/vasp/qmof.py
@@ -38,7 +38,7 @@ def qmof_relax_job(
     relax_cell: bool = True,
     run_prerelax: bool = True,
     copy_files: CopyFiles | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> QMOFRelaxSchema:
     """
     Relax a structure in a multi-step process for increased computational efficiency.
@@ -119,7 +119,7 @@ def qmof_relax_job(
 
 
 def _prerelax(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
 ) -> OptSchema:
     """
     A "pre-relaxation" with BFGSLineSearch to resolve very high forces.
@@ -164,7 +164,7 @@ def _prerelax(
 
 
 def _loose_relax_positions(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Position relaxation with default ENCUT and coarse k-point grid.
@@ -210,7 +210,7 @@ def _loose_relax_positions(
 
 
 def _loose_relax_cell(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Volume relaxation with coarse k-point grid.
@@ -257,7 +257,7 @@ def _double_relax(
     atoms: Atoms,
     copy_files: CopyFiles | None = None,
     relax_cell: bool = True,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> list[VaspSchema]:
     """
     Double relaxation using production-quality settings.
@@ -322,7 +322,7 @@ def _double_relax(
 
 
 def _static(
-    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs
+    atoms: Atoms, copy_files: CopyFiles | None = None, **calc_kwargs: object
 ) -> VaspSchema:
     """
     Static calculation using production-quality settings.

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -24,7 +24,7 @@ def static_job(
     preset: str | None = "SlabSetPBE",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Function to carry out a single-point calculation on a slab.
@@ -78,7 +78,7 @@ def relax_job(
     preset: str | None = "SlabSetPBE",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs,
+    **calc_kwargs: object,
 ) -> VaspSchema:
     """
     Function to relax a slab.

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -24,7 +24,7 @@ def static_job(
     preset: str | None = "SlabSetPBE",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Function to carry out a single-point calculation on a slab.
@@ -78,7 +78,7 @@ def relax_job(
     preset: str | None = "SlabSetPBE",
     copy_files: CopyFiles | None = None,
     additional_fields: dict[str, Any] | None = None,
-    **calc_kwargs: object,
+    **calc_kwargs: Any,
 ) -> VaspSchema:
     """
     Function to relax a slab.

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
 from shutil import which
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, ParamSpec, TypeVar, Union
 
 import psutil
 from pydantic import Field, field_validator, model_validator
@@ -15,10 +15,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ruamel.yaml import YAML
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator
     from typing import Any
 
 _DEFAULT_CONFIG_FILE_PATH = Path("~", ".quacc.yaml").expanduser().resolve()
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class QuaccSettings(BaseSettings):
@@ -540,7 +542,7 @@ class QuaccSettings(BaseSettings):
         return _type_handler(cls._use_custom_config_settings(settings))
 
     @model_validator(mode="after")
-    def set_jobflow_settings(self):
+    def set_jobflow_settings(self) -> QuaccSettings:
         """
         If WORKFLOW_ENGINE is jobflow, ensure that CREATE_UNIQUE_DIR
         is set to False since Jobflow already handles this for us.
@@ -575,7 +577,7 @@ def _type_handler(settings: dict[str, Any]) -> dict[str, Any]:
 
 
 @contextmanager
-def change_settings(changes: dict[str, Any]):
+def change_settings(changes: dict[str, Any]) -> Generator[None]:
     """
     Temporarily change an attribute of an object.
 
@@ -602,7 +604,9 @@ def change_settings(changes: dict[str, Any]):
         _internally_set_settings(changes=original_values)
 
 
-def change_settings_wrap(func: Callable, changes: dict[str, Any]) -> Callable:
+def change_settings_wrap(
+    func: Callable[P, R], changes: dict[str, Any]
+) -> Callable[P, R]:
     """
     Wraps a function with the change_settings context manager if not already wrapped.
 
@@ -621,7 +625,7 @@ def change_settings_wrap(func: Callable, changes: dict[str, Any]) -> Callable:
     original_func = func._original_func if getattr(func, "_changed", False) else func
 
     @wraps(original_func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         with change_settings(changes):
             return original_func(*args, **kwargs)
 

--- a/src/quacc/utils/dicts.py
+++ b/src/quacc/utils/dicts.py
@@ -21,7 +21,7 @@ class Remove:
     `None` is a valid value for many keyword arguments.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError(
             "Remove is a sentinel class and should not be instantiated."
         )

--- a/src/quacc/wflow_tools/context.py
+++ b/src/quacc/wflow_tools/context.py
@@ -22,14 +22,19 @@ from contextvars import ContextVar
 from enum import Enum
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from monty.json import MSONable
 
 from quacc.utils.files import make_unique_name
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator
+    from contextlib import AbstractContextManager
+    from typing import Any
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class NodeType(Enum):
@@ -49,7 +54,7 @@ class ContextNode(MSONable):
     context is passed across process boundaries.
     """
 
-    def __init__(self, name: str, node_type: NodeType):
+    def __init__(self, name: str, node_type: NodeType) -> None:
         self.name = name
         self.node_type = node_type
 
@@ -92,7 +97,7 @@ def get_context_path() -> str:
 
 
 @contextmanager
-def _push_context(name: str, node_type: NodeType):
+def _push_context(name: str, node_type: NodeType) -> Generator[None]:
     """Push a new node onto the execution-context stack for the duration of
     the ``with`` block, then restore the previous stack on exit."""
     old = _execution_context.get()
@@ -105,7 +110,7 @@ def _push_context(name: str, node_type: NodeType):
 
 
 @contextmanager
-def _push_directory_context(directory_path: str):
+def _push_directory_context(directory_path: str) -> Generator[None]:
     """Temporarily set the root output directory for the current invocation."""
     token = _directory_context.set(directory_path)
     try:
@@ -114,12 +119,12 @@ def _push_directory_context(directory_path: str):
         _directory_context.reset(token)
 
 
-def directory_context(directory_path: str):
+def directory_context(directory_path: str) -> AbstractContextManager[None]:
     """Public convenience wrapper around ``_push_directory_context``."""
     return _push_directory_context(directory_path)
 
 
-def tracked(node_type: NodeType):
+def tracked(node_type: NodeType) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator factory that wraps a function to track its execution context.
 
@@ -130,7 +135,7 @@ def tracked(node_type: NodeType):
     (_quacc_ctx, _quacc_dir) which are extracted and restored before execution.
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         # Preserve the true original (pre-decoration) function so that
         # strip_decorator() can fully unwrap back to the user's code.
         original = getattr(func, "original", func)
@@ -138,13 +143,13 @@ def tracked(node_type: NodeType):
         if asyncio.iscoroutinefunction(func):
 
             @wraps(func)
-            async def wrapper(*args, **kwargs):
+            async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
                 return await _tracked_call(func, node_type, args, kwargs)
 
         else:
 
             @wraps(func)
-            def wrapper(*args, **kwargs):
+            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                 return _tracked_call(func, node_type, args, kwargs)
 
         # Attach the original unwrapped function so it can be recovered later.
@@ -154,7 +159,12 @@ def tracked(node_type: NodeType):
     return decorator
 
 
-def _tracked_call(func, node_type, args, kwargs):
+def _tracked_call(
+    func: Callable[P, R],
+    node_type: NodeType,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> R:
     """Shared tracking logic for both sync and async tracked wrappers.
 
     For async functions, the caller must ``await`` the return value.

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -17,7 +17,7 @@ Flow = Callable[..., Any]
 Subflow = Callable[..., Any]
 
 
-def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
+def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
     """
     Decorator for individual compute jobs. This is a `#!Python @job` decorator. Think of
     each `#!Python @job`-decorated function as an individual SLURM job, if that helps.
@@ -141,7 +141,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
         # See https://github.com/dask/dask/issues/10733
 
         @wraps(_func)
-        def wrapper(*f_args, **f_kwargs):
+        def wrapper(*f_args: object, **f_kwargs: object) -> object:
             return _func(*f_args, **f_kwargs)
 
         return Delayed_(delayed(wrapper, **kwargs))
@@ -164,7 +164,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
         if settings.PREFECT_AUTO_SUBMIT:
 
             @wraps(_func)
-            def wrapper(*f_args, **f_kwargs):
+            def wrapper(*f_args: object, **f_kwargs: object) -> object:
                 decorated = task(_func, **kwargs)
                 return decorated.submit(*f_args, **f_kwargs)
 
@@ -181,7 +181,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
         )
 
         @wraps(_ray_target)
-        def wrapper(*f_args, **f_kwargs):
+        def wrapper(*f_args: object, **f_kwargs: object) -> RayFuture:
             f_args = tuple(_unwrap_ray_future(a) for a in f_args)
             f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
             return RayFuture(remote_func.remote(*f_args, **f_kwargs))
@@ -192,7 +192,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs) -> Job:
         return _func
 
 
-def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
+def flow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Flow:
     """
     Decorator for workflows, which consist of at least one compute job. This is a
     `#!Python @flow` decorator.
@@ -334,7 +334,7 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs) -> Flow:
         return tracked(NodeType.FLOW)(_func)
 
 
-def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
+def subflow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Subflow:
     """
     Decorator for (dynamic) sub-workflows. This is a `#!Python @subflow` decorator.
 
@@ -508,7 +508,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
         # See https://github.com/dask/dask/issues/10733
 
         @wraps(_func)
-        def wrapper(*f_args, **f_kwargs):
+        def wrapper(*f_args: object, **f_kwargs: object) -> object:
             with worker_client() as client:
                 futures = client.compute(_func(*f_args, **f_kwargs))
                 return client.gather(futures)
@@ -534,7 +534,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
         target_func = _wrap_ray_target(_wrap_partial_for_ray(_func), ray)
 
         @wraps(target_func)
-        def _ray_subflow_target(*f_args, **f_kwargs):
+        def _ray_subflow_target(*f_args: object, **f_kwargs: object) -> object:
             return _resolve_ray_subflow_result(target_func(*f_args, **f_kwargs), ray)
 
         remote_subflow = (
@@ -544,7 +544,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs) -> Subflow:
         )
 
         @wraps(target_func)
-        def wrapper(*f_args, **f_kwargs):
+        def wrapper(*f_args: object, **f_kwargs: object) -> RayFuture:
             f_args = tuple(_unwrap_ray_future(a) for a in f_args)
             f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
             return RayFuture(remote_subflow.remote(*f_args, **f_kwargs))
@@ -582,11 +582,11 @@ def _get_parsl_wrapped_func(
     )
 
     def wrapper(
-        *f_args,
-        walltime=walltime,  # noqa: ARG001
-        parsl_resource_specification=parsl_resource_specification,  # noqa: ARG001
-        **f_kwargs,
-    ):
+        *f_args: object,
+        walltime: object = walltime,  # noqa: ARG001
+        parsl_resource_specification: object = parsl_resource_specification,  # noqa: ARG001
+        **f_kwargs: object,
+    ) -> object:
         return func(*f_args, **f_kwargs)
 
     if getattr(func, "_changed", False):
@@ -597,7 +597,7 @@ def _get_parsl_wrapped_func(
 
 
 def _get_prefect_wrapped_flow(
-    _func: Callable, settings: QuaccSettings, **kwargs
+    _func: Callable, settings: QuaccSettings, **kwargs: object
 ) -> Callable:
     from prefect import flow as prefect_flow
     from prefect.futures import resolve_futures_to_results
@@ -607,7 +607,7 @@ def _get_prefect_wrapped_flow(
         if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
             @wraps(_func)
-            async def async_wrapper(*f_args, **f_kwargs):
+            async def async_wrapper(*f_args: object, **f_kwargs: object) -> object:
                 result = await _func(*f_args, **f_kwargs)
                 return resolve_futures_to_results(result)
 
@@ -619,7 +619,7 @@ def _get_prefect_wrapped_flow(
         if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
             @wraps(_func)
-            def sync_wrapper(*f_args, **f_kwargs):
+            def sync_wrapper(*f_args: object, **f_kwargs: object) -> object:
                 result = _func(*f_args, **f_kwargs)
                 return resolve_futures_to_results(result)
 
@@ -628,7 +628,9 @@ def _get_prefect_wrapped_flow(
             return prefect_flow(_func, validate_parameters=False, **kwargs)
 
 
-def _get_jobflow_wrapped_func(method=None, **job_kwargs):
+def _get_jobflow_wrapped_func(
+    method: Callable | None = None, **job_kwargs: object
+) -> Callable:
     from jobflow import job as jf_job
 
     return jf_job(method, **job_kwargs)
@@ -647,13 +649,13 @@ class Delayed_:
 
     __slots__ = ("func",)
 
-    def __init__(self, func):
+    def __init__(self, func: Callable) -> None:
         self.func = func
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[type[Delayed_], tuple[Callable]]:
         return (Delayed_, (self.func,))
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         return self.func(*args, **kwargs)
 
 
@@ -669,7 +671,7 @@ class RayFuture:
     def __init__(self, ref: Any) -> None:
         self._ref = ref
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[type[RayFuture], tuple[Any]]:
         return (RayFuture, (self._ref,))
 
     def __getitem__(self, key: Any) -> RayFuture:
@@ -709,7 +711,7 @@ def _wrap_partial_for_ray(func: Callable) -> Callable:
     inner = func
 
     @wraps(inner.func)
-    def _real(*f_args, **f_kwargs):
+    def _real(*f_args: object, **f_kwargs: object) -> object:
         return inner(*f_args, **f_kwargs)
 
     return _real
@@ -739,7 +741,7 @@ def _wrap_ray_target(func: Callable, ray_mod: Any) -> Callable:
     """Resolve nested Ray references before invoking a remote function."""
 
     @wraps(func)
-    def wrapper(*f_args, **f_kwargs):
+    def wrapper(*f_args: object, **f_kwargs: object) -> object:
         f_args = tuple(_resolve_ray_value(a, ray_mod) for a in f_args)
         f_kwargs = {k: _resolve_ray_value(v, ray_mod) for k, v in f_kwargs.items()}
         return func(*f_args, **f_kwargs)

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -17,7 +17,7 @@ Flow = Callable[..., Any]
 Subflow = Callable[..., Any]
 
 
-def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
+def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
     """
     Decorator for individual compute jobs. This is a `#!Python @job` decorator. Think of
     each `#!Python @job`-decorated function as an individual SLURM job, if that helps.
@@ -141,7 +141,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
         # See https://github.com/dask/dask/issues/10733
 
         @wraps(_func)
-        def wrapper(*f_args: object, **f_kwargs: object) -> object:
+        def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
             return _func(*f_args, **f_kwargs)
 
         return Delayed_(delayed(wrapper, **kwargs))
@@ -164,7 +164,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
         if settings.PREFECT_AUTO_SUBMIT:
 
             @wraps(_func)
-            def wrapper(*f_args: object, **f_kwargs: object) -> object:
+            def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
                 decorated = task(_func, **kwargs)
                 return decorated.submit(*f_args, **f_kwargs)
 
@@ -181,7 +181,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
         )
 
         @wraps(_ray_target)
-        def wrapper(*f_args: object, **f_kwargs: object) -> RayFuture:
+        def wrapper(*f_args: Any, **f_kwargs: Any) -> RayFuture:
             f_args = tuple(_unwrap_ray_future(a) for a in f_args)
             f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
             return RayFuture(remote_func.remote(*f_args, **f_kwargs))
@@ -192,7 +192,7 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: object) -> Job:
         return _func
 
 
-def flow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Flow:
+def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
     """
     Decorator for workflows, which consist of at least one compute job. This is a
     `#!Python @flow` decorator.
@@ -334,7 +334,7 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Flow:
         return tracked(NodeType.FLOW)(_func)
 
 
-def subflow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Subflow:
+def subflow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Subflow:
     """
     Decorator for (dynamic) sub-workflows. This is a `#!Python @subflow` decorator.
 
@@ -508,7 +508,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Subflo
         # See https://github.com/dask/dask/issues/10733
 
         @wraps(_func)
-        def wrapper(*f_args: object, **f_kwargs: object) -> object:
+        def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
             with worker_client() as client:
                 futures = client.compute(_func(*f_args, **f_kwargs))
                 return client.gather(futures)
@@ -534,7 +534,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Subflo
         target_func = _wrap_ray_target(_wrap_partial_for_ray(_func), ray)
 
         @wraps(target_func)
-        def _ray_subflow_target(*f_args: object, **f_kwargs: object) -> object:
+        def _ray_subflow_target(*f_args: Any, **f_kwargs: Any) -> Any:
             return _resolve_ray_subflow_result(target_func(*f_args, **f_kwargs), ray)
 
         remote_subflow = (
@@ -544,7 +544,7 @@ def subflow(_func: Callable[..., Any] | None = None, **kwargs: object) -> Subflo
         )
 
         @wraps(target_func)
-        def wrapper(*f_args: object, **f_kwargs: object) -> RayFuture:
+        def wrapper(*f_args: Any, **f_kwargs: Any) -> RayFuture:
             f_args = tuple(_unwrap_ray_future(a) for a in f_args)
             f_kwargs = {k: _unwrap_ray_future(v) for k, v in f_kwargs.items()}
             return RayFuture(remote_subflow.remote(*f_args, **f_kwargs))
@@ -585,7 +585,7 @@ def _get_parsl_wrapped_func(
         *f_args: object,
         walltime: object = walltime,  # noqa: ARG001
         parsl_resource_specification: object = parsl_resource_specification,  # noqa: ARG001
-        **f_kwargs: object,
+        **f_kwargs: Any,
     ) -> object:
         return func(*f_args, **f_kwargs)
 
@@ -597,7 +597,7 @@ def _get_parsl_wrapped_func(
 
 
 def _get_prefect_wrapped_flow(
-    _func: Callable, settings: QuaccSettings, **kwargs: object
+    _func: Callable, settings: QuaccSettings, **kwargs: Any
 ) -> Callable:
     from prefect import flow as prefect_flow
     from prefect.futures import resolve_futures_to_results
@@ -607,7 +607,7 @@ def _get_prefect_wrapped_flow(
         if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
             @wraps(_func)
-            async def async_wrapper(*f_args: object, **f_kwargs: object) -> object:
+            async def async_wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
                 result = await _func(*f_args, **f_kwargs)
                 return resolve_futures_to_results(result)
 
@@ -619,7 +619,7 @@ def _get_prefect_wrapped_flow(
         if settings.PREFECT_RESOLVE_FLOW_RESULTS:
 
             @wraps(_func)
-            def sync_wrapper(*f_args: object, **f_kwargs: object) -> object:
+            def sync_wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
                 result = _func(*f_args, **f_kwargs)
                 return resolve_futures_to_results(result)
 
@@ -629,7 +629,7 @@ def _get_prefect_wrapped_flow(
 
 
 def _get_jobflow_wrapped_func(
-    method: Callable | None = None, **job_kwargs: object
+    method: Callable | None = None, **job_kwargs: Any
 ) -> Callable:
     from jobflow import job as jf_job
 
@@ -655,7 +655,7 @@ class Delayed_:
     def __reduce__(self) -> tuple[type[Delayed_], tuple[Callable]]:
         return (Delayed_, (self.func,))
 
-    def __call__(self, *args: object, **kwargs: object) -> object:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.func(*args, **kwargs)
 
 
@@ -711,7 +711,7 @@ def _wrap_partial_for_ray(func: Callable) -> Callable:
     inner = func
 
     @wraps(inner.func)
-    def _real(*f_args: object, **f_kwargs: object) -> object:
+    def _real(*f_args: Any, **f_kwargs: Any) -> Any:
         return inner(*f_args, **f_kwargs)
 
     return _real
@@ -741,7 +741,7 @@ def _wrap_ray_target(func: Callable, ray_mod: Any) -> Callable:
     """Resolve nested Ray references before invoking a remote function."""
 
     @wraps(func)
-    def wrapper(*f_args: object, **f_kwargs: object) -> object:
+    def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
         f_args = tuple(_resolve_ray_value(a, ray_mod) for a in f_args)
         f_kwargs = {k: _resolve_ray_value(v, ray_mod) for k, v in f_kwargs.items()}
         return func(*f_args, **f_kwargs)

--- a/src/quacc/wflow_tools/job_patterns.py
+++ b/src/quacc/wflow_tools/job_patterns.py
@@ -110,7 +110,9 @@ def map_partitioned_lists(
 
 @job
 def map_partition(
-    func: Callable, unmapped_kwargs: dict[str, Any] | None = None, **mapped_kwargs
+    func: Callable,
+    unmapped_kwargs: dict[str, Any] | None = None,
+    **mapped_kwargs: list[Any],
 ) -> list[Any]:
     """
     Job to apply a function to each set of elements in mapped_kwargs.
@@ -134,7 +136,9 @@ def map_partition(
 
 
 def kwarg_map(
-    func: Callable, unmapped_kwargs: dict[str, Any] | None = None, **mapped_kwargs
+    func: Callable,
+    unmapped_kwargs: dict[str, Any] | None = None,
+    **mapped_kwargs: list[Any],
 ) -> list[Any]:
     """
     A helper function for when you want to construct a chain of objects with individual arguments for each one.  Can


### PR DESCRIPTION
## Summary

- add missing annotations across workflow wrappers, settings helpers, calculators, atom utilities, and recipe keyword-forwarding interfaces
- preserve wrapped callable signatures with `ParamSpec` and `TypeVar`
- correct context-manager, Pydantic validator, constructor, and comparison-helper annotations
- annotate workflow-engine and recipe `*args`/`**kwargs` boundaries without changing runtime behavior
- ignore Ruff `ANN401` project-wide for intentionally dynamic third-party interfaces

## Impact

This removes every Ruff missing-annotation finding (`ANN001`, `ANN002`, `ANN003`, `ANN201`, `ANN202`, and `ANN204`) from `src/quacc`. Dynamic `Any` boundaries such as CLI values and third-party Ray/workflow APIs remain explicitly typed and are exempted via the project-level `ANN401` ignore.

## Validation

- `ruff check src/quacc` — passed
- `python -m compileall -q src/quacc` — passed
- focused workflow, recipe, and calculator tests — 53 passed, 18 skipped
- prior focused settings and atom utility tests — 17 passed, 1 skipped
- `git diff --check` — passed