### PR TITLE
Use the flow decorator throughout workflow docs

### DIFF
--- a/docs/user/wflow_engine/executors.md
+++ b/docs/user/wflow_engine/executors.md
@@ -228,9 +228,11 @@ If you haven't done so already:
 
     ```python
     from ase.collections import g2
+    from quacc import flow
     from quacc.recipes.tblite.core import relax_job, freq_job
 
 
+    @flow
     def workflow(atoms):
         relax_output = relax_job(atoms)
         return freq_job(relax_output["atoms"], energy=relax_output["results"]["energy"])
@@ -420,9 +422,11 @@ If you haven't done so already:
     from ase.collections import g2
     from concurrent.futures import as_completed
     from tqdm import tqdm
+    from quacc import flow
     from quacc.recipes.tblite.core import relax_job, freq_job
 
 
+    @flow
     def workflow(atoms):
         relax_output = relax_job(atoms)
         return freq_job(relax_output["atoms"], energy=relax_output["results"]["energy"])
@@ -566,9 +570,11 @@ If you haven't done so already:
 
     ```python
     from ase.collections import g2
+    from quacc import flow
     from quacc.recipes.tblite.core import freq_job, relax_job
 
 
+    @flow
     def workflow(atoms_objects):
         futures = []
         for atoms in atoms_objects:
@@ -634,9 +640,11 @@ Once you have ensured that you can run VASP with quacc by following the [Calcula
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.vasp.core import relax_job, static_job
 
 
+    @flow
     def workflow(atoms):
         relax_output = relax_job(atoms, kpts=[3, 3, 3])
         return static_job(relax_output["atoms"], kpts=[3, 3, 3])
@@ -817,9 +825,11 @@ Once you have ensured that you can run VASP with quacc by following the [Calcula
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.vasp.core import relax_job, static_job
 
 
+    @flow
     def workflow(atoms):
         relax_output = relax_job(atoms, kpts=[3, 3, 3])
         return static_job(relax_output["atoms"], kpts=[3, 3, 3])
@@ -923,13 +933,14 @@ Once you have ensured that you can run VASP with quacc by following the [Calcula
 
     ```python
     from ase.build import bulk
-    from quacc import job, redecorate
+    from quacc import flow, job, redecorate
     from quacc.recipes.vasp.core import relax_job, static_job
 
     relax_job_ = redecorate(relax_job, job(num_cpus=cores_per_node))  # (1)!
     static_job_ = redecorate(static_job, job(num_cpus=cores_per_node))
 
 
+    @flow
     def workflow(list_of_atoms):
         futures = []
         for atoms in list_of_atoms:

--- a/docs/user/wflow_engine/wflow_engines2.md
+++ b/docs/user/wflow_engine/wflow_engines2.md
@@ -29,10 +29,12 @@ graph LR
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job, static_job
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         # Define Job 1
         delayed1 = relax_job(atoms)
@@ -133,10 +135,12 @@ graph LR
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job, static_job
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         # Define Job 1
         future1 = relax_job(atoms)
@@ -257,10 +261,12 @@ graph LR
     ```python
     import ray
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job, static_job
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         # Define Job 1
         future1 = relax_job(atoms)
@@ -383,10 +389,12 @@ graph LR
 
     ```python
     from ase.build import bulk, molecule
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
 
 
     # Define workflow
+    @flow
     def workflow(atoms1, atoms2):
         # Define two independent relaxation jobs
         result1 = relax_job(atoms1)
@@ -437,10 +445,12 @@ graph LR
 
     ```python
     from ase.build import bulk, molecule
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
 
 
     # Define workflow
+    @flow
     def workflow(atoms1, atoms2):
         # Define two independent relaxation jobs
         result1 = relax_job(atoms1)
@@ -498,10 +508,12 @@ graph LR
     ```python
     import ray
     from ase.build import bulk, molecule
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
 
 
     # Define workflow
+    @flow
     def workflow(atoms1, atoms2):
         # Define two independent relaxation jobs
         result1 = relax_job(atoms1)
@@ -570,11 +582,13 @@ graph LR
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
     from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         relaxed_bulk = relax_job(atoms)
         relaxed_slabs = bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)
@@ -643,11 +657,13 @@ graph LR
 
     ```python
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
     from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         relaxed_bulk = relax_job(atoms)
         relaxed_slabs = bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)
@@ -729,11 +745,13 @@ graph LR
     ```python
     import ray
     from ase.build import bulk
+    from quacc import flow
     from quacc.recipes.emt.core import relax_job
     from quacc.recipes.emt.slabs import bulk_to_slabs_flow
 
 
     # Define the workflow
+    @flow
     def workflow(atoms):
         relaxed_bulk = relax_job(atoms)
         relaxed_slabs = bulk_to_slabs_flow(relaxed_bulk["atoms"], run_static=False)


### PR DESCRIPTION
## Summary

- decorate custom Dask, Parsl, and Ray workflow examples with `@flow`
- add the corresponding `flow` imports to workflow-engine and executor examples
- standardize workflow boundaries across the documentation

Closes #3426

## Checks

- `git diff --check`
- verified every documented workflow definition has a matching `@flow` decorator and import

Note: `blacken-docs` was not available in the local environment.