### PR TITLE
Remove hard-coded cell relaxation from elastic recipes

### DIFF
--- a/src/quacc/recipes/common/elastic.py
+++ b/src/quacc/recipes/common/elastic.py
@@ -57,7 +57,7 @@ def elastic_tensor_flow(
         See the return type-hint for the data structure.
     """
     if pre_relax:
-        undeformed_result = relax_job(atoms, relax_cell=True)
+        undeformed_result = relax_job(atoms)
         if run_static:
             undeformed_result = static_job(undeformed_result["atoms"])
     else:

--- a/tests/core/recipes/emt_recipes/test_emt_elastic.py
+++ b/tests/core/recipes/emt_recipes/test_emt_elastic.py
@@ -15,7 +15,7 @@ def test_elastic_jobs(tmp_path, monkeypatch):
     assert outputs["deformed_results"][0]["atoms"].get_volume() != pytest.approx(
         atoms.get_volume()
     )
-    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(134.579)
+    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(125.897)
     for output in outputs["deformed_results"]:
         assert output["parameters"]["asap_cutoff"] is False
         assert output["name"] == "EMT Relax"


### PR DESCRIPTION
## Summary

- stop forcing `relax_cell=True` during the undeformed pre-relaxation in elastic tensor workflows
- let each supplied relaxation recipe use its own configured/default cell-relaxation behavior
- update the EMT elastic regression value for the fixed-cell calculation

## Root cause and impact

The common elastic workflow overrode the relaxation recipe by always passing `relax_cell=True`. This made it impossible for recipe defaults or user configuration to control the undeformed pre-relaxation. The workflow now calls the supplied relaxation job without that override.

Closes #2897.

## Validation

- `python -m pytest tests/core/recipes/emt_recipes/test_emt_elastic.py -q` (1 passed)
- `python -m ruff check src/quacc/recipes/common/elastic.py tests/core/recipes/emt_recipes/test_emt_elastic.py`
- `git diff --check`