### PR TITLE
Use fairchem-data-odac for ODAC VASP settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 [project.optional-dependencies]
 dask = ["dask[distributed]>=2023.12.1", "dask-jobqueue>=0.8.2"]
 defects = ["pymatgen-analysis-defects>=2024.10.22", "shakenbreak>=3.2.0"]
-fairchem = ["fairchem-data-omat>=0.2", "fairchem-data-oc>=1.0.2", "fairchem-core>=2.21.0"]
+fairchem = ["fairchem-data-odac>=0.1.0", "fairchem-data-omat>=0.2", "fairchem-data-oc>=1.0.2", "fairchem-core>=2.21.0"]
 jobflow = ["jobflow>=0.3.0", "jobflow-remote>=1.0.0"]
 mlip = ["fairchem-core>=2.21.0", "matcalc[matgl]>=0.5.1", "rootstock>=0.9.1"]
 mp = ["atomate2>=0.0.14"]

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from importlib.util import find_spec
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 from monty.dev import requires
@@ -16,6 +18,11 @@ has_fairchem_omat = (
     has_fairchem
     and bool(find_spec("fairchem.data"))
     and bool(find_spec("fairchem.data.omat"))
+)
+has_fairchem_odac = (
+    has_fairchem
+    and bool(find_spec("fairchem.data"))
+    and bool(find_spec("fairchem.data.odac"))
 )
 has_atomate2 = bool(find_spec("atomate2"))
 
@@ -173,6 +180,10 @@ def _make_omc_inputs(atoms: Atoms) -> dict:
 
 
 @job
