### PR TITLE
Preserve return types for workflow-decorated functions

### DIFF
--- a/src/quacc/wflow_tools/decorators.py
+++ b/src/quacc/wflow_tools/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 from quacc.settings import change_settings_wrap
 from quacc.wflow_tools.context import NodeType, tracked
@@ -16,16 +16,17 @@ Job = Callable[..., Any]
 Flow = Callable[..., Any]
 Subflow = Callable[..., Any]
 P = ParamSpec("P")
+R = TypeVar("R")
 
 
 @overload
-def job(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def job(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def job(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
@@ -204,13 +205,13 @@ def job(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Job:
 
 
 @overload
-def flow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def flow(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def flow(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
@@ -356,13 +357,13 @@ def flow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Flow:
 
 
 @overload
-def subflow(_func: Callable[P, Any], **kwargs: Any) -> Callable[P, Any]: ...
+def subflow(_func: Callable[P, R], **kwargs: Any) -> Callable[P, R]: ...
 
 
 @overload
 def subflow(
     _func: None = None, **kwargs: Any
-) -> Callable[[Callable[P, Any]], Callable[P, Any]]: ...
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def subflow(_func: Callable[..., Any] | None = None, **kwargs: Any) -> Subflow:


### PR DESCRIPTION
## Summary

- carry the decorated function's declared return type through the `@job`, `@flow`, and `@subflow` overloads
- retain concrete recipe schema types in VS Code/Pylance hover information

## Root cause

The overloads added in #3419 preserve parameters with `ParamSpec`, but still return `Callable[P, Any]`. As a result, a recipe such as `quacc.recipes.vasp.core.relax_job` exposes its argument defaults but shows `Any` instead of `VaspSchema`.

## User impact

Decorated recipes now retain their declared return type. For example, hovering over `relax_job` shows `VaspSchema`.

## Validation

- `pytest tests/core/wflow/test_decorators.py -q` — 6 passed
- `ruff check src/quacc/wflow_tools/decorators.py` — passed
- `ruff format --check src/quacc/wflow_tools/decorators.py` — passed