### PR TITLE
Automate successful Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,53 @@
+name: Dependabot auto-merge
+
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Merge current Dependabot PRs
+        uses: actions/github-script@v8
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const candidates = context.payload.workflow_run.pull_requests ?? [];
+
+            for (const candidate of candidates) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: candidate.number,
+              });
+
+              if (pullRequest.user.login !== "dependabot[bot]") {
+                core.info(`Skipping PR #${pullRequest.number}: not opened by Dependabot.`);
+                continue;
+              }
+
+              if (pullRequest.head.sha !== context.payload.workflow_run.head_sha) {
+                core.info(`Skipping PR #${pullRequest.number}: a newer commit is awaiting tests.`);
+                continue;
+              }
+
+              await exec.exec("gh", [
+                "pr",
+                "merge",
+                String(pullRequest.number),
+                "--repo",
+                `${owner}/${repo}`,
+                "--squash",
+                "--auto",
+              ]);
+            }


### PR DESCRIPTION
## What changed

Adds a GitHub Actions workflow that merges Dependabot pull requests only after the repository's existing CI workflow completes successfully.

## Safety

- Verifies the pull request author is `dependabot[bot]`.
- Verifies the successful workflow run tested the pull request's current head commit.
- Uses squash merging and leaves branch-protection enforcement to GitHub.
- Grants only `contents: write` and `pull-requests: write` to the trusted `workflow_run` job.

## Validation

- Confirmed the monitored CI workflow runs for pull requests.
- Confirmed the branch contains only the intended automation changes.
- Confirmed repository auto-merge and squash merging are enabled.