+@requires(
+    has_fairchem_odac,
+    "fairchem-data-odac is not installed. Run `pip install quacc[fairchem]`",
+)
 def odac_static_job(
     atoms: Atoms,
     kpts: tuple = (1, 1, 1),
@@ -207,36 +218,18 @@ def odac_static_job(
         See the type-hint for the data structure.
     """
 
-    calc_defaults = {
+    from fairchem.data.odac.setup_vasp import setup_vasp_calc_mof
+
+    odac_atoms = atoms.copy()
+    with TemporaryDirectory() as tmpdir:
+        setup_vasp_calc_mof(odac_atoms, Path(tmpdir))
+        calc_defaults = dict(odac_atoms.calc.parameters)
+    calc_defaults |= {
         "kpts": kpts,
-        "nwrite": 2,
-        "xc": "pbe",
-        "ivdw": 12,
-        "encut": 600.0,
-        "lcharg": False,
-        "lwave": False,
-        "ismear": 0,
-        "sigma": 0.2,
-        "ispin": 2,
-        "prec": "accurate",
-        "nelm": 60,
-        "nelmin": 2,
-        "ediff": 1e-5,
-        "ediffg": -0.05,
-        "maxmix": 40,
         "nsw": 0,
-        "ibrion": 2,
-        "isif": 3,
-        "potim": 0.01,
-        "algo": "normal",
-        "ldiag": True,
-        "lreal": "auto",
-        "lplane": True,
-        "gamma": True,
-        "isym": 0,
-        "pp_version": "54",
+        "incar_copilot_mode": "critical",
+        "use_custodian": False,
     }
-    calc_defaults |= {"incar_copilot_mode": "critical", "use_custodian": False}
     return run_and_summarize(
         atoms,
         calc_defaults=calc_defaults,

--- a/src/quacc/recipes/vasp/fairchem.py
+++ b/src/quacc/recipes/vasp/fairchem.py
@@ -24,6 +24,11 @@ has_fairchem_odac = (
     and bool(find_spec("fairchem.data"))
     and bool(find_spec("fairchem.data.odac"))
 )
+has_fairchem_oc = (
+    has_fairchem
+    and bool(find_spec("fairchem.data"))
+    and bool(find_spec("fairchem.data.oc"))
+)
 has_atomate2 = bool(find_spec("atomate2"))
 
 if TYPE_CHECKING:
@@ -224,9 +229,12 @@ def odac_static_job(
     with TemporaryDirectory() as tmpdir:
         setup_vasp_calc_mof(odac_atoms, Path(tmpdir))
         calc_defaults = dict(odac_atoms.calc.parameters)
+    calc_defaults.pop("istart", None)
     calc_defaults |= {
         "kpts": kpts,
         "nsw": 0,
+        "xc": "pbe",
+        "pp": "PBE",
         "incar_copilot_mode": "critical",
         "use_custodian": False,
     }
@@ -241,7 +249,7 @@ def odac_static_job(
 
 @job
 @requires(
-    has_fairchem_omat,
+    has_fairchem_oc,
     "fairchem-data-oc is not installed. Run `pip install quacc[fairchem]`",
 )
 def oc20_static_job(

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -54,6 +54,11 @@ has_fairchem_oc = (
     and util.find_spec("fairchem.data") is not None
     and util.find_spec("fairchem.data.oc") is not None
 )
+has_fairchem_odac = (
+    has_fairchem
+    and util.find_spec("fairchem.data") is not None
+    and util.find_spec("fairchem.data.odac") is not None
+)
 FILE_DIR = Path(__file__).parent
 MOCKED_DIR = FILE_DIR / "mocked_vasp_runs"
 
@@ -1562,6 +1567,7 @@ def test_fairchem_omc(patch_metallic_taskdoc):
     }
 
 
+@pytest.mark.skipif(not has_fairchem_odac, reason="fairchem-data-odac not installed")
 def test_fairchem_odac(patch_nonmetallic_taskdoc):
     from quacc.recipes.vasp.fairchem import odac_static_job
 
@@ -1570,11 +1576,11 @@ def test_fairchem_odac(patch_nonmetallic_taskdoc):
     output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "kpts": (1, 1, 1),
+        "istart": 0,
         "ediffg": -0.05,
         "ibrion": 2,
         "nwrite": 2,
-        "gga": "PE",
-        "xc": "pbe",
+        "gga": "pe",
         "ivdw": 12,
         "encut": 600.0,
         "lcharg": False,
@@ -1597,7 +1603,6 @@ def test_fairchem_odac(patch_nonmetallic_taskdoc):
         "gamma": True,
         "isym": 0,
         "potim": 0.01,
-        "pp": "PBE",
         "pp_version": "54",
     }
 

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1576,11 +1576,11 @@ def test_fairchem_odac(patch_nonmetallic_taskdoc):
     output["parameters"].pop("ncore")
     assert output["parameters"] == {
         "kpts": (1, 1, 1),
-        "istart": 0,
         "ediffg": -0.05,
         "ibrion": 2,
         "nwrite": 2,
-        "gga": "pe",
+        "gga": "PE",
+        "xc": "pbe",
         "ivdw": 12,
         "encut": 600.0,
         "lcharg": False,
@@ -1603,6 +1603,7 @@ def test_fairchem_odac(patch_nonmetallic_taskdoc):
         "gamma": True,
         "isym": 0,
         "potim": 0.01,
+        "pp": "PBE",
         "pp_version": "54",
     }
 

--- a/tests/requirements-fairchem.txt
+++ b/tests/requirements-fairchem.txt
@@ -1,4 +1,5 @@
 fairchem-core==2.21.0
+fairchem-data-odac==0.1.0
 fairchem-data-oc==1.0.2
 fairchem-data-omat==0.2
 atomate2==0.1.5


### PR DESCRIPTION
## Summary

- add fairchem-data-odac to the FairChem optional and test dependencies
- source ODAC VASP calculator parameters from fairchem-data-odac instead of duplicating them in quacc
- preserve the recipe's static-calculation and quacc-specific overrides
- update the mocked ODAC test to track the package-provided settings

## Validation

- python -m pytest tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py -q -p no:cacheprovider (22 passed, 21 skipped)
- python -m ruff check src/quacc/recipes/vasp/fairchem.py tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
- git diff --check