### PR TITLE
Restore full project test coverage

### DIFF
--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -247,3 +247,44 @@ def test_bad_calculator_params():
 
     with pytest.raises(NotImplementedError, match="does not support the directory"):
         Espresso(input_atoms=atoms, kpts=(1, 1, 1), directory="bad")
+
+
+def test_prepare_copy_files_pw_restart():
+    parameters = {
+        "input_data": {
+            "control": {"restart_mode": "restart"},
+            "electrons": {},
+        }
+    }
+
+    to_copy = prepare_copy_files(parameters)
+
+    assert Path("pwscf.wfc*") in to_copy
+    assert Path("pwscf.mix*") in to_copy
+    assert Path("pwscf.restart_k*") in to_copy
+    assert Path("pwscf.restart_scf*") in to_copy
+    assert Path("pwscf.save", "charge-density.*") in to_copy
+    assert Path("pwscf.save", "wfc*.*") in to_copy
+
+
+def test_prepare_copy_files_ph_recovery():
+    parameters = {
+        "input_data": {"inputph": {"lqdir": True, "recover": True}}
+    }
+
+    to_copy = prepare_copy_files(parameters, binary="ph")
+
+    assert Path("_ph*", "pwscf.q_*", "pwscf.save", "charge-density.*") in to_copy
+    assert Path("_ph*", "pwscf.phsave") in to_copy
+
+
+@pytest.mark.parametrize(
+    ("binary", "expected"),
+    [
+        ("matdyn", Path("q2r.fc*")),
+        ("q2r", Path("matdyn*")),
+        ("dvscf_q2r", Path("matdyn0*")),
+    ],
+)
+def test_prepare_copy_files_postprocessing(binary, expected):
+    assert expected in prepare_copy_files({}, binary=binary)

--- a/tests/core/calculators/espresso/test_espresso.py
+++ b/tests/core/calculators/espresso/test_espresso.py
@@ -251,10 +251,7 @@ def test_bad_calculator_params():
 
 def test_prepare_copy_files_pw_restart():
     parameters = {
-        "input_data": {
-            "control": {"restart_mode": "restart"},
-            "electrons": {},
-        }
+        "input_data": {"control": {"restart_mode": "restart"}, "electrons": {}}
     }
 
     to_copy = prepare_copy_files(parameters)
@@ -268,9 +265,7 @@ def test_prepare_copy_files_pw_restart():
 
 
 def test_prepare_copy_files_ph_recovery():
-    parameters = {
-        "input_data": {"inputph": {"lqdir": True, "recover": True}}
-    }
+    parameters = {"input_data": {"inputph": {"lqdir": True, "recover": True}}}
 
     to_copy = prepare_copy_files(parameters, binary="ph")
 

--- a/tests/core/utils/test_files.py
+++ b/tests/core/utils/test_files.py
@@ -275,3 +275,11 @@ def test_safe_decompress_dir_skips_disappearing_files(tmp_path, monkeypatch, cap
         safe_decompress_dir(tmp_path)
 
     assert f"Cannot find {disappearing_file.name}" in caplog.text
+
+
+def test_find_recent_logfile_skips_directories(tmp_path):
+    (tmp_path / "directory.log").mkdir()
+    logfile = tmp_path / "actual.log"
+    logfile.touch()
+
+    assert find_recent_logfile(tmp_path, ".log") == logfile.resolve()


### PR DESCRIPTION
## Summary

- cover Quantum Espresso restart file preparation
- cover phonon recovery and post-processing copy paths
- cover directory filtering when selecting recent log files

## Why

The latest successful Codecov report showed 99.48% project coverage: 4,245 of 4,267 lines, with all 22 uncovered lines concentrated in `src/quacc/calculators/espresso/utils.py` and `src/quacc/utils/files.py`. These tests exercise those behaviors without changing production code.

## Validation

- compared all 17 coverage XML artifacts from the latest successful test workflow and identified the union of uncovered lines
- confirmed this branch is two commits ahead of `main` and modifies only the two targeted test files
- GitHub Actions/Codecov will provide the full dependency-matrix validation

### Requirements

- [x] My PR is focused on a single change.
- [x] My PR has relevant unit-test coverage.
- [x] My PR is on a custom branch.