### PR TITLE
Suppress jobflow flow output warning

### DIFF
--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from logging import basicConfig
 from pathlib import Path
 from typing import TYPE_CHECKING
+from warnings import filterwarnings
 
 from ase.atoms import Atoms
 from pymatgen.io.ase import MSONAtoms
@@ -89,6 +90,14 @@ def get_settings() -> QuaccSettings:
 
 
 _settings = get_settings()
+
+if _settings.WORKFLOW_ENGINE == "jobflow":
+    filterwarnings(
+        "ignore",
+        message=r"@flow decorated function .* contains a Flow or\s*Job as an output\.",
+        category=UserWarning,
+        module=r"jobflow\.core\.flow",
+    )
 
 # Dummy value for when a default setting will be applied
 QuaccDefault = DefaultSetting()

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Any
-from warnings import catch_warnings, filterwarnings
 
 from quacc.settings import change_settings_wrap
 from quacc.wflow_tools.context import NodeType, tracked
@@ -640,20 +639,7 @@ def _get_jobflow_wrapped_func(
 def _get_jobflow_wrapped_flow(_func: Callable) -> Callable:
     from jobflow import flow as jf_flow
 
-    decorated_flow = jf_flow(_func)
-
-    @wraps(_func)
-    def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
-        with catch_warnings():
-            filterwarnings(
-                "ignore",
-                message=r"@flow decorated function .* contains a Flow or\s*Job as an output\.",
-                category=UserWarning,
-                module=r"jobflow\.core\.flow",
-            )
-            return decorated_flow(*f_args, **f_kwargs)
-
-    return wrapper
+    return jf_flow(_func)
 
 
 class Delayed_:

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Any
+from warnings import catch_warnings, filterwarnings
 
 from quacc.settings import change_settings_wrap
 from quacc.wflow_tools.context import NodeType, tracked
@@ -639,7 +640,20 @@ def _get_jobflow_wrapped_func(
 def _get_jobflow_wrapped_flow(_func: Callable) -> Callable:
     from jobflow import flow as jf_flow
 
-    return jf_flow(_func)
+    decorated_flow = jf_flow(_func)
+
+    @wraps(_func)
+    def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
+        with catch_warnings():
+            filterwarnings(
+                "ignore",
+                message=r"@flow decorated function .* contains a Flow or\s*Job as an output\.",
+                category=UserWarning,
+                module=r"jobflow\.core\.flow",
+            )
+            return decorated_flow(*f_args, **f_kwargs)
+
+    return wrapper
 
 
 class Delayed_:

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 jf = pytest.importorskip("jobflow")
@@ -63,3 +65,21 @@ def test_jobflow_decorators_args(tmp_path, monkeypatch):
     assert isinstance(mult(1, 2), jf.Job)
     assert isinstance(workflow(1, 2, 3), jf.Flow)
     assert isinstance(add_distributed([1, 2, 3], 4), jf.Job)
+
+
+def test_jobflow_flow_output_warning_is_suppressed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    @job
+    def add(a, b):
+        return a + b
+
+    @flow
+    def workflow(a, b):
+        return add(a, b)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        assert isinstance(workflow(1, 2), jf.Flow)
+
+    assert not caught_warnings

--- a/tests/jobflow/test_syntax.py
+++ b/tests/jobflow/test_syntax.py
@@ -79,7 +79,6 @@ def test_jobflow_flow_output_warning_is_suppressed(tmp_path, monkeypatch):
         return add(a, b)
 
     with warnings.catch_warnings(record=True) as caught_warnings:
-        warnings.simplefilter("always")
         assert isinstance(workflow(1, 2), jf.Flow)
 
     assert not caught_warnings


### PR DESCRIPTION
## Summary

- register a targeted jobflow warning filter once during quacc initialization
- activate the filter only when jobflow is the configured workflow engine
- add a regression test covering the warning behavior

## Why

Quacc deliberately accepts a Job or Flow returned from a quacc `@flow`. Jobflow normalizes that output but emits a warning each time, even though this is expected behavior for quacc users.

Registering the filter at initialization keeps the flow adapter unchanged while suppressing this warning throughout a jobflow-backed quacc session. The filter matches the warning text, category, and originating module so unrelated warnings remain visible.

## Validation

- `pytest tests/jobflow/test_syntax.py --basetemp .pytest_tmp` (3 passed)
- `ruff check src/quacc/__init__.py src/quacc/wflow_tools/decorators.py tests/jobflow/test_syntax.py`
- `ruff format --check src/quacc/__init__.py src/quacc/wflow_tools/decorators.py tests/jobflow/test_syntax.py`
- `git diff --check`