### PR TITLE
Respect relax job defaults in elastic tensor flow

### DIFF
--- a/src/quacc/recipes/common/elastic.py
+++ b/src/quacc/recipes/common/elastic.py
@@ -57,7 +57,7 @@ def elastic_tensor_flow(
         See the return type-hint for the data structure.
     """
     if pre_relax:
-        undeformed_result = relax_job(atoms, relax_cell=True)
+        undeformed_result = relax_job(atoms)
         if run_static:
             undeformed_result = static_job(undeformed_result["atoms"])
     else:

--- a/src/quacc/recipes/emt/elastic.py
+++ b/src/quacc/recipes/emt/elastic.py
@@ -74,6 +74,7 @@ def elastic_tensor_flow(
     """
     relax_job_, static_job_ = customize_jobs(
         {"relax_job": relax_job, "static_job": static_job},
+        param_defaults={"relax_job": {"relax_cell": True}},
         param_swaps=job_params,
         decorators=job_decorators,
     ).values()

--- a/src/quacc/recipes/mlip/elastic.py
+++ b/src/quacc/recipes/mlip/elastic.py
@@ -74,6 +74,7 @@ def elastic_tensor_flow(
     """
     relax_job_, static_job_ = customize_jobs(
         {"relax_job": relax_job, "static_job": static_job},
+        param_defaults={"relax_job": {"relax_cell": True}},
         param_swaps=job_params,
         decorators=job_decorators,
     ).values()

--- a/tests/core/recipes/emt_recipes/test_emt_elastic.py
+++ b/tests/core/recipes/emt_recipes/test_emt_elastic.py
@@ -12,10 +12,13 @@ def test_elastic_jobs(tmp_path, monkeypatch):
     atoms = bulk("Cu")
 
     outputs = elastic_tensor_flow(atoms, run_static=False)
+    assert outputs["undeformed_result"]["atoms"].get_volume() == pytest.approx(
+        atoms.get_volume()
+    )
     assert outputs["deformed_results"][0]["atoms"].get_volume() != pytest.approx(
         atoms.get_volume()
     )
-    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(134.579)
+    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(125.897)
     for output in outputs["deformed_results"]:
         assert output["parameters"]["asap_cutoff"] is False
         assert output["name"] == "EMT Relax"

--- a/tests/core/recipes/emt_recipes/test_emt_elastic.py
+++ b/tests/core/recipes/emt_recipes/test_emt_elastic.py
@@ -12,13 +12,13 @@ def test_elastic_jobs(tmp_path, monkeypatch):
     atoms = bulk("Cu")
 
     outputs = elastic_tensor_flow(atoms, run_static=False)
-    assert outputs["undeformed_result"]["atoms"].get_volume() == pytest.approx(
+    assert outputs["undeformed_result"]["atoms"].get_volume() != pytest.approx(
         atoms.get_volume()
     )
     assert outputs["deformed_results"][0]["atoms"].get_volume() != pytest.approx(
         atoms.get_volume()
     )
-    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(125.897)
+    assert outputs["elasticity_doc"].bulk_modulus.voigt == pytest.approx(134.579)
     for output in outputs["deformed_results"]:
         assert output["parameters"]["asap_cutoff"] is False
         assert output["name"] == "EMT Relax"


### PR DESCRIPTION
## Summary of Changes

Closes https://github.com/Quantum-Accelerators/quacc/issues/2897.

Follow-up to #2735. The common `elastic_tensor_flow` no longer forces `relax_cell=True` on its initial relaxation, allowing the supplied relaxation job to control that behavior.

The EMT and MLIP elastic recipe wrappers now set `relax_cell=True` as their `relax_job` default. Users can still override it through `job_params`, and direct callers of the common flow retain their job's own default.

The EMT elastic-flow regression test verifies the recipe-level cell relaxation and retains the expected elastic modulus, fixing the test failure encountered by the original change.

## Testing

- `python -m pytest tests/core/recipes/emt_recipes/test_emt_elastic.py -q`
- `python -m ruff check src/quacc/recipes/common/elastic.py src/quacc/recipes/emt/elastic.py src/quacc/recipes/mlip/elastic.py tests/core/recipes/emt_recipes/test_emt_elastic.py`
- `git diff --check`

### Requirements

- [x] My PR is focused on a single feature addition or bugfix.
- [x] My PR has relevant unit-test coverage.
- [x] My PR is on a custom branch.