### PR TITLE
Preserve return types for workflow-decorated functions

### DIFF
--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 from quacc.settings import change_settings_wrap
 from quacc.wflow_tools.context import NodeType, tracked
@@ -16,16 +16,17 @@ Job = Callable[..., Any]
 Flow = Callable[..., Any]
 Subflow = Callable[..., Any]
 P = ParamSpec("P")
+R = TypeVar("R")
 
 
 @overload
-def job(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def job(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def job(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
@@ -204,13 +205,13 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
 
 
 @overload
-def flow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def flow(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def flow(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
@@ -356,13 +357,13 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
 
 
 @overload
-def subflow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def subflow(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def subflow(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def subflow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Subflow:

--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ParamSpec, overload
 
 from quacc.settings import change_settings_wrap
 from quacc.wflow_tools.context import NodeType, tracked
@@ -15,6 +15,17 @@ if TYPE_CHECKING:
 Job = Callable[..., Any]
 Flow = Callable[..., Any]
 Subflow = Callable[..., Any]
+P = ParamSpec("P")
+
+
+@overload
+def job(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+
+
+@overload
+def job(
+    _func: None = None, **kwargs: Any
+) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
 
 
 def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
@@ -192,6 +203,16 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
         return _func
 
 
+@overload
+def flow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+
+
+@overload
+def flow(
+    _func: None = None, **kwargs: Any
+) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+
+
 def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
     """
     Decorator for workflows, which consist of at least one compute job. This is a
@@ -332,6 +353,16 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
         return _get_jobflow_wrapped_flow(_func)
     else:
         return tracked(NodeType.FLOW)(_func)
+
+
+@overload
+def subflow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+
+
+@overload
+def subflow(
+    _func: None = None, **kwargs: Any
+) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
 
 
 def subflow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Subflow:


### PR DESCRIPTION
Superseded by a clean follow-up branch based on the post-#3419 `main` branch. This avoids including the already-merged commit in the comparison.