### PR TITLE
Allow excluding individual VASP Custodian errors

### DIFF
--- a/src/quacc/calculators/vasp/vasp_custodian.py
+++ b/src/quacc/calculators/vasp/vasp_custodian.py
@@ -218,4 +218,3 @@ def run_custodian(
     )
 
     return c.run()
-

--- a/src/quacc/calculators/vasp/vasp_custodian.py
+++ b/src/quacc/calculators/vasp/vasp_custodian.py
@@ -42,6 +42,7 @@ def run_custodian(
     vasp_custodian_wall_time: float | DefaultSetting = QuaccDefault,
     vtst_fixes: bool | DefaultSetting = QuaccDefault,
     vasp_custodian_handlers: list[str] | DefaultSetting | None = QuaccDefault,
+    vasp_custodian_vasp_error_exclude: list[str] | DefaultSetting = QuaccDefault,
     vasp_custodian_validators: list[str] | DefaultSetting | None = QuaccDefault,
     scratch_dir: str | None = None,
     directory: str | Path | None = None,
@@ -70,6 +71,9 @@ def run_custodian(
         Whether to apply VTST input swaps. Defaults to False in settings.
     vasp_custodian_handlers
         List of handlers to use in Custodian. See settings for list.
+    vasp_custodian_vasp_error_exclude
+        List of errors to exclude from Custodian's VaspErrorHandler. See
+        ``VaspErrorHandler.error_msgs`` for available errors.
     vasp_custodian_validators
         List of validators to use in Custodian. See settings for list.
     scratch_dir
@@ -117,6 +121,11 @@ def run_custodian(
         if vasp_custodian_handlers == QuaccDefault
         else vasp_custodian_handlers
     )
+    vasp_custodian_vasp_error_exclude = (
+        settings.VASP_CUSTODIAN_VASP_ERROR_EXCLUDE
+        if vasp_custodian_vasp_error_exclude == QuaccDefault
+        else vasp_custodian_vasp_error_exclude
+    )
 
     vasp_custodian_validators = (
         settings.VASP_CUSTODIAN_VALIDATORS
@@ -124,9 +133,24 @@ def run_custodian(
         else vasp_custodian_validators
     )
 
+    unknown_vasp_errors = set(vasp_custodian_vasp_error_exclude) - set(
+        VaspErrorHandler.error_msgs
+    )
+    if unknown_vasp_errors:
+        msg = f"Unknown VASP errors to exclude: {sorted(unknown_vasp_errors)}"
+        raise ValueError(msg)
+
+    vasp_errors_to_catch = [
+        error
+        for error in VaspErrorHandler.error_msgs
+        if error not in vasp_custodian_vasp_error_exclude
+    ]
+
     # Handlers for VASP
     handlers_dict = {
-        "VaspErrorHandler": VaspErrorHandler(vtst_fixes=vtst_fixes),
+        "VaspErrorHandler": VaspErrorHandler(
+            vtst_fixes=vtst_fixes, errors_subset_to_catch=vasp_errors_to_catch
+        ),
         "FrozenJobErrorHandler": FrozenJobErrorHandler(),
         "IncorrectSmearingHandler": IncorrectSmearingHandler(),
         "LargeSigmaHandler": LargeSigmaHandler(),
@@ -194,3 +218,4 @@ def run_custodian(
     )
 
     return c.run()
+

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -375,6 +375,9 @@ class QuaccSettings(BaseSettings):
         ],
         description="Handlers for Custodian",
     )
+    VASP_CUSTODIAN_VASP_ERROR_EXCLUDE: list[str] = Field(
+        [], description="VASP errors to exclude from Custodian's VaspErrorHandler"
+    )
     VASP_CUSTODIAN_VALIDATORS: list[str] = Field(
         ["VasprunXMLValidator", "VaspFilesValidator"],
         description="Validators for Custodian",
@@ -634,3 +637,4 @@ def change_settings_wrap(
     wrapper._changed = True
     wrapper._original_func = original_func
     return wrapper
+

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -637,4 +637,3 @@ def change_settings_wrap(
     wrapper._changed = True
     wrapper._original_func = original_func
     return wrapper
-

--- a/tests/core/calculators/vasp/test_vasp_custodian.py
+++ b/tests/core/calculators/vasp/test_vasp_custodian.py
@@ -68,4 +68,3 @@ def test_vasp_error_exclude(monkeypatch):
 
     with pytest.raises(ValueError, match="Unknown VASP errors to exclude"):
         run_custodian(vasp_custodian_vasp_error_exclude=["not-a-vasp-error"])
-

--- a/tests/core/calculators/vasp/test_vasp_custodian.py
+++ b/tests/core/calculators/vasp/test_vasp_custodian.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytest
 from custodian import Custodian
+from custodian.vasp.handlers import VaspErrorHandler
 
+from quacc.calculators.vasp import vasp_custodian
 from quacc.calculators.vasp.vasp_custodian import run_custodian
 
 
@@ -40,3 +42,30 @@ def test_run_vasp_custodian(monkeypatch):
 
     with pytest.raises(ValueError, match="Unknown VASP validator"):
         run_custodian(vasp_custodian_validators=["cow"])
+
+
+def test_vasp_error_exclude(monkeypatch):
+    original_error_msgs = VaspErrorHandler.error_msgs
+    seen_handlers = []
+
+    class MockVaspErrorHandler:
+        error_msgs = original_error_msgs
+        is_monitor = False
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            seen_handlers.append(self)
+
+    monkeypatch.setattr(vasp_custodian, "VaspErrorHandler", MockVaspErrorHandler)
+
+    run_custodian(vasp_custodian_vasp_error_exclude=["bravais"])
+
+    handler = seen_handlers[0]
+    assert "bravais" not in handler.kwargs["errors_subset_to_catch"]
+    assert set(handler.kwargs["errors_subset_to_catch"]) == set(original_error_msgs) - {
+        "bravais"
+    }
+
+    with pytest.raises(ValueError, match="Unknown VASP errors to exclude"):
+        run_custodian(vasp_custodian_vasp_error_exclude=["not-a-vasp-error"])
+


### PR DESCRIPTION
## Summary

- add a `VASP_CUSTODIAN_VASP_ERROR_EXCLUDE` setting for selectively disabling errors handled by `VaspErrorHandler`
- expose the same behavior through `run_custodian(vasp_custodian_vasp_error_exclude=...)`
- validate excluded names so configuration typos fail clearly
- add regression coverage for excluding `bravais`

This lets users ignore a single VASP error such as `bravais` without disabling `VaspErrorHandler` and all of its other corrections.

Example:

```yaml
VASP_CUSTODIAN_VASP_ERROR_EXCLUDE:
  - bravais
```

## Testing

- `python -m pytest tests/core/calculators/vasp -q` (60 passed, 1 skipped)
- `python -m ruff check src/quacc/settings.py src/quacc/calculators/vasp/vasp_custodian.py tests/core/calculators/vasp/test_vasp_custodian.py`
- `python -m ruff format --check src/quacc/settings.py src/quacc/calculators/vasp/vasp_custodian.py tests/core/calculators/vasp/test_vasp_custodian.py`