### PR TITLE
Replace customize_funcs with a mapping-based API

### DIFF
--- a/docs/dev/recipes/flows.md
+++ b/docs/dev/recipes/flows.md
@@ -16,7 +16,7 @@ A simple, representative flow can be found in [quacc.recipes.vasp.mp24.mp_metagg
 
 !!! Note
 
-    All `#!Python @flow`-decorated functions distributed with quacc must allow for the individual job parameters and decorators to be updated by the user, which is typically done via the [quacc.wflow_tools.customizers.customize_funcs][] function. Refer to the example above for details.
+    All `#!Python @flow`-decorated functions distributed with quacc must allow for the individual job parameters and decorators to be updated by the user, which is typically done via the [quacc.wflow_tools.customizers.customize_jobs][] function. Refer to the example above for details.
 
 ## Dynamic Flows
 

--- a/src/quacc/recipes/emt/defects.py
+++ b/src/quacc/recipes/emt/defects.py
@@ -11,7 +11,7 @@ from quacc import flow
 from quacc.recipes.common.defects import bulk_to_defects_subflow
 from quacc.recipes.emt.core import relax_job, static_job
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_pmg_defects = bool(find_spec("pymatgen.analysis.defects"))
 has_shakenbreak = bool(find_spec("shakenbreak"))
@@ -100,12 +100,11 @@ def bulk_to_defects_flow(
         or [quacc.schemas.ase.Summarize.opt][].
         See the return type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
     make_defects_kwargs = recursive_dict_merge(
         make_defects_kwargs, {"defect_gen": defect_gen, "defect_charge": defect_charge}
     )

--- a/src/quacc/recipes/emt/elastic.py
+++ b/src/quacc/recipes/emt/elastic.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from quacc import flow
 from quacc.recipes.common.elastic import elastic_tensor_flow as elastic_tensor_flow_
 from quacc.recipes.emt.core import relax_job, static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -72,12 +72,11 @@ def elastic_tensor_flow(
     ElasticSchema
         See the return type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )  # type: ignore
+    ).values()
 
     return elastic_tensor_flow_(
         atoms=atoms,

--- a/src/quacc/recipes/emt/phonons.py
+++ b/src/quacc/recipes/emt/phonons.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from quacc import flow
 from quacc.recipes.common.phonons import phonon_subflow
 from quacc.recipes.emt.core import static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -88,13 +88,12 @@ def phonon_flow(
         Dictionary of results from [quacc.schemas.phonons.summarize_phonopy][].
         See the return type-hint for the data structure.
     """
-    static_job_ = customize_funcs(
-        ["static_job"],
-        [static_job],
+    static_job_ = customize_jobs(
+        {"static_job": static_job},
         param_defaults=None,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    )["static_job"]
 
     return phonon_subflow(
         atoms,

--- a/src/quacc/recipes/emt/slabs.py
+++ b/src/quacc/recipes/emt/slabs.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from quacc import flow
 from quacc.recipes.common.slabs import bulk_to_slabs_subflow
 from quacc.recipes.emt.core import relax_job, static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -61,12 +61,11 @@ def bulk_to_slabs_flow(
         [OptSchema][quacc.schemas.ase.Summarize.opt] for each slab.
         See the return type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     return bulk_to_slabs_subflow(
         atoms,

--- a/src/quacc/recipes/espresso/bands.py
+++ b/src/quacc/recipes/espresso/bands.py
@@ -15,7 +15,7 @@ from quacc import flow, job
 from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso._base import run_and_summarize
 from quacc.utils.kpts import convert_pmg_kpts
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -275,12 +275,15 @@ def bands_flow(
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
     """
-    (bands_pw_job_, bands_pp_job_, fermi_surface_job_) = customize_funcs(
-        ["bands_pw_job", "bands_pp_job", "fermi_surface_job"],
-        [bands_pw_job, bands_pp_job, fermi_surface_job],
+    (bands_pw_job_, bands_pp_job_, fermi_surface_job_) = customize_jobs(
+        {
+            "bands_pw_job": bands_pw_job,
+            "bands_pp_job": bands_pp_job,
+            "fermi_surface_job": fermi_surface_job,
+        },
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     bands_results = bands_pw_job_(
         atoms,

--- a/src/quacc/recipes/espresso/dos.py
+++ b/src/quacc/recipes/espresso/dos.py
@@ -9,7 +9,7 @@ from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.recipes.espresso._base import run_and_summarize
 from quacc.recipes.espresso.core import non_scf_job, static_job
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -182,13 +182,12 @@ def dos_flow(
         ),
     }
 
-    static_job_, non_scf_job_, dos_job_ = customize_funcs(
-        ["static_job", "non_scf_job", "dos_job"],
-        [static_job, non_scf_job, dos_job],
+    static_job_, non_scf_job_, dos_job_ = customize_jobs(
+        {"static_job": static_job, "non_scf_job": non_scf_job, "dos_job": dos_job},
         param_defaults=default_job_params,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     static_results = static_job_(atoms)
     static_results_dir = static_results["dir_name"]
@@ -259,13 +258,16 @@ def projwfc_flow(
             },
         ),
     }
-    static_job_, non_scf_job_, projwfc_job_ = customize_funcs(
-        ["static_job", "non_scf_job", "projwfc_job"],
-        [static_job, non_scf_job, projwfc_job],
+    static_job_, non_scf_job_, projwfc_job_ = customize_jobs(
+        {
+            "static_job": static_job,
+            "non_scf_job": non_scf_job,
+            "projwfc_job": projwfc_job,
+        },
         param_defaults=default_job_params,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     static_results = static_job_(atoms)
     static_results_dir = static_results["dir_name"]

--- a/src/quacc/recipes/espresso/phonons.py
+++ b/src/quacc/recipes/espresso/phonons.py
@@ -19,7 +19,7 @@ from quacc.calculators.espresso.espresso import EspressoTemplate
 from quacc.calculators.espresso.utils import grid_copy_files, grid_prepare_repr
 from quacc.recipes.espresso._base import run_and_summarize
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections import UserDict
@@ -266,13 +266,12 @@ def phonon_dos_flow(
             "input_data": {"input": {"dos": True, "nk1": 32, "nk2": 32, "nk3": 32}}
         },
     }
-    ph_job, fc_job, dos_job = customize_funcs(
-        ["phonon_job", "q2r_job", "matdyn_job"],
-        [phonon_job, q2r_job, matdyn_job],
+    ph_job, fc_job, dos_job = customize_jobs(
+        {"phonon_job": phonon_job, "q2r_job": q2r_job, "matdyn_job": matdyn_job},
         param_defaults=default_job_params,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     ph_job_results = ph_job(copy_files=copy_files, prev_outdir=prev_outdir)
     fc_job_results = fc_job([{"source": ph_job_results["dir_name"], "filenames": "*"}])
@@ -462,13 +461,12 @@ def grid_phonon_flow(
             job_params.get("ph_job"),
         ),
     }
-    ph_init_job, ph_job, ph_recover_job = customize_funcs(
-        ["ph_init_job", "ph_job", "ph_recover_job"],
-        [phonon_job, phonon_job, phonon_job],
+    ph_init_job, ph_job, ph_recover_job = customize_jobs(
+        {"ph_init_job": phonon_job, "ph_job": phonon_job, "ph_recover_job": phonon_job},
         param_defaults=default_job_params,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     ph_init_job_results = ph_init_job(copy_files=copy_files, prev_outdir=prev_outdir)
     grid_results = _grid_phonon_subflow(

--- a/src/quacc/recipes/mlip/elastic.py
+++ b/src/quacc/recipes/mlip/elastic.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from quacc import flow
 from quacc.recipes.common.elastic import elastic_tensor_flow as elastic_tensor_flow_
 from quacc.recipes.mlip.core import relax_job, static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -72,12 +72,11 @@ def elastic_tensor_flow(
     ElasticSchema
         See the return type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )  # type: ignore
+    ).values()
 
     return elastic_tensor_flow_(
         atoms=atoms,

--- a/src/quacc/recipes/mlip/phonons.py
+++ b/src/quacc/recipes/mlip/phonons.py
@@ -10,7 +10,7 @@ from monty.dev import requires
 from quacc import flow
 from quacc.recipes.common.phonons import phonon_subflow
 from quacc.recipes.mlip.core import static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_phonopy = bool(find_spec("phonopy"))
 has_seekpath = bool(find_spec("seekpath"))
@@ -94,9 +94,9 @@ def phonon_flow(
         Dictionary of results from [quacc.schemas.phonons.summarize_phonopy][].
         See the type-hint for the data structure.
     """
-    static_job_ = customize_funcs(
-        ["static_job"], [static_job], param_swaps=job_params, decorators=job_decorators
-    )
+    static_job_ = customize_jobs(
+        {"static_job": static_job}, param_swaps=job_params, decorators=job_decorators
+    )["static_job"]
 
     return phonon_subflow(
         atoms,

--- a/src/quacc/recipes/tblite/phonons.py
+++ b/src/quacc/recipes/tblite/phonons.py
@@ -10,7 +10,7 @@ from monty.dev import requires
 from quacc import flow
 from quacc.recipes.common.phonons import phonon_subflow
 from quacc.recipes.tblite.core import static_job
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_tblite = bool(find_spec("tblite"))
 has_phonopy = bool(find_spec("phonopy"))
@@ -96,13 +96,12 @@ def phonon_flow(
         Dictionary of results from [quacc.schemas.phonons.summarize_phonopy][].
         See the type-hint for the data structure.
     """
-    static_job_ = customize_funcs(
-        ["static_job"],
-        [static_job],
+    static_job_ = customize_jobs(
+        {"static_job": static_job},
         param_defaults=None,
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    )["static_job"]
 
     return phonon_subflow(
         atoms,

--- a/src/quacc/recipes/vasp/matpes.py
+++ b/src/quacc/recipes/vasp/matpes.py
@@ -17,7 +17,7 @@ from monty.dev import requires
 from quacc import flow, job
 from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
@@ -158,16 +158,15 @@ def matpes_static_flow(
     MatPESStaticFlowSchema
         Dictionary containing the PBE and r2SCAN results.
     """
-    pbe_static_job, r2scan_static_job = customize_funcs(
-        ["pbe_static_job", "r2scan_static_job"],
-        [matpes_static_job, matpes_static_job],
+    pbe_static_job, r2scan_static_job = customize_jobs(
+        {"pbe_static_job": matpes_static_job, "r2scan_static_job": matpes_static_job},
         param_defaults={
             "pbe_static_job": {"level": "PBE"},
             "r2scan_static_job": {"level": "r2SCAN"},
         },
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     pbe_results = pbe_static_job(atoms)
     r2scan_results = r2scan_static_job(

--- a/src/quacc/recipes/vasp/mof_off.py
+++ b/src/quacc/recipes/vasp/mof_off.py
@@ -13,7 +13,7 @@ from monty.dev import requires
 from quacc import flow, job
 from quacc.recipes.vasp.matpes import matpes_static_job
 from quacc.utils.dicts import recursive_dict_merge
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
@@ -119,16 +119,15 @@ def mof_off_static_flow(
     MOFOffStaticFlowSchema
         Dictionary containing the PBE and r2SCAN results.
     """
-    pbe_static_job, r2scan_static_job = customize_funcs(
-        ["pbe_static_job", "r2scan_static_job"],
-        [mof_off_static_job, mof_off_static_job],
+    pbe_static_job, r2scan_static_job = customize_jobs(
+        {"pbe_static_job": mof_off_static_job, "r2scan_static_job": mof_off_static_job},
         param_defaults={
             "pbe_static_job": {"level": "PBE", "dispersion": dispersion},
             "r2scan_static_job": {"level": "r2SCAN", "dispersion": dispersion},
         },
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     pbe_results = pbe_static_job(atoms)
     r2scan_results = r2scan_static_job(

--- a/src/quacc/recipes/vasp/mp24.py
+++ b/src/quacc/recipes/vasp/mp24.py
@@ -10,7 +10,7 @@ from monty.dev import requires
 from quacc import flow, job
 from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
@@ -202,12 +202,15 @@ def mp_metagga_relax_flow(
     MPMetaGGARelaxFlowSchema
         Dictionary of results. See the type-hint for the data structure.
     """
-    (mp_prerelax_job_, mp_metagga_relax_job_, mp_metagga_static_job_) = customize_funcs(
-        ["mp_prerelax_job", "mp_metagga_relax_job", "mp_metagga_static_job"],
-        [mp_prerelax_job, mp_metagga_relax_job, mp_metagga_static_job],
+    (mp_prerelax_job_, mp_metagga_relax_job_, mp_metagga_static_job_) = customize_jobs(
+        {
+            "mp_prerelax_job": mp_prerelax_job,
+            "mp_metagga_relax_job": mp_metagga_relax_job,
+            "mp_metagga_static_job": mp_metagga_static_job,
+        },
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     # Run the prerelax
     prerelax_results = mp_prerelax_job_(atoms)

--- a/src/quacc/recipes/vasp/mp_legacy.py
+++ b/src/quacc/recipes/vasp/mp_legacy.py
@@ -10,7 +10,7 @@ from monty.dev import requires
 from quacc import flow, job
 from quacc.calculators.vasp.params import MPtoASEConverter
 from quacc.recipes.vasp._base import run_and_summarize
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 has_atomate2 = bool(find_spec("atomate2"))
 
@@ -156,12 +156,11 @@ def mp_gga_relax_flow(
     MPGGARelaxFlowSchema
         Dictionary of results. See the type-hint for the data structure.
     """
-    (mp_gga_relax_job_, mp_gga_static_job_) = customize_funcs(
-        ["mp_gga_relax_job", "mp_gga_static_job"],
-        [mp_gga_relax_job, mp_gga_static_job],
+    (mp_gga_relax_job_, mp_gga_static_job_) = customize_jobs(
+        {"mp_gga_relax_job": mp_gga_relax_job, "mp_gga_static_job": mp_gga_static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     # Run the relax
     relax_results = mp_gga_relax_job_(atoms)

--- a/src/quacc/recipes/vasp/slabs.py
+++ b/src/quacc/recipes/vasp/slabs.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from quacc import flow, job
 from quacc.recipes.common.slabs import bulk_to_slabs_subflow, slab_to_ads_subflow
 from quacc.recipes.vasp._base import run_and_summarize
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -168,12 +168,11 @@ def bulk_to_slabs_flow(
         List of dictionary results from [quacc.schemas.vasp.VaspSummarize.run][].
         See the type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     return bulk_to_slabs_subflow(
         atoms,
@@ -228,12 +227,11 @@ def slab_to_ads_flow(
         List of dictionaries of results from [quacc.schemas.vasp.VaspSummarize.run][].
         See the type-hint for the data structure.
     """
-    relax_job_, static_job_ = customize_funcs(
-        ["relax_job", "static_job"],
-        [relax_job, static_job],
+    relax_job_, static_job_ = customize_jobs(
+        {"relax_job": relax_job, "static_job": static_job},
         param_swaps=job_params,
         decorators=job_decorators,
-    )
+    ).values()
 
     return slab_to_ads_subflow(
         slab,

--- a/src/quacc/wflow_tools/customizers.py
+++ b/src/quacc/wflow_tools/customizers.py
@@ -150,70 +150,43 @@ def update_parameters(
     return partial_fn
 
 
-def customize_funcs(
-    names: list[str] | str,
-    funcs: list[Callable] | Callable,
+def customize_jobs(
+    jobs: dict[str, Callable],
     param_defaults: dict[str, dict[str, Any]] | None = None,
     param_swaps: dict[str, dict[str, Any]] | None = None,
     decorators: dict[str, Callable | None] | None = None,
-) -> tuple[Callable, ...] | Callable:
-    """
-    Customize a set of functions with decorators and common parameters.
+) -> dict[str, Callable]:
+    """Customize a mapping of workflow jobs.
 
-    Parameters
-    ----------
-    names
-        The names of the functions to customize, in the order they should be returned.
-    funcs
-        The functions to customize, in the order they are described in `names`.
-    param_defaults
-        Default parameters to apply to each function. The keys of this dictionary correspond
-        to the strings in `names`. If the key `"all"` is present, it will be applied to all
-        functions. If the value is `None`, no custom parameters will be applied to that function.
-    param_swaps
-        User-overrides of parameters to apply to each function. The keys of this dictionary correspond
-        to the strings in `names`. If the key `"all"` is present, it will be applied to all
-        functions. If the value is `None`, no custom parameters will be applied to that function.
-    decorators
-        Custom decorators to apply to each function. The keys of this dictionary correspond
-        to the strings in `names`. If the key `"all"` is present, it will be applied to all
-        functions. If a value is `None`, no decorator will be applied that function.
-
-    Returns
-    -------
-    tuple[Callable, ...] | Callable
-        The customized functions, returned in the same order as provided in `funcs`.
+    The keys identify jobs in ``param_defaults``, ``param_swaps``, and
+    ``decorators``. The returned mapping preserves the input order.
     """
     parameters = recursive_dict_merge(param_defaults, param_swaps)
     decorators = decorators or {}
-    updated_funcs = []
+    names = list(jobs)
 
-    if not isinstance(names, list | tuple):
-        names = [names]
-    if not isinstance(funcs, list | tuple):
-        funcs = [funcs]
-
-    if "all" in names:
+    if "all" in jobs:
         raise ValueError("Invalid function name: 'all' is a reserved name.")
-    if bad_decorator_keys := [k for k in decorators if k not in names and k != "all"]:
+    if bad_decorator_keys := [k for k in decorators if k not in jobs and k != "all"]:
         raise ValueError(
             f"Invalid decorator keys: {bad_decorator_keys}. Valid keys are: {names}"
         )
-    if bad_parameter_keys := [k for k in parameters if k not in names and k != "all"]:
+    if bad_parameter_keys := [k for k in parameters if k not in jobs and k != "all"]:
         raise ValueError(
             f"Invalid parameter keys: {bad_parameter_keys}. Valid keys are: {names}"
         )
 
-    for i, func in enumerate(funcs):
+    updated_jobs = {}
+    for name, func in jobs.items():
         func_ = deepcopy(func)
-        if decorator := decorators.get("all"):
-            func_ = redecorate(func_, decorator)
-        if decorator := decorators.get(names[i]):
-            func_ = redecorate(func_, decorator)
+        if "all" in decorators:
+            func_ = redecorate(func_, decorators["all"])
+        if name in decorators:
+            func_ = redecorate(func_, decorators[name])
         if params := parameters.get("all"):
             func_ = update_parameters(func_, params)
-        if params := parameters.get(names[i]):
+        if params := parameters.get(name):
             func_ = update_parameters(func_, params)
-        updated_funcs.append(func_)
+        updated_jobs[name] = func_
 
-    return updated_funcs[0] if len(updated_funcs) == 1 else tuple(updated_funcs)
+    return updated_jobs

--- a/src/quacc/wflow_tools/customizers.py
+++ b/src/quacc/wflow_tools/customizers.py
@@ -156,10 +156,34 @@ def customize_jobs(
     param_swaps: dict[str, dict[str, Any]] | None = None,
     decorators: dict[str, Callable | None] | None = None,
 ) -> dict[str, Callable]:
-    """Customize a mapping of workflow jobs.
+    """
+    Customize a mapping of workflow jobs with decorators and common parameters.
 
-    The keys identify jobs in ``param_defaults``, ``param_swaps``, and
-    ``decorators``. The returned mapping preserves the input order.
+    Parameters
+    ----------
+    jobs
+        Mapping of job names to functions. The names are used as keys in
+        `param_defaults`, `param_swaps`, and `decorators`.
+    param_defaults
+        Default parameters to apply to each job. The keys of this dictionary
+        correspond to the keys in `jobs`. If the key `"all"` is present, its
+        parameters are applied to every job before job-specific parameters.
+        If the value is `None`, no default parameters are applied to that job.
+    param_swaps
+        User overrides of parameters to apply to each job. The keys of this
+        dictionary correspond to the keys in `jobs`. If the key `"all"` is
+        present, its parameters are applied to every job before job-specific
+        parameters. If the value is `None`, no parameters are applied to that job.
+    decorators
+        Custom decorators to apply to each job. The keys of this dictionary
+        correspond to the keys in `jobs`. If the key `"all"` is present, its
+        decorator is applied to every job before job-specific decorators. A value
+        of `None` strips the existing decorator from that job.
+
+    Returns
+    -------
+    dict[str, Callable]
+        Mapping of customized jobs in the same order as `jobs`.
     """
     parameters = recursive_dict_merge(param_defaults, param_swaps)
     decorators = decorators or {}

--- a/tests/core/wflow/test_customizers.py
+++ b/tests/core/wflow/test_customizers.py
@@ -5,7 +5,28 @@ from types import SimpleNamespace
 import pytest
 
 from quacc import job
-from quacc.wflow_tools.customizers import customize_funcs, update_parameters
+from quacc.wflow_tools.customizers import customize_jobs, update_parameters
+
+
+def test_customize_jobs():
+    def add(a, b=1):
+        return a + b
+
+    def mult(a, b=2):
+        return a * b
+
+    jobs = customize_jobs(
+        {"add": add, "mult": mult}, param_swaps={"all": {"b": 3}, "add": {"b": 4}}
+    )
+    assert list(jobs) == ["add", "mult"]
+    assert jobs["add"](1) == 5
+    assert jobs["mult"](2) == 6
+
+    with pytest.raises(ValueError, match="Invalid parameter keys"):
+        customize_jobs({"add": add}, param_swaps={"bad": {"b": 2}})
+
+    with pytest.raises(ValueError, match="reserved name"):
+        customize_jobs({"all": add})
 
 
 def test_basic_customizers():
@@ -15,36 +36,35 @@ def test_basic_customizers():
     def mult(a, b=1, c=2, d=2):
         return a * b * c * d
 
-    add_, mult_ = customize_funcs(
-        ["add", "mult"], [add, mult], param_swaps={"add": {"b": 2}}
-    )
+    jobs = customize_jobs({"add": add, "mult": mult}, param_swaps={"add": {"b": 2}})
+    add_, mult_ = jobs.values()
     assert add_(1) == 5
     assert mult_(1) == 4
     assert add(1) == 4
     assert mult(1) == 4
 
-    add_, mult_ = customize_funcs(
-        ["add", "mult"], [add, mult], param_swaps={"add": {"b": 2}, "mult": {"b": 2}}
+    jobs = customize_jobs(
+        {"add": add, "mult": mult}, param_swaps={"add": {"b": 2}, "mult": {"b": 2}}
     )
+    add_, mult_ = jobs.values()
     assert add_(1) == 5
     assert mult_(1) == 8
     assert add(1) == 4
     assert mult(1) == 4
 
-    add_, mult_ = customize_funcs(
-        ["add", "mult"],
-        [add, mult],
+    jobs = customize_jobs(
+        {"add": add, "mult": mult},
         param_swaps={"add": {"b": 2}, "mult": {"b": 2}},
         decorators={"add": job(), "mult": job()},
     )
+    add_, mult_ = jobs.values()
     assert add_(1) == 5
     assert mult_(1) == 8
     assert add(1) == 4
     assert mult(1) == 4
 
-    add_, mult_ = customize_funcs(
-        ["add", "mult"], [add, mult], param_swaps={"all": {"b": 2}}
-    )
+    jobs = customize_jobs({"add": add, "mult": mult}, param_swaps={"all": {"b": 2}})
+    add_, mult_ = jobs.values()
     assert add_(1) == 5
     assert mult_(1) == 8
     assert add(1) == 4
@@ -54,17 +74,17 @@ def test_basic_customizers():
         ValueError,
         match=r"Invalid parameter keys: \['bad'\]. Valid keys are: \['add', 'mult']",
     ):
-        customize_funcs(["add", "mult"], [add, mult], param_swaps={"bad": {"b": 2}})
+        customize_jobs({"add": add, "mult": mult}, param_swaps={"bad": {"b": 2}})
 
     with pytest.raises(
         ValueError, match="Invalid function name: 'all' is a reserved name"
     ):
-        customize_funcs("all", [add], param_swaps={"all": {"b": 2}})
+        customize_jobs({"all": add}, param_swaps={"all": {"b": 2}})
 
     with pytest.raises(ValueError, match="Invalid decorator keys"):
-        customize_funcs("add", add, decorators={"bad": job})
+        customize_jobs({"add": add}, decorators={"bad": job})
 
-    assert customize_funcs("add", add)(1) == 4
+    assert customize_jobs({"add": add})["add"](1) == 4
 
 
 def test_update_parameters_edge_cases(monkeypatch):

--- a/tests/dask/test_customizers.py
+++ b/tests/dask/test_customizers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from dask.distributed import get_client
 
 from quacc import flow, get_settings, job, redecorate, strip_decorator, subflow
-from quacc.wflow_tools.customizers import customize_funcs, update_parameters
+from quacc.wflow_tools.customizers import customize_jobs, update_parameters
 
 client = get_client()
 
@@ -38,7 +38,7 @@ def test_strip_decorators():
     assert stripped_add3(1, 2) == 3
 
 
-def test_customize_funcs(monkeypatch, tmp_path):
+def test_customize_jobs(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
     @job
@@ -99,9 +99,9 @@ def test_change_settings_redecorate_flow(tmp_path_factory):
 
     @flow
     def write_file_flow(name="flow.txt", job_decorators=None):
-        write_file_job_ = customize_funcs(
-            ["write_file_job"], [write_file_job], decorators=job_decorators
-        )
+        write_file_job_ = customize_jobs(
+            {"write_file_job": write_file_job}, decorators=job_decorators
+        )["write_file_job"]
         return write_file_job_(name=name)
 
     # Test with redecorating a job in a flow

--- a/tests/parsl/test_customizers.py
+++ b/tests/parsl/test_customizers.py
@@ -16,7 +16,7 @@ from quacc import (
     strip_decorator,
     subflow,
 )
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 
 def test_strip_decorators():
@@ -81,9 +81,9 @@ def test_change_settings_redecorate_flow(tmp_path_factory):
 
     @flow
     def write_file_flow(name="flow.txt", job_decorators=None):
-        write_file_job_ = customize_funcs(
-            ["write_file_job"], [write_file_job], decorators=job_decorators
-        )
+        write_file_job_ = customize_jobs(
+            {"write_file_job": write_file_job}, decorators=job_decorators
+        )["write_file_job"]
         return write_file_job_(name=name)
 
     # Test with redecorating a job in a flow

--- a/tests/prefect/test_customizers.py
+++ b/tests/prefect/test_customizers.py
@@ -7,7 +7,7 @@ prefect = pytest.importorskip("prefect")
 from pathlib import Path
 
 from quacc import flow, get_settings, job, redecorate, strip_decorator, subflow
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 
 def test_strip_decorators():
@@ -63,9 +63,9 @@ def test_change_settings_redecorate_flow(tmp_path_factory):
 
     @flow
     def write_file_flow(name="flow.txt", job_decorators=None):
-        write_file_job_ = customize_funcs(
-            ["write_file_job"], [write_file_job], decorators=job_decorators
-        )
+        write_file_job_ = customize_jobs(
+            {"write_file_job": write_file_job}, decorators=job_decorators
+        )["write_file_job"]
         return write_file_job_(name=name)
 
     # Test with redecorating a job in a flow

--- a/tests/ray/test_customizers.py
+++ b/tests/ray/test_customizers.py
@@ -7,7 +7,7 @@ ray = pytest.importorskip("ray")
 from pathlib import Path
 
 from quacc import flow, get_settings, job, redecorate, strip_decorator, subflow
-from quacc.wflow_tools.customizers import customize_funcs, update_parameters
+from quacc.wflow_tools.customizers import customize_jobs, update_parameters
 
 
 def test_strip_decorators():
@@ -33,7 +33,7 @@ def test_strip_decorators():
     assert stripped_add3(1, 2) == 3
 
 
-def test_customize_funcs(monkeypatch, tmp_path):
+def test_customize_jobs(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
     @job
@@ -95,9 +95,9 @@ def test_change_settings_redecorate_flow(tmp_path_factory):
 
     @flow
     def write_file_flow(name="flow.txt", job_decorators=None):
-        write_file_job_ = customize_funcs(
-            ["write_file_job"], [write_file_job], decorators=job_decorators
-        )
+        write_file_job_ = customize_jobs(
+            {"write_file_job": write_file_job}, decorators=job_decorators
+        )["write_file_job"]
         return write_file_job_(name=name)
 
     (

--- a/tests/redun/test_customizers.py
+++ b/tests/redun/test_customizers.py
@@ -7,7 +7,7 @@ redun = pytest.importorskip("redun")
 from pathlib import Path
 
 from quacc import flow, get_settings, job, redecorate, strip_decorator, subflow
-from quacc.wflow_tools.customizers import customize_funcs
+from quacc.wflow_tools.customizers import customize_jobs
 
 
 @pytest.fixture
@@ -63,9 +63,9 @@ def test_change_settings_redecorate_flow(tmp_path_factory, scheduler):
 
     @flow
     def write_file_flow(name="flow.txt", job_decorators=None):
-        write_file_job_ = customize_funcs(
-            ["write_file_job"], [write_file_job], decorators=job_decorators
-        )
+        write_file_job_ = customize_jobs(
+            {"write_file_job": write_file_job}, decorators=job_decorators
+        )["write_file_job"]
         return write_file_job_(name=name)
 
     # Test with redecorating a job in a flow


### PR DESCRIPTION
## Summary

- replace the parallel `names`/`funcs` API with `customize_jobs({name: job})`
- return a consistently ordered job mapping instead of a callable-or-tuple union
- migrate every production recipe, workflow-engine test, and developer-doc reference
- allow explicit `None` decorator entries to reach `redecorate`, including overriding an `all` decorator

## Why

The old API required synchronized name and callable sequences and changed its return type based on the number of inputs. A mapping makes each job name inseparable from its callable and gives callers one predictable return type.

## Validation

- `python -m pytest tests/core/wflow/test_customizers.py -q --basetemp=.pytest-customizers` — 3 passed
- `python -m ruff check ...` — passed for all affected Python files
- `python -m ruff format --check ...` — passed for all affected Python files
- broader `tests/core/wflow` run — 22 passed, 4 skipped; 7 unrelated Windows path-length failures in nested-results tests