### PR TITLE
MD recipe added for MLIPs with ensemble presets inspired by matcalc

### DIFF
--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from ase.calculators.emt import EMT
 from ase.md.npt import NPT
-from ase.md.verlet import VelocityVerlet
 from ase.units import bar, fs
 
 from quacc import Remove, job
@@ -30,7 +29,7 @@ if TYPE_CHECKING:
 @job
 def md_job(
     atoms: Atoms,
-    dynamics: MolecularDynamics | MDEnsemble = VelocityVerlet,
+    dynamics: MolecularDynamics | MDEnsemble = "nve",
     steps: int = 10000,
     timestep_fs: float = 0.5,
     temperature_K: float | None = None,
@@ -48,23 +47,33 @@ def md_job(
     atoms
         Atoms object
     dynamics
-        Either an ASE `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`)
-        or an ensemble name from [quacc.utils.md.MDEnsemble][], resolved to an ASE
-        dynamics class with sensible defaults by
-        [quacc.utils.md.resolve_md_ensemble][] (all of which can be overridden
-        via `md_params["dynamics_kwargs"]`). For the NPT-family ensembles,
-        `pressure_bar` is routed to the appropriate keyword argument of the
-        dynamics class (`externalstress` or `pressure_au`) and defaults to 0 bar
-        when not specified. If the `NPT` class is used, the cell is transformed
-        to the upper-triangular form it requires.
+        Either an ensemble name from [quacc.utils.md.MDEnsemble][] (the default
+        is `"nve"`), resolved to an ASE dynamics class with sensible defaults
+        by [quacc.utils.md.resolve_md_ensemble][] (all of which can be
+        overridden via `md_params["dynamics_kwargs"]`), or an ASE
+        `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`). For the
+        NPT-family ensembles, `pressure_bar` is routed to the appropriate
+        keyword argument of the dynamics class (`externalstress` or
+        `pressure_au`) and defaults to 0 bar when not specified. If the `NPT`
+        class is used, the cell is transformed to the upper-triangular form it
+        requires.
     steps
         Number of MD steps to run.
     timestep_fs
         Time step in fs.
     temperature_K
-        Temperature in K, if applicable for the given ensemble.
+        Temperature in K, if applicable for the given ensemble. Unless the
+        input atoms already have nonzero momenta, a Maxwell-Boltzmann
+        distribution at this temperature is also applied to initialize the
+        velocities; set `md_params={"maxwell_boltzmann_kwargs": None}` to
+        disable this. When `dynamics` is an ASE class, `temperature_K` is also
+        passed to the class and is only compatible with classes that accept
+        that keyword argument.
     pressure_bar
-        Pressure in bar, if applicable for the given ensemble.
+        Pressure in bar, if applicable for the given ensemble. When `dynamics`
+        is an ASE class, this is passed as `pressure_au` and is only compatible
+        with classes that accept that keyword argument (e.g. the Berendsen
+        family); prefer an ensemble name for NPT runs.
     md_params
         Dictionary of custom kwargs for the MD run. For a list of available
         keys, refer to [quacc.runners.ase.Runner.run_md][].
@@ -98,6 +107,8 @@ def md_job(
         atoms = upper_triangular_cell(atoms)
 
     md_defaults = {"steps": steps, "dynamics_kwargs": dynamics_defaults}
+    if temperature_K is not None and not atoms.get_momenta().any():
+        md_defaults["maxwell_boltzmann_kwargs"] = {"temperature_K": temperature_K}
     md_params = recursive_dict_merge(md_defaults, md_params)
 
     calc = EMT(**calc_kwargs)

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
-    from quacc.types import CopyFiles, DynSchema, MDEnsemble, MDParams
+    from quacc.types import CopyFiles, DynSchema, MDParams
+    from quacc.utils.md import MDEnsemble
 
 
 @job
@@ -48,7 +49,7 @@ def md_job(
         Atoms object
     dynamics
         Either an ASE `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`)
-        or an ensemble name from [quacc.types.MDEnsemble][], resolved to an ASE
+        or an ensemble name from [quacc.utils.md.MDEnsemble][], resolved to an ASE
         dynamics class with sensible defaults by
         [quacc.utils.md.resolve_md_ensemble][] (all of which can be overridden
         via `md_params["dynamics_kwargs"]`). For the NPT-family ensembles,

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -94,7 +94,10 @@ def md_job(
     """
     if isinstance(dynamics, str):
         dynamics, dynamics_defaults = resolve_md_ensemble(
-            dynamics, timestep_fs * fs, temperature_K, pressure_bar
+            dynamics,
+            timestep_fs=timestep_fs,
+            temperature_K=temperature_K,
+            pressure_bar=pressure_bar,
         )
     else:
         dynamics_defaults = {

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 def md_job(
     atoms: Atoms,
     dynamics: MolecularDynamics | MDEnsemble = "nve",
-    steps: int = 10000,
+    steps: int = 20000,
     timestep_fs: float = 0.5,
     temperature_K: float | None = None,
     pressure_bar: float | None = None,

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -76,8 +76,8 @@ def md_job(
         "steps": steps,
         "dynamics_kwargs": {
             "timestep": timestep_fs * fs,
-            "temperature_K": temperature_K if temperature_K else Remove,
-            "pressure_au": pressure_bar * bar if pressure_bar else Remove,
+            "temperature_K": temperature_K if temperature_K is not None else Remove,
+            "pressure_au": pressure_bar * bar if pressure_bar is not None else Remove,
         },
     }
     md_params = recursive_dict_merge(md_defaults, md_params)

--- a/src/quacc/recipes/emt/md.py
+++ b/src/quacc/recipes/emt/md.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ase.calculators.emt import EMT
+from ase.md.npt import NPT
 from ase.md.verlet import VelocityVerlet
 from ase.units import bar, fs
 
@@ -14,6 +15,7 @@ from quacc import Remove, job
 from quacc.runners.ase import Runner
 from quacc.schemas.ase import Summarize
 from quacc.utils.dicts import recursive_dict_merge
+from quacc.utils.md import resolve_md_ensemble, upper_triangular_cell
 
 if TYPE_CHECKING:
     from typing import Any
@@ -21,15 +23,15 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
-    from quacc.types import CopyFiles, DynSchema, MDParams
+    from quacc.types import CopyFiles, DynSchema, MDEnsemble, MDParams
 
 
 @job
 def md_job(
     atoms: Atoms,
-    dynamics: MolecularDynamics = VelocityVerlet,
-    steps: int = 1000,
-    timestep_fs: float = 1.0,
+    dynamics: MolecularDynamics | MDEnsemble = VelocityVerlet,
+    steps: int = 10000,
+    timestep_fs: float = 0.5,
     temperature_K: float | None = None,
     pressure_bar: float | None = None,
     md_params: MDParams | None = None,
@@ -45,7 +47,15 @@ def md_job(
     atoms
         Atoms object
     dynamics
-        ASE `MolecularDynamics` class to use, from `ase.md.md.MolecularDynamics`.
+        Either an ASE `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`)
+        or an ensemble name from [quacc.types.MDEnsemble][], resolved to an ASE
+        dynamics class with sensible defaults by
+        [quacc.utils.md.resolve_md_ensemble][] (all of which can be overridden
+        via `md_params["dynamics_kwargs"]`). For the NPT-family ensembles,
+        `pressure_bar` is routed to the appropriate keyword argument of the
+        dynamics class (`externalstress` or `pressure_au`) and defaults to 0 bar
+        when not specified. If the `NPT` class is used, the cell is transformed
+        to the upper-triangular form it requires.
     steps
         Number of MD steps to run.
     timestep_fs
@@ -72,14 +82,21 @@ def md_job(
         Dictionary of results, specified in [quacc.schemas.ase.Summarize.md][].
         See the type-hint for the data structure.
     """
-    md_defaults = {
-        "steps": steps,
-        "dynamics_kwargs": {
-            "timestep": timestep_fs * fs,
+    if isinstance(dynamics, str):
+        dynamics, dynamics_defaults = resolve_md_ensemble(
+            dynamics, timestep_fs * fs, temperature_K, pressure_bar
+        )
+    else:
+        dynamics_defaults = {
             "temperature_K": temperature_K if temperature_K is not None else Remove,
             "pressure_au": pressure_bar * bar if pressure_bar is not None else Remove,
-        },
-    }
+        }
+    dynamics_defaults["timestep"] = timestep_fs * fs
+
+    if dynamics is NPT:
+        atoms = upper_triangular_cell(atoms)
+
+    md_defaults = {"steps": steps, "dynamics_kwargs": dynamics_defaults}
     md_params = recursive_dict_merge(md_defaults, md_params)
 
     calc = EMT(**calc_kwargs)

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+from ase.md.andersen import Andersen
+from ase.md.bussi import Bussi
+from ase.md.langevin import Langevin
+from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
+from ase.md.npt import NPT
+from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
+from ase.md.nvtberendsen import NVTBerendsen
 from ase.md.verlet import VelocityVerlet
 from ase.units import bar, fs
 
@@ -26,7 +34,7 @@ if TYPE_CHECKING:
 def md_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
-    dynamics: MolecularDynamics = VelocityVerlet,
+    dynamics: MolecularDynamics | str = VelocityVerlet,
     steps: int = 1000,
     timestep_fs: float = 1.0,
     temperature_K: float | None = None,
@@ -48,7 +56,28 @@ def md_job(
         - `matcalc` passes `**calc_kwargs` to `matcalc.load_fp()`
         - `rootstock` passes `**calc_kwargs` to `rootstock.RootstockCalculator()`
     dynamics
-        ASE `MolecularDynamics` class to use, from `ase.md.md.MolecularDynamics`.
+        Either an ASE `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`)
+        or an ensemble name. Supported ensemble names, their ASE dynamics classes,
+        and their default parameters (any of which can be overridden via
+        `md_params["dynamics_kwargs"]`; `taut` defaults to 100x the timestep and
+        `taup` to 1000x the timestep):
+
+        - `"nve"`: `VelocityVerlet` (`temperature_K` and `pressure_bar` are ignored)
+        - `"nvt"`, `"nvt_nose_hoover"`: `NoseHooverChainNVT` (`tdamp=taut`)
+        - `"nvt_berendsen"`: `NVTBerendsen` (`taut`)
+        - `"nvt_langevin"`: `Langevin` (`friction=0.001`)
+        - `"nvt_andersen"`: `Andersen` (`andersen_prob=0.01`)
+        - `"nvt_bussi"`: `Bussi` (`taut`)
+        - `"npt"`, `"npt_nose_hoover"`: `NPT` (`ttime=25 fs`, `pfactor=75**2 fs`)
+        - `"npt_berendsen"`: `NPTBerendsen` (`taut`, `taup`)
+        - `"npt_inhomogeneous"`: `Inhomogeneous_NPTBerendsen` (`taut`, `taup`)
+        - `"npt_mtk"`: `MTKNPT` (`tdamp=taut`, `pdamp=taup`)
+        - `"npt_isotropic_mtk"`: `IsotropicMTKNPT` (`tdamp=taut`, `pdamp=taup`)
+
+        For the NPT-family ensembles, `pressure_bar` is routed to the appropriate
+        keyword argument of the dynamics class (`externalstress` or `pressure_au`)
+        and defaults to 0 bar when not specified. If the `NPT` class is used, the
+        cell is transformed to the upper-triangular form it requires.
     steps
         Number of MD steps to run.
     timestep_fs
@@ -56,7 +85,10 @@ def md_job(
     temperature_K
         Temperature in K, if applicable for the given ensemble.
     pressure_bar
-        Pressure in bar, if applicable for the given ensemble.
+        Pressure in bar, if applicable for the given ensemble. When `dynamics` is
+        an ASE class, this is passed as `pressure_au` and is only compatible with
+        classes that accept that keyword argument (e.g. the Berendsen family);
+        prefer an ensemble name for NPT runs.
     md_params
         Dictionary of custom kwargs for the MD run. For a list of available
         keys, refer to [quacc.runners.ase.Runner.run_md][].
@@ -71,14 +103,21 @@ def md_job(
         Dictionary of results, specified in [quacc.schemas.ase.Summarize.md][].
         See the type-hint for the data structure.
     """
-    md_defaults = {
-        "steps": steps,
-        "dynamics_kwargs": {
-            "timestep": timestep_fs * fs,
+    if isinstance(dynamics, str):
+        dynamics, dynamics_defaults = _resolve_ensemble(
+            dynamics, timestep_fs * fs, temperature_K, pressure_bar
+        )
+    else:
+        dynamics_defaults = {
             "temperature_K": temperature_K if temperature_K is not None else Remove,
             "pressure_au": pressure_bar * bar if pressure_bar is not None else Remove,
-        },
-    }
+        }
+    dynamics_defaults["timestep"] = timestep_fs * fs
+
+    if dynamics is NPT:
+        atoms = _upper_triangular_cell(atoms)
+
+    md_defaults = {"steps": steps, "dynamics_kwargs": dynamics_defaults}
     md_params = recursive_dict_merge(md_defaults, md_params)
 
     calc = pick_calculator(library, **calc_kwargs)
@@ -87,3 +126,121 @@ def md_job(
     return Summarize(
         additional_fields={"name": f"{library} MD"} | (additional_fields or {})
     ).md(dyn)
+
+
+def _resolve_ensemble(
+    ensemble: str,
+    timestep: float,
+    temperature_K: float | None,
+    pressure_bar: float | None,
+) -> tuple[type[MolecularDynamics], dict[str, Any]]:
+    """
+    Resolve an ensemble name to an ASE dynamics class and its default kwargs.
+
+    The default parameters follow matcalc's `MDCalc`: `taut` is 100x the
+    timestep, `taup` is 1000x the timestep, and the pressure defaults to 0 bar
+    for the NPT-family ensembles.
+
+    Parameters
+    ----------
+    ensemble
+        Name of the ensemble (case-insensitive). See [quacc.recipes.mlip.md.md_job][]
+        for the supported names.
+    timestep
+        Time step in ASE units.
+    temperature_K
+        Temperature in K, if applicable for the given ensemble.
+    pressure_bar
+        Pressure in bar, if applicable for the given ensemble.
+
+    Returns
+    -------
+    tuple[type[MolecularDynamics], dict]
+        The ASE dynamics class and its default `dynamics_kwargs`.
+    """
+    taut = 100 * timestep
+    taup = 1000 * timestep
+    temperature = {
+        "temperature_K": temperature_K if temperature_K is not None else Remove
+    }
+    pressure = (pressure_bar if pressure_bar is not None else 0.0) * bar
+
+    presets: dict[str, tuple[type[MolecularDynamics], dict[str, Any]]] = {
+        "nve": (VelocityVerlet, {}),
+        "nvt": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
+        "nvt_nose_hoover": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
+        "nvt_berendsen": (NVTBerendsen, temperature | {"taut": taut}),
+        "nvt_langevin": (Langevin, temperature | {"friction": 1.0e-3}),
+        "nvt_andersen": (Andersen, temperature | {"andersen_prob": 1.0e-2}),
+        "nvt_bussi": (Bussi, temperature | {"taut": taut}),
+        "npt": (
+            NPT,
+            temperature
+            | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},
+        ),
+        "npt_nose_hoover": (
+            NPT,
+            temperature
+            | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},
+        ),
+        "npt_berendsen": (
+            NPTBerendsen,
+            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
+        ),
+        "npt_inhomogeneous": (
+            Inhomogeneous_NPTBerendsen,
+            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
+        ),
+        "npt_mtk": (
+            MTKNPT,
+            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
+        ),
+        "npt_isotropic_mtk": (
+            IsotropicMTKNPT,
+            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
+        ),
+    }
+
+    if ensemble.lower() not in presets:
+        msg = (
+            f"Unsupported ensemble: {ensemble}. "
+            f"Valid options are: {', '.join(presets)}."
+        )
+        raise ValueError(msg)
+
+    return presets[ensemble.lower()]
+
+
+def _upper_triangular_cell(atoms: Atoms) -> Atoms:
+    """
+    Transform the cell to the upper-triangular form required by the ASE `NPT`
+    class, if it is not already in that form. Adapted from matcalc's `MDCalc`.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+
+    Returns
+    -------
+    Atoms
+        A copy of the Atoms object with an upper-triangular cell, or the
+        original Atoms object if the cell is already upper-triangular.
+    """
+    if atoms.cell[1, 0] == atoms.cell[2, 0] == atoms.cell[2, 1] == 0.0:
+        return atoms
+
+    atoms = atoms.copy()
+    a, b, c, alpha, beta, gamma = atoms.cell.cellpar()
+    angles = np.radians((alpha, beta, gamma))
+    sin_a, sin_b, _ = np.sin(angles)
+    cos_a, cos_b, cos_g = np.cos(angles)
+    cos_p = np.clip((cos_g - cos_a * cos_b) / (sin_a * sin_b), -1, 1)
+    sin_p = np.sqrt(1 - cos_p**2)
+    new_basis = [
+        (a * sin_b * sin_p, a * sin_b * cos_p, a * cos_b),
+        (0, b * sin_a, b * cos_a),
+        (0, 0, c),
+    ]
+    atoms.set_cell(new_basis, scale_atoms=True)
+    return atoms

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -29,7 +29,7 @@ def md_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
     dynamics: MolecularDynamics | MDEnsemble = "nve",
-    steps: int = 10000,
+    steps: int = 20000,
     timestep_fs: float = 0.5,
     temperature_K: float | None = None,
     pressure_bar: float | None = None,

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -1,0 +1,89 @@
+"""Molecular dynamics recipes for universal machine-learned interatomic potentials."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ase.md.verlet import VelocityVerlet
+from ase.units import bar, fs
+
+from quacc import Remove, job
+from quacc.recipes.mlip._base import pick_calculator
+from quacc.runners.ase import Runner
+from quacc.schemas.ase import Summarize
+from quacc.utils.dicts import recursive_dict_merge
+
+if TYPE_CHECKING:
+    from typing import Any, Literal
+
+    from ase.atoms import Atoms
+    from ase.md.md import MolecularDynamics
+
+    from quacc.types import DynSchema, MDParams
+
+
+@job
+def md_job(
+    atoms: Atoms,
+    library: Literal["fairchem", "matcalc", "rootstock"],
+    dynamics: MolecularDynamics = VelocityVerlet,
+    steps: int = 1000,
+    timestep_fs: float = 1.0,
+    temperature_K: float | None = None,
+    pressure_bar: float | None = None,
+    md_params: MDParams | None = None,
+    additional_fields: dict[str, Any] | None = None,
+    **calc_kwargs: Any,
+) -> DynSchema:
+    """
+    Carry out a Molecular Dynamics calculation.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    library
+        MLIP library to use:
+        - `fairchem` passes `**calc_kwargs` to `FAIRChemCalculator.from_model_checkpoint()`
+        - `matcalc` passes `**calc_kwargs` to `matcalc.load_fp()`
+        - `rootstock` passes `**calc_kwargs` to `rootstock.RootstockCalculator()`
+    dynamics
+        ASE `MolecularDynamics` class to use, from `ase.md.md.MolecularDynamics`.
+    steps
+        Number of MD steps to run.
+    timestep_fs
+        Time step in fs.
+    temperature_K
+        Temperature in K, if applicable for the given ensemble.
+    pressure_bar
+        Pressure in bar, if applicable for the given ensemble.
+    md_params
+        Dictionary of custom kwargs for the MD run. For a list of available
+        keys, refer to [quacc.runners.ase.Runner.run_md][].
+    additional_fields
+        Additional fields to add to the results dictionary.
+    **calc_kwargs
+        Custom kwargs for the underlying MLIP library.
+
+    Returns
+    -------
+    DynSchema
+        Dictionary of results, specified in [quacc.schemas.ase.Summarize.md][].
+        See the type-hint for the data structure.
+    """
+    md_defaults = {
+        "steps": steps,
+        "dynamics_kwargs": {
+            "timestep": timestep_fs * fs,
+            "temperature_K": temperature_K if temperature_K else Remove,
+            "pressure_au": pressure_bar * bar if pressure_bar else Remove,
+        },
+    }
+    md_params = recursive_dict_merge(md_defaults, md_params)
+
+    calc = pick_calculator(library, **calc_kwargs)
+    dyn = Runner(atoms, calc).run_md(dynamics, **md_params)
+
+    return Summarize(
+        additional_fields={"name": f"{library} MD"} | (additional_fields or {})
+    ).md(dyn)

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -4,14 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
-from ase.md.andersen import Andersen
-from ase.md.bussi import Bussi
-from ase.md.langevin import Langevin
-from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
 from ase.md.npt import NPT
-from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
-from ase.md.nvtberendsen import NVTBerendsen
 from ase.md.verlet import VelocityVerlet
 from ase.units import bar, fs
 
@@ -20,6 +13,7 @@ from quacc.recipes.mlip._base import pick_calculator
 from quacc.runners.ase import Runner
 from quacc.schemas.ase import Summarize
 from quacc.utils.dicts import recursive_dict_merge
+from quacc.utils.md import resolve_md_ensemble, upper_triangular_cell
 
 if TYPE_CHECKING:
     from typing import Any, Literal
@@ -27,21 +21,7 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
-    from quacc.types import DynSchema, MDParams
-
-    MDEnsemble = Literal[
-        "nve",
-        "nvt",
-        "nvt_berendsen",
-        "nvt_langevin",
-        "nvt_andersen",
-        "nvt_bussi",
-        "npt",
-        "npt_berendsen",
-        "npt_inhomogeneous",
-        "npt_mtk",
-        "npt_isotropic_mtk",
-    ]
+    from quacc.types import DynSchema, MDEnsemble, MDParams
 
 
 @job
@@ -118,7 +98,7 @@ def md_job(
         See the type-hint for the data structure.
     """
     if isinstance(dynamics, str):
-        dynamics, dynamics_defaults = _resolve_ensemble(
+        dynamics, dynamics_defaults = resolve_md_ensemble(
             dynamics, timestep_fs * fs, temperature_K, pressure_bar
         )
     else:
@@ -129,7 +109,7 @@ def md_job(
     dynamics_defaults["timestep"] = timestep_fs * fs
 
     if dynamics is NPT:
-        atoms = _upper_triangular_cell(atoms)
+        atoms = upper_triangular_cell(atoms)
 
     md_defaults = {"steps": steps, "dynamics_kwargs": dynamics_defaults}
     md_params = recursive_dict_merge(md_defaults, md_params)
@@ -140,115 +120,3 @@ def md_job(
     return Summarize(
         additional_fields={"name": f"{library} MD"} | (additional_fields or {})
     ).md(dyn)
-
-
-def _resolve_ensemble(
-    ensemble: MDEnsemble,
-    timestep: float,
-    temperature_K: float | None,
-    pressure_bar: float | None,
-) -> tuple[type[MolecularDynamics], dict[str, Any]]:
-    """
-    Resolve an ensemble name to an ASE dynamics class and its default kwargs.
-
-    The default parameters follow matcalc's `MDCalc`: `taut` is 100x the
-    timestep, `taup` is 1000x the timestep, and the pressure defaults to 0 bar
-    for the NPT-family ensembles.
-
-    Parameters
-    ----------
-    ensemble
-        Name of the ensemble (case-insensitive). See [quacc.recipes.mlip.md.md_job][]
-        for the supported names.
-    timestep
-        Time step in ASE units.
-    temperature_K
-        Temperature in K, if applicable for the given ensemble.
-    pressure_bar
-        Pressure in bar, if applicable for the given ensemble.
-
-    Returns
-    -------
-    tuple[type[MolecularDynamics], dict]
-        The ASE dynamics class and its default `dynamics_kwargs`.
-    """
-    taut = 100 * timestep
-    taup = 1000 * timestep
-    temperature = {
-        "temperature_K": temperature_K if temperature_K is not None else Remove
-    }
-    pressure = (pressure_bar if pressure_bar is not None else 0.0) * bar
-
-    presets: dict[str, tuple[type[MolecularDynamics], dict[str, Any]]] = {
-        "nve": (VelocityVerlet, {}),
-        "nvt": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
-        "nvt_berendsen": (NVTBerendsen, temperature | {"taut": taut}),
-        "nvt_langevin": (Langevin, temperature | {"friction": 1.0e-3}),
-        "nvt_andersen": (Andersen, temperature | {"andersen_prob": 1.0e-2}),
-        "nvt_bussi": (Bussi, temperature | {"taut": taut}),
-        "npt": (
-            NPT,
-            temperature
-            | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},
-        ),
-        "npt_berendsen": (
-            NPTBerendsen,
-            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
-        ),
-        "npt_inhomogeneous": (
-            Inhomogeneous_NPTBerendsen,
-            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
-        ),
-        "npt_mtk": (
-            MTKNPT,
-            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
-        ),
-        "npt_isotropic_mtk": (
-            IsotropicMTKNPT,
-            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
-        ),
-    }
-
-    if ensemble.lower() not in presets:
-        msg = (
-            f"Unsupported ensemble: {ensemble}. "
-            f"Valid options are: {', '.join(presets)}."
-        )
-        raise ValueError(msg)
-
-    return presets[ensemble.lower()]
-
-
-def _upper_triangular_cell(atoms: Atoms) -> Atoms:
-    """
-    Transform the cell to the upper-triangular form required by the ASE `NPT`
-    class, if it is not already in that form. Adapted from matcalc's `MDCalc`.
-
-    Parameters
-    ----------
-    atoms
-        Atoms object.
-
-    Returns
-    -------
-    Atoms
-        A copy of the Atoms object with an upper-triangular cell, or the
-        original Atoms object if the cell is already upper-triangular.
-    """
-    if atoms.cell[1, 0] == atoms.cell[2, 0] == atoms.cell[2, 1] == 0.0:
-        return atoms
-
-    atoms = atoms.copy()
-    a, b, c, alpha, beta, gamma = atoms.cell.cellpar()
-    angles = np.radians((alpha, beta, gamma))
-    sin_a, sin_b, _ = np.sin(angles)
-    cos_a, cos_b, cos_g = np.cos(angles)
-    cos_p = np.clip((cos_g - cos_a * cos_b) / (sin_a * sin_b), -1, 1)
-    sin_p = np.sqrt(1 - cos_p**2)
-    new_basis = [
-        (a * sin_b * sin_p, a * sin_b * cos_p, a * cos_b),
-        (0, b * sin_a, b * cos_a),
-        (0, 0, c),
-    ]
-    atoms.set_cell(new_basis, scale_atoms=True)
-    return atoms

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -29,14 +29,28 @@ if TYPE_CHECKING:
 
     from quacc.types import DynSchema, MDParams
 
+    MDEnsemble = Literal[
+        "nve",
+        "nvt",
+        "nvt_berendsen",
+        "nvt_langevin",
+        "nvt_andersen",
+        "nvt_bussi",
+        "npt",
+        "npt_berendsen",
+        "npt_inhomogeneous",
+        "npt_mtk",
+        "npt_isotropic_mtk",
+    ]
+
 
 @job
 def md_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
-    dynamics: MolecularDynamics | str = VelocityVerlet,
-    steps: int = 1000,
-    timestep_fs: float = 1.0,
+    dynamics: MolecularDynamics | MDEnsemble = VelocityVerlet,
+    steps: int = 10000,
+    timestep_fs: float = 0.5,
     temperature_K: float | None = None,
     pressure_bar: float | None = None,
     md_params: MDParams | None = None,
@@ -63,12 +77,12 @@ def md_job(
         `taup` to 1000x the timestep):
 
         - `"nve"`: `VelocityVerlet` (`temperature_K` and `pressure_bar` are ignored)
-        - `"nvt"`, `"nvt_nose_hoover"`: `NoseHooverChainNVT` (`tdamp=taut`)
+        - `"nvt"`: `NoseHooverChainNVT` (`tdamp=taut`)
         - `"nvt_berendsen"`: `NVTBerendsen` (`taut`)
         - `"nvt_langevin"`: `Langevin` (`friction=0.001`)
         - `"nvt_andersen"`: `Andersen` (`andersen_prob=0.01`)
         - `"nvt_bussi"`: `Bussi` (`taut`)
-        - `"npt"`, `"npt_nose_hoover"`: `NPT` (`ttime=25 fs`, `pfactor=75**2 fs`)
+        - `"npt"`: `NPT` (`ttime=25 fs`, `pfactor=75**2 fs`)
         - `"npt_berendsen"`: `NPTBerendsen` (`taut`, `taup`)
         - `"npt_inhomogeneous"`: `Inhomogeneous_NPTBerendsen` (`taut`, `taup`)
         - `"npt_mtk"`: `MTKNPT` (`tdamp=taut`, `pdamp=taup`)
@@ -129,7 +143,7 @@ def md_job(
 
 
 def _resolve_ensemble(
-    ensemble: str,
+    ensemble: MDEnsemble,
     timestep: float,
     temperature_K: float | None,
     pressure_bar: float | None,
@@ -168,17 +182,11 @@ def _resolve_ensemble(
     presets: dict[str, tuple[type[MolecularDynamics], dict[str, Any]]] = {
         "nve": (VelocityVerlet, {}),
         "nvt": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
-        "nvt_nose_hoover": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
         "nvt_berendsen": (NVTBerendsen, temperature | {"taut": taut}),
         "nvt_langevin": (Langevin, temperature | {"friction": 1.0e-3}),
         "nvt_andersen": (Andersen, temperature | {"andersen_prob": 1.0e-2}),
         "nvt_bussi": (Bussi, temperature | {"taut": taut}),
         "npt": (
-            NPT,
-            temperature
-            | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},
-        ),
-        "npt_nose_hoover": (
             NPT,
             temperature
             | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
-    from quacc.types import DynSchema, MDEnsemble, MDParams
+    from quacc.types import DynSchema, MDParams
+    from quacc.utils.md import MDEnsemble
 
 
 @job

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ase.md.npt import NPT
-from ase.md.verlet import VelocityVerlet
 from ase.units import bar, fs
 
 from quacc import Remove, job
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 def md_job(
     atoms: Atoms,
     library: Literal["fairchem", "matcalc", "rootstock"],
-    dynamics: MolecularDynamics | MDEnsemble = VelocityVerlet,
+    dynamics: MolecularDynamics | MDEnsemble = "nve",
     steps: int = 10000,
     timestep_fs: float = 0.5,
     temperature_K: float | None = None,
@@ -51,21 +50,27 @@ def md_job(
         - `matcalc` passes `**calc_kwargs` to `matcalc.load_fp()`
         - `rootstock` passes `**calc_kwargs` to `rootstock.RootstockCalculator()`
     dynamics
-        Either an ASE `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`)
-        or an ensemble name. Supported ensemble names, their ASE dynamics classes,
-        and their default parameters (any of which can be overridden via
+        Either an ensemble name (the default is `"nve"`) or an ASE
+        `MolecularDynamics` class (from `ase.md.md.MolecularDynamics`).
+        Supported ensemble names, their ASE dynamics classes, and their default
+        parameters (any of which can be overridden via
         `md_params["dynamics_kwargs"]`; `taut` defaults to 100x the timestep and
         `taup` to 1000x the timestep):
 
-        - `"nve"`: `VelocityVerlet` (`temperature_K` and `pressure_bar` are ignored)
+        - `"nve"`: `VelocityVerlet` (`pressure_bar` is ignored; `temperature_K`
+          only sets the initial velocities)
         - `"nvt"`: `NoseHooverChainNVT` (`tdamp=taut`)
         - `"nvt_berendsen"`: `NVTBerendsen` (`taut`)
         - `"nvt_langevin"`: `Langevin` (`friction=0.001`)
         - `"nvt_andersen"`: `Andersen` (`andersen_prob=0.01`)
         - `"nvt_bussi"`: `Bussi` (`taut`)
-        - `"npt"`: `NPT` (`ttime=25 fs`, `pfactor=75**2 fs`)
-        - `"npt_berendsen"`: `NPTBerendsen` (`taut`, `taup`)
-        - `"npt_inhomogeneous"`: `Inhomogeneous_NPTBerendsen` (`taut`, `taup`)
+        - `"npt"`: `NPT` (`ttime=25 fs` and matcalc's `pfactor=75**2 fs`; set
+          `pfactor` to `ptime**2 * B`, with `B` the bulk modulus, for a
+          physically motivated barostat time)
+        - `"npt_berendsen"`: `NPTBerendsen` (`taut`, `taup`; requires a
+          `compressibility_au` via `md_params["dynamics_kwargs"]`)
+        - `"npt_inhomogeneous"`: `Inhomogeneous_NPTBerendsen` (`taut`, `taup`;
+          requires a `compressibility_au` via `md_params["dynamics_kwargs"]`)
         - `"npt_mtk"`: `MTKNPT` (`tdamp=taut`, `pdamp=taup`)
         - `"npt_isotropic_mtk"`: `IsotropicMTKNPT` (`tdamp=taut`, `pdamp=taup`)
 
@@ -78,7 +83,13 @@ def md_job(
     timestep_fs
         Time step in fs.
     temperature_K
-        Temperature in K, if applicable for the given ensemble.
+        Temperature in K, if applicable for the given ensemble. Unless the
+        input atoms already have nonzero momenta, a Maxwell-Boltzmann
+        distribution at this temperature is also applied to initialize the
+        velocities; set `md_params={"maxwell_boltzmann_kwargs": None}` to
+        disable this. When `dynamics` is an ASE class, `temperature_K` is also
+        passed to the class and is only compatible with classes that accept
+        that keyword argument.
     pressure_bar
         Pressure in bar, if applicable for the given ensemble. When `dynamics` is
         an ASE class, this is passed as `pressure_au` and is only compatible with
@@ -113,6 +124,8 @@ def md_job(
         atoms = upper_triangular_cell(atoms)
 
     md_defaults = {"steps": steps, "dynamics_kwargs": dynamics_defaults}
+    if temperature_K is not None and not atoms.get_momenta().any():
+        md_defaults["maxwell_boltzmann_kwargs"] = {"temperature_K": temperature_K}
     md_params = recursive_dict_merge(md_defaults, md_params)
 
     calc = pick_calculator(library, **calc_kwargs)

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -75,8 +75,8 @@ def md_job(
         "steps": steps,
         "dynamics_kwargs": {
             "timestep": timestep_fs * fs,
-            "temperature_K": temperature_K if temperature_K else Remove,
-            "pressure_au": pressure_bar * bar if pressure_bar else Remove,
+            "temperature_K": temperature_K if temperature_K is not None else Remove,
+            "pressure_au": pressure_bar * bar if pressure_bar is not None else Remove,
         },
     }
     md_params = recursive_dict_merge(md_defaults, md_params)

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -111,7 +111,10 @@ def md_job(
     """
     if isinstance(dynamics, str):
         dynamics, dynamics_defaults = resolve_md_ensemble(
-            dynamics, timestep_fs * fs, temperature_K, pressure_bar
+            dynamics,
+            timestep_fs=timestep_fs,
+            temperature_K=temperature_K,
+            pressure_bar=pressure_bar,
         )
     else:
         dynamics_defaults = {

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -69,21 +69,6 @@ if TYPE_CHECKING:
 
     # ----------- Runner parameter type hints -----------
 
-    MDEnsemble = Literal[
-        "nve",
-        "nvt",
-        "nvt_berendsen",
-        "nvt_langevin",
-        "nvt_andersen",
-        "nvt_bussi",
-        "npt",
-        "npt_berendsen",
-        "npt_inhomogeneous",
-        "npt_mtk",
-        "npt_isotropic_mtk",
-    ]
-    """Ensemble names accepted by [quacc.utils.md.resolve_md_ensemble][]."""
-
     class OptParams(TypedDict, total=False):
         """
         Type hint for `opt_params` used throughout quacc.

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -69,6 +69,21 @@ if TYPE_CHECKING:
 
     # ----------- Runner parameter type hints -----------
 
+    MDEnsemble = Literal[
+        "nve",
+        "nvt",
+        "nvt_berendsen",
+        "nvt_langevin",
+        "nvt_andersen",
+        "nvt_bussi",
+        "npt",
+        "npt_berendsen",
+        "npt_inhomogeneous",
+        "npt_mtk",
+        "npt_isotropic_mtk",
+    ]
+    """Ensemble names accepted by [quacc.utils.md.resolve_md_ensemble][]."""
+
     class OptParams(TypedDict, total=False):
         """
         Type hint for `opt_params` used throughout quacc.

--- a/src/quacc/utils/md.py
+++ b/src/quacc/utils/md.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ase.md.andersen import Andersen
 from ase.md.bussi import Bussi
@@ -22,7 +22,20 @@ if TYPE_CHECKING:
     from ase.atoms import Atoms
     from ase.md.md import MolecularDynamics
 
-    from quacc.types import MDEnsemble
+MDEnsemble = Literal[
+    "nve",
+    "nvt",
+    "nvt_berendsen",
+    "nvt_langevin",
+    "nvt_andersen",
+    "nvt_bussi",
+    "npt",
+    "npt_berendsen",
+    "npt_inhomogeneous",
+    "npt_mtk",
+    "npt_isotropic_mtk",
+]
+"""Ensemble names accepted by [quacc.utils.md.resolve_md_ensemble][]."""
 
 
 def resolve_md_ensemble(
@@ -37,8 +50,8 @@ def resolve_md_ensemble(
     Parameters
     ----------
     ensemble
-        Name of the ensemble (case-insensitive). See [quacc.types.MDEnsemble][]
-        for the supported names.
+        Name of the ensemble (case-insensitive). See
+        [quacc.utils.md.MDEnsemble][] for the supported names.
     timestep
         Time step in ASE units.
     temperature_K

--- a/src/quacc/utils/md.py
+++ b/src/quacc/utils/md.py
@@ -47,6 +47,10 @@ def resolve_md_ensemble(
     """
     Resolve an ensemble name to an ASE dynamics class and its default kwargs.
 
+    Note that the `npt_berendsen` and `npt_inhomogeneous` 
+    presets additionally require a
+    `compressibility_au`, which is not set here.
+
     Parameters
     ----------
     ensemble

--- a/src/quacc/utils/md.py
+++ b/src/quacc/utils/md.py
@@ -40,24 +40,23 @@ MDEnsemble = Literal[
 
 def resolve_md_ensemble(
     ensemble: MDEnsemble,
-    timestep: float,
+    timestep_fs: float,
     temperature_K: float | None,
     pressure_bar: float | None,
 ) -> tuple[type[MolecularDynamics], dict[str, Any]]:
     """
     Resolve an ensemble name to an ASE dynamics class and its default kwargs.
 
-    Note that the `npt_berendsen` and `npt_inhomogeneous`
-    presets additionally require a
-    `compressibility_au`, which is not set here.
+    Note that the `npt_berendsen` and `npt_inhomogeneous` presets additionally
+    require a `compressibility_au`, which is not set here.
 
     Parameters
     ----------
     ensemble
         Name of the ensemble (case-insensitive). See
         [quacc.utils.md.MDEnsemble][] for the supported names.
-    timestep
-        Time step in ASE units.
+    timestep_fs
+        Time step in fs.
     temperature_K
         Temperature in K, if applicable for the given ensemble.
     pressure_bar
@@ -68,8 +67,8 @@ def resolve_md_ensemble(
     tuple[type[MolecularDynamics], dict]
         The ASE dynamics class and its default `dynamics_kwargs`.
     """
-    taut = 100 * timestep
-    taup = 1000 * timestep
+    taut = 100 * timestep_fs * fs
+    taup = 1000 * timestep_fs * fs
     temperature = {
         "temperature_K": temperature_K if temperature_K is not None else Remove
     }

--- a/src/quacc/utils/md.py
+++ b/src/quacc/utils/md.py
@@ -1,0 +1,127 @@
+"""Utility functions for molecular dynamics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ase.md.andersen import Andersen
+from ase.md.bussi import Bussi
+from ase.md.langevin import Langevin
+from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
+from ase.md.npt import NPT
+from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
+from ase.md.nvtberendsen import NVTBerendsen
+from ase.md.verlet import VelocityVerlet
+from ase.units import bar, fs
+
+from quacc.utils.dicts import Remove
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ase.atoms import Atoms
+    from ase.md.md import MolecularDynamics
+
+    from quacc.types import MDEnsemble
+
+
+def resolve_md_ensemble(
+    ensemble: MDEnsemble,
+    timestep: float,
+    temperature_K: float | None,
+    pressure_bar: float | None,
+) -> tuple[type[MolecularDynamics], dict[str, Any]]:
+    """
+    Resolve an ensemble name to an ASE dynamics class and its default kwargs.
+
+    Parameters
+    ----------
+    ensemble
+        Name of the ensemble (case-insensitive). See [quacc.types.MDEnsemble][]
+        for the supported names.
+    timestep
+        Time step in ASE units.
+    temperature_K
+        Temperature in K, if applicable for the given ensemble.
+    pressure_bar
+        Pressure in bar, if applicable for the given ensemble.
+
+    Returns
+    -------
+    tuple[type[MolecularDynamics], dict]
+        The ASE dynamics class and its default `dynamics_kwargs`.
+    """
+    taut = 100 * timestep
+    taup = 1000 * timestep
+    temperature = {
+        "temperature_K": temperature_K if temperature_K is not None else Remove
+    }
+    pressure = (pressure_bar if pressure_bar is not None else 0.0) * bar
+
+    presets: dict[str, tuple[type[MolecularDynamics], dict[str, Any]]] = {
+        "nve": (VelocityVerlet, {}),
+        "nvt": (NoseHooverChainNVT, temperature | {"tdamp": taut}),
+        "nvt_berendsen": (NVTBerendsen, temperature | {"taut": taut}),
+        "nvt_langevin": (Langevin, temperature | {"friction": 1.0e-3}),
+        "nvt_andersen": (Andersen, temperature | {"andersen_prob": 1.0e-2}),
+        "nvt_bussi": (Bussi, temperature | {"taut": taut}),
+        "npt": (
+            NPT,
+            temperature
+            | {"externalstress": pressure, "ttime": 25 * fs, "pfactor": 75.0**2 * fs},
+        ),
+        "npt_berendsen": (
+            NPTBerendsen,
+            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
+        ),
+        "npt_inhomogeneous": (
+            Inhomogeneous_NPTBerendsen,
+            temperature | {"pressure_au": pressure, "taut": taut, "taup": taup},
+        ),
+        "npt_mtk": (
+            MTKNPT,
+            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
+        ),
+        "npt_isotropic_mtk": (
+            IsotropicMTKNPT,
+            temperature | {"pressure_au": pressure, "tdamp": taut, "pdamp": taup},
+        ),
+    }
+
+    if ensemble.lower() not in presets:
+        msg = (
+            f"Unsupported ensemble: {ensemble}. "
+            f"Valid options are: {', '.join(presets)}."
+        )
+        raise ValueError(msg)
+
+    return presets[ensemble.lower()]
+
+
+def upper_triangular_cell(atoms: Atoms) -> Atoms:
+    """
+    Rotate the cell to the upper-triangular form required by the ASE `NPT`
+    class, using `ase.cell.Cell.standard_form`. The positions and any momenta are rotated
+    along with the cell, so the structure is unchanged.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object.
+
+    Returns
+    -------
+    Atoms
+        A copy of the Atoms object with an upper-triangular cell, or the
+        original Atoms object if the cell is already upper-triangular.
+    """
+    if atoms.cell[1, 0] == atoms.cell[2, 0] == atoms.cell[2, 1] == 0.0:
+        return atoms
+
+    atoms = atoms.copy()
+    cell, rotation = atoms.cell.standard_form(form="upper")
+    atoms.set_cell(cell)
+    atoms.set_positions(atoms.get_positions() @ rotation.T)
+    if atoms.has("momenta"):
+        atoms.set_momenta(atoms.get_momenta() @ rotation.T)
+    return atoms

--- a/src/quacc/utils/md.py
+++ b/src/quacc/utils/md.py
@@ -47,7 +47,7 @@ def resolve_md_ensemble(
     """
     Resolve an ensemble name to an ASE dynamics class and its default kwargs.
 
-    Note that the `npt_berendsen` and `npt_inhomogeneous` 
+    Note that the `npt_berendsen` and `npt_inhomogeneous`
     presets additionally require a
     `compressibility_au`, which is not set here.
 

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from ase.build import bulk, molecule
 from ase.constraints import FixAtoms
-from ase.md.langevin import Langevin
 from ase.md.npt import NPT
 from ase.optimize import FIRE
 from ase.units import fs
@@ -176,21 +175,6 @@ def test_md_job3():
     assert output["name"] == "EMT MD"
     assert output["trajectory_log"][1]["temperature"] == pytest.approx(759.8829)
     assert output["trajectory_results"][-1]["energy"] == pytest.approx(2.0363759)
-
-
-def test_md_job_zero_temperature():
-    # A 0 K setting (e.g. a Langevin quench) is valid and should not be
-    # silently dropped as falsy.
-    atoms = molecule("H2O")
-    output = md_job(
-        atoms,
-        dynamics=Langevin,
-        temperature_K=0,
-        steps=10,
-        md_params={"dynamics_kwargs": {"friction": 0.01}},
-    )
-    assert output["parameters_md"]["temperature_K"] == 0
-    assert len(output["trajectory"]) == 11
 
 
 def test_md_job_error():

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -7,8 +7,9 @@ import pytest
 from ase.build import bulk, molecule
 from ase.constraints import FixAtoms
 from ase.md.npt import NPT
+from ase.md.nptberendsen import NPTBerendsen
 from ase.optimize import FIRE
-from ase.units import fs
+from ase.units import bar, fs
 
 from quacc.recipes.emt.core import relax_job, static_job
 from quacc.recipes.emt.md import md_job
@@ -168,7 +169,11 @@ def test_md_job3():
         timestep_fs=1.0,
         temperature_K=1000,
         steps=500,
-        md_params={"dynamics_kwargs": {"ttime": 50 * fs}},
+        md_params={
+            "dynamics_kwargs": {"ttime": 50 * fs},
+            # The reference values below assume a zero-velocity start.
+            "maxwell_boltzmann_kwargs": None,
+        },
     )
     assert output["parameters"]["asap_cutoff"] is False
     assert len(output["trajectory"]) == 501
@@ -184,6 +189,52 @@ def test_md_job_ensemble():
     assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
     assert output["parameters_md"]["temperature_K"] == 300
     assert output["parameters_md"]["friction"] == pytest.approx(1.0e-3)
+
+
+def test_md_job_maxwell_boltzmann_default():
+    # When a temperature is given, the velocities are initialized to a
+    # Maxwell-Boltzmann distribution at that temperature by default.
+    atoms = molecule("H2O")
+    output = md_job(atoms, dynamics="nve", temperature_K=300, steps=5)
+    assert output["trajectory_log"][0]["temperature"] > 0
+
+    # An all-zero momenta array (e.g. from a file round-trip) is still seeded.
+    atoms = molecule("H2O")
+    atoms.set_momenta(np.zeros((len(atoms), 3)))
+    output = md_job(atoms, dynamics="nve", temperature_K=300, steps=5)
+    assert output["trajectory_log"][0]["temperature"] > 0
+
+
+def test_md_job_maxwell_boltzmann_preserves_momenta():
+    # Atoms that already carry momenta (e.g. a restart) are not re-seeded.
+    atoms = molecule("H2O")
+    atoms.set_momenta(np.full((len(atoms), 3), 0.1))
+    expected_temperature = atoms.get_temperature()
+    output = md_job(atoms, dynamics="nve", temperature_K=300, steps=5)
+    assert output["trajectory_log"][0]["temperature"] == pytest.approx(
+        expected_temperature
+    )
+
+
+def test_md_job_npt_berendsen():
+    # An ASE dynamics class that accepts pressure_au, with an explicit 0 bar.
+    atoms = bulk("Cu") * (2, 2, 2)
+    output = md_job(
+        atoms,
+        dynamics=NPTBerendsen,
+        temperature_K=300,
+        pressure_bar=0.0,
+        steps=10,
+        md_params={
+            "dynamics_kwargs": {
+                "taut": 50 * fs,
+                "taup": 500 * fs,
+                "compressibility_au": 4.57e-5 / bar,
+            }
+        },
+    )
+    assert len(output["trajectory"]) == 11
+    assert output["trajectory_log"][0]["temperature"] > 0
 
 
 def test_md_job_error():

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -120,7 +120,7 @@ def test_relax_job(tmp_path, monkeypatch):
 def test_md_job1():
     atoms = molecule("H2O")
     old_positions = atoms.positions.copy()
-    output = md_job(atoms, steps=500)
+    output = md_job(atoms, timestep_fs=1.0, steps=500)
     assert output["parameters"]["asap_cutoff"] is False
     assert len(output["trajectory"]) == 501
     assert output["name"] == "EMT MD"
@@ -175,6 +175,15 @@ def test_md_job3():
     assert output["name"] == "EMT MD"
     assert output["trajectory_log"][1]["temperature"] == pytest.approx(759.8829)
     assert output["trajectory_results"][-1]["energy"] == pytest.approx(2.0363759)
+
+
+def test_md_job_ensemble():
+    atoms = molecule("H2O")
+    output = md_job(atoms, dynamics="nvt_langevin", temperature_K=300, steps=20)
+    assert len(output["trajectory"]) == 21
+    assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
+    assert output["parameters_md"]["temperature_K"] == 300
+    assert output["parameters_md"]["friction"] == pytest.approx(1.0e-3)
 
 
 def test_md_job_error():

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from ase.build import bulk, molecule
 from ase.constraints import FixAtoms
+from ase.md.langevin import Langevin
 from ase.md.npt import NPT
 from ase.optimize import FIRE
 from ase.units import fs
@@ -175,6 +176,21 @@ def test_md_job3():
     assert output["name"] == "EMT MD"
     assert output["trajectory_log"][1]["temperature"] == pytest.approx(759.8829)
     assert output["trajectory_results"][-1]["energy"] == pytest.approx(2.0363759)
+
+
+def test_md_job_zero_temperature():
+    # A 0 K setting (e.g. a Langevin quench) is valid and should not be
+    # silently dropped as falsy.
+    atoms = molecule("H2O")
+    output = md_job(
+        atoms,
+        dynamics=Langevin,
+        temperature_K=0,
+        steps=10,
+        md_params={"dynamics_kwargs": {"friction": 0.01}},
+    )
+    assert output["parameters_md"]["temperature_K"] == 0
+    assert len(output["trajectory"]) == 11
 
 
 def test_md_job_error():

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -8,18 +8,10 @@ from importlib.util import find_spec
 
 import numpy as np
 from ase.build import bulk
-from ase.md.andersen import Andersen
-from ase.md.bussi import Bussi
 from ase.md.langevin import Langevin
-from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
-from ase.md.npt import NPT
-from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
-from ase.md.nvtberendsen import NVTBerendsen
-from ase.md.verlet import VelocityVerlet
-from ase.units import bar, fs
+from ase.units import fs
 
-from quacc import Remove
-from quacc.recipes.mlip.md import _resolve_ensemble, _upper_triangular_cell, md_job
+from quacc.recipes.mlip.md import md_job
 
 libraries = []
 if has_matcalc := find_spec("matcalc") and find_spec("matgl"):
@@ -65,8 +57,8 @@ def test_md_job(tmp_path, monkeypatch, library):
 
     assert output["name"] == f"{library} MD"
     assert len(output["trajectory"]) == 21
-    assert output["parameters_md"]["timestep"] == pytest.approx(1.0 * fs)
-    assert output["trajectory_log"][10]["time"] == pytest.approx(10 * fs)
+    assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
+    assert output["trajectory_log"][10]["time"] == pytest.approx(10 * 0.5 * fs)
     assert np.shape(output["results"]["forces"]) == (8, 3)
     # The velocities are seeded, so the initial temperature does not depend on
     # the MLIP library.
@@ -130,7 +122,7 @@ def test_md_job_ensemble_nvt_langevin(tmp_path, monkeypatch, library):
 
     assert output["name"] == f"{library} MD"
     assert len(output["trajectory"]) == 11
-    assert output["parameters_md"]["timestep"] == pytest.approx(1.0 * fs)
+    assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
     assert output["parameters_md"]["temperature_K"] == 300
     assert output["parameters_md"]["friction"] == pytest.approx(1.0e-3)
     assert output["trajectory_log"][-1]["temperature"] > 0
@@ -167,91 +159,3 @@ def test_md_job_ensemble_npt(tmp_path, monkeypatch, library):
     assert final_cell[1, 0] == final_cell[2, 0] == final_cell[2, 1] == 0.0
     # The input Atoms object should not be mutated.
     assert atoms.cell == pytest.approx(old_cell[:])
-
-
-@pytest.mark.parametrize(
-    ("ensemble", "expected_class"),
-    [
-        ("nve", VelocityVerlet),
-        ("nvt", NoseHooverChainNVT),
-        ("nvt_berendsen", NVTBerendsen),
-        ("nvt_langevin", Langevin),
-        ("nvt_andersen", Andersen),
-        ("nvt_bussi", Bussi),
-        ("npt", NPT),
-        ("npt_berendsen", NPTBerendsen),
-        ("npt_inhomogeneous", Inhomogeneous_NPTBerendsen),
-        ("npt_mtk", MTKNPT),
-        ("npt_isotropic_mtk", IsotropicMTKNPT),
-    ],
-)
-def test_resolve_ensemble_classes(ensemble, expected_class):
-    dynamics, _ = _resolve_ensemble(ensemble, 1.0 * fs, 300, None)
-    assert dynamics is expected_class
-
-
-def test_resolve_ensemble_is_case_insensitive():
-    dynamics, _ = _resolve_ensemble("NVT_Langevin", 1.0 * fs, 300, None)
-    assert dynamics is Langevin
-
-
-def test_resolve_ensemble_coupling_times_scale_with_timestep():
-    _, kwargs = _resolve_ensemble("npt_berendsen", 2.0 * fs, 300, 1.0)
-    assert kwargs["taut"] == pytest.approx(200 * fs)
-    assert kwargs["taup"] == pytest.approx(2000 * fs)
-
-    _, kwargs = _resolve_ensemble("nvt", 2.0 * fs, 300, None)
-    assert kwargs["tdamp"] == pytest.approx(200 * fs)
-
-
-def test_resolve_ensemble_pressure_routing():
-    # ase.md.npt.NPT takes `externalstress`; the Berendsen and MTK families
-    # take `pressure_au`.
-    _, kwargs = _resolve_ensemble("npt", 1.0 * fs, 300, 2.0)
-    assert kwargs["externalstress"] == pytest.approx(2.0 * bar)
-    assert "pressure_au" not in kwargs
-
-    _, kwargs = _resolve_ensemble("npt_berendsen", 1.0 * fs, 300, 2.0)
-    assert kwargs["pressure_au"] == pytest.approx(2.0 * bar)
-    assert "externalstress" not in kwargs
-
-    # The pressure defaults to 0 bar for the NPT-family ensembles.
-    _, kwargs = _resolve_ensemble("npt_mtk", 1.0 * fs, 300, None)
-    assert kwargs["pressure_au"] == 0.0
-
-
-def test_resolve_ensemble_temperature_handling():
-    # An explicit 0 K is honored; only None means unset.
-    _, kwargs = _resolve_ensemble("nvt_langevin", 1.0 * fs, 0, None)
-    assert kwargs["temperature_K"] == 0
-
-    _, kwargs = _resolve_ensemble("nvt_langevin", 1.0 * fs, None, None)
-    assert kwargs["temperature_K"] is Remove
-
-    # NVE ignores the temperature and pressure entirely.
-    _, kwargs = _resolve_ensemble("nve", 1.0 * fs, 300, 1.0)
-    assert kwargs == {}
-
-
-def test_resolve_ensemble_unknown():
-    with pytest.raises(ValueError, match="Unsupported ensemble"):
-        _resolve_ensemble("nvt_gibberish", 1.0 * fs, 300, None)
-
-
-def test_upper_triangular_cell():
-    # The primitive fcc cell is not upper-triangular.
-    atoms = bulk("Cu")
-    old_cell = atoms.cell.copy()
-
-    transformed = _upper_triangular_cell(atoms)
-    new_cell = transformed.cell
-
-    assert transformed is not atoms
-    assert new_cell[1, 0] == new_cell[2, 0] == new_cell[2, 1] == 0.0
-    assert new_cell.cellpar() == pytest.approx(old_cell.cellpar())
-    # The input Atoms object should not be mutated.
-    assert atoms.cell == pytest.approx(old_cell[:])
-
-    # An already upper-triangular cell is returned as-is.
-    cubic = bulk("Cu", cubic=True)
-    assert _upper_triangular_cell(cubic) is cubic

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from importlib.util import find_spec
+
+import numpy as np
+from ase.build import bulk
+from ase.md.langevin import Langevin
+from ase.units import fs
+
+from quacc.recipes.mlip.md import md_job
+
+libraries = []
+if has_matcalc := find_spec("matcalc") and find_spec("matgl"):
+    libraries.append("matcalc")
+
+
+if find_spec("fairchem"):
+    from huggingface_hub.utils._auth import get_token
+
+    if get_token():
+        libraries.append("fairchem")
+
+
+def _calc_kwargs(library):
+    if library == "fairchem":
+        # Note that for this to work, you need HF_TOKEN env variable set!
+        return {"name_or_path": "uma-s-1p1", "task_name": "omat"}
+    if library == "matcalc":
+        return {"name": "TensorNet-PES-MatPES-PBE-2025.2"}
+    return {}
+
+
+@pytest.mark.parametrize("library", libraries)
+def test_md_job(tmp_path, monkeypatch, library):
+    monkeypatch.chdir(tmp_path)
+
+    atoms = bulk("Cu") * (2, 2, 2)
+    old_positions = atoms.positions.copy()
+
+    output = md_job(
+        atoms,
+        library=library,
+        steps=20,
+        md_params={
+            "maxwell_boltzmann_kwargs": {
+                "temperature_K": 300,
+                "rng": np.random.default_rng(seed=42),
+            },
+            "set_com_stationary": True,
+        },
+        **_calc_kwargs(library),
+    )
+
+    assert output["name"] == f"{library} MD"
+    assert len(output["trajectory"]) == 21
+    assert output["parameters_md"]["timestep"] == pytest.approx(1.0 * fs)
+    assert output["trajectory_log"][10]["time"] == pytest.approx(10 * fs)
+    assert np.shape(output["results"]["forces"]) == (8, 3)
+    # The velocities are seeded, so the initial temperature does not depend on
+    # the MLIP library.
+    assert output["trajectory_log"][0]["temperature"] == pytest.approx(205.312, abs=0.01)
+    # The input Atoms object should not be mutated.
+    assert atoms.positions == pytest.approx(old_positions)
+
+
+@pytest.mark.parametrize("library", libraries)
+def test_md_job_nvt(tmp_path, monkeypatch, library):
+    monkeypatch.chdir(tmp_path)
+
+    atoms = bulk("Cu") * (2, 2, 2)
+
+    output = md_job(
+        atoms,
+        library=library,
+        dynamics=Langevin,
+        steps=20,
+        timestep_fs=0.5,
+        temperature_K=300,
+        md_params={
+            "dynamics_kwargs": {"friction": 0.01},
+            "maxwell_boltzmann_kwargs": {
+                "temperature_K": 300,
+                "rng": np.random.default_rng(seed=42),
+            },
+        },
+        **_calc_kwargs(library),
+    )
+
+    assert output["name"] == f"{library} MD"
+    assert len(output["trajectory"]) == 21
+    assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
+    assert output["parameters_md"]["temperature_K"] == 300
+    assert output["trajectory_log"][-1]["temperature"] > 0

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -84,10 +84,7 @@ def test_md_job_nvt(tmp_path, monkeypatch, library):
         temperature_K=300,
         md_params={
             "dynamics_kwargs": {"friction": 0.01},
-            "maxwell_boltzmann_kwargs": {
-                "temperature_K": 300,
-                "rng": np.random.default_rng(seed=42),
-            },
+            "maxwell_boltzmann_kwargs": {"rng": np.random.default_rng(seed=42)},
         },
         **_calc_kwargs(library),
     )
@@ -111,12 +108,7 @@ def test_md_job_ensemble_nvt_langevin(tmp_path, monkeypatch, library):
         dynamics="nvt_langevin",
         steps=10,
         temperature_K=300,
-        md_params={
-            "maxwell_boltzmann_kwargs": {
-                "temperature_K": 300,
-                "rng": np.random.default_rng(seed=42),
-            }
-        },
+        md_params={"maxwell_boltzmann_kwargs": {"rng": np.random.default_rng(seed=42)}},
         **_calc_kwargs(library),
     )
 
@@ -143,12 +135,7 @@ def test_md_job_ensemble_npt(tmp_path, monkeypatch, library):
         dynamics="npt",
         steps=10,
         temperature_K=300,
-        md_params={
-            "maxwell_boltzmann_kwargs": {
-                "temperature_K": 300,
-                "rng": np.random.default_rng(seed=42),
-            }
-        },
+        md_params={"maxwell_boltzmann_kwargs": {"rng": np.random.default_rng(seed=42)}},
         **_calc_kwargs(library),
     )
 

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -148,7 +148,7 @@ def test_md_job_ensemble_npt(tmp_path, monkeypatch, library):
     output = md_job(
         atoms,
         library=library,
-        dynamics="npt_nose_hoover",
+        dynamics="npt",
         steps=10,
         temperature_K=300,
         md_params={
@@ -174,13 +174,11 @@ def test_md_job_ensemble_npt(tmp_path, monkeypatch, library):
     [
         ("nve", VelocityVerlet),
         ("nvt", NoseHooverChainNVT),
-        ("nvt_nose_hoover", NoseHooverChainNVT),
         ("nvt_berendsen", NVTBerendsen),
         ("nvt_langevin", Langevin),
         ("nvt_andersen", Andersen),
         ("nvt_bussi", Bussi),
         ("npt", NPT),
-        ("npt_nose_hoover", NPT),
         ("npt_berendsen", NPTBerendsen),
         ("npt_inhomogeneous", Inhomogeneous_NPTBerendsen),
         ("npt_mtk", MTKNPT),

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -8,10 +8,18 @@ from importlib.util import find_spec
 
 import numpy as np
 from ase.build import bulk
+from ase.md.andersen import Andersen
+from ase.md.bussi import Bussi
 from ase.md.langevin import Langevin
-from ase.units import fs
+from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
+from ase.md.npt import NPT
+from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
+from ase.md.nvtberendsen import NVTBerendsen
+from ase.md.verlet import VelocityVerlet
+from ase.units import bar, fs
 
-from quacc.recipes.mlip.md import md_job
+from quacc import Remove
+from quacc.recipes.mlip.md import _resolve_ensemble, _upper_triangular_cell, md_job
 
 libraries = []
 if has_matcalc := find_spec("matcalc") and find_spec("matgl"):
@@ -97,3 +105,155 @@ def test_md_job_nvt(tmp_path, monkeypatch, library):
     assert output["parameters_md"]["timestep"] == pytest.approx(0.5 * fs)
     assert output["parameters_md"]["temperature_K"] == 300
     assert output["trajectory_log"][-1]["temperature"] > 0
+
+
+@pytest.mark.parametrize("library", libraries)
+def test_md_job_ensemble_nvt_langevin(tmp_path, monkeypatch, library):
+    monkeypatch.chdir(tmp_path)
+
+    atoms = bulk("Cu") * (2, 2, 2)
+
+    output = md_job(
+        atoms,
+        library=library,
+        dynamics="nvt_langevin",
+        steps=10,
+        temperature_K=300,
+        md_params={
+            "maxwell_boltzmann_kwargs": {
+                "temperature_K": 300,
+                "rng": np.random.default_rng(seed=42),
+            }
+        },
+        **_calc_kwargs(library),
+    )
+
+    assert output["name"] == f"{library} MD"
+    assert len(output["trajectory"]) == 11
+    assert output["parameters_md"]["timestep"] == pytest.approx(1.0 * fs)
+    assert output["parameters_md"]["temperature_K"] == 300
+    assert output["parameters_md"]["friction"] == pytest.approx(1.0e-3)
+    assert output["trajectory_log"][-1]["temperature"] > 0
+
+
+@pytest.mark.parametrize("library", libraries)
+def test_md_job_ensemble_npt(tmp_path, monkeypatch, library):
+    monkeypatch.chdir(tmp_path)
+
+    # The primitive fcc cell is not upper-triangular, which the ASE NPT class
+    # requires; md_job should transform it automatically.
+    atoms = bulk("Cu") * (2, 2, 2)
+    old_cell = atoms.cell.copy()
+
+    output = md_job(
+        atoms,
+        library=library,
+        dynamics="npt_nose_hoover",
+        steps=10,
+        temperature_K=300,
+        md_params={
+            "maxwell_boltzmann_kwargs": {
+                "temperature_K": 300,
+                "rng": np.random.default_rng(seed=42),
+            }
+        },
+        **_calc_kwargs(library),
+    )
+
+    assert output["name"] == f"{library} MD"
+    assert len(output["trajectory"]) == 11
+    assert output["trajectory_log"][-1]["temperature"] > 0
+    final_cell = output["atoms"].cell
+    assert final_cell[1, 0] == final_cell[2, 0] == final_cell[2, 1] == 0.0
+    # The input Atoms object should not be mutated.
+    assert atoms.cell == pytest.approx(old_cell[:])
+
+
+@pytest.mark.parametrize(
+    ("ensemble", "expected_class"),
+    [
+        ("nve", VelocityVerlet),
+        ("nvt", NoseHooverChainNVT),
+        ("nvt_nose_hoover", NoseHooverChainNVT),
+        ("nvt_berendsen", NVTBerendsen),
+        ("nvt_langevin", Langevin),
+        ("nvt_andersen", Andersen),
+        ("nvt_bussi", Bussi),
+        ("npt", NPT),
+        ("npt_nose_hoover", NPT),
+        ("npt_berendsen", NPTBerendsen),
+        ("npt_inhomogeneous", Inhomogeneous_NPTBerendsen),
+        ("npt_mtk", MTKNPT),
+        ("npt_isotropic_mtk", IsotropicMTKNPT),
+    ],
+)
+def test_resolve_ensemble_classes(ensemble, expected_class):
+    dynamics, _ = _resolve_ensemble(ensemble, 1.0 * fs, 300, None)
+    assert dynamics is expected_class
+
+
+def test_resolve_ensemble_is_case_insensitive():
+    dynamics, _ = _resolve_ensemble("NVT_Langevin", 1.0 * fs, 300, None)
+    assert dynamics is Langevin
+
+
+def test_resolve_ensemble_coupling_times_scale_with_timestep():
+    _, kwargs = _resolve_ensemble("npt_berendsen", 2.0 * fs, 300, 1.0)
+    assert kwargs["taut"] == pytest.approx(200 * fs)
+    assert kwargs["taup"] == pytest.approx(2000 * fs)
+
+    _, kwargs = _resolve_ensemble("nvt", 2.0 * fs, 300, None)
+    assert kwargs["tdamp"] == pytest.approx(200 * fs)
+
+
+def test_resolve_ensemble_pressure_routing():
+    # ase.md.npt.NPT takes `externalstress`; the Berendsen and MTK families
+    # take `pressure_au`.
+    _, kwargs = _resolve_ensemble("npt", 1.0 * fs, 300, 2.0)
+    assert kwargs["externalstress"] == pytest.approx(2.0 * bar)
+    assert "pressure_au" not in kwargs
+
+    _, kwargs = _resolve_ensemble("npt_berendsen", 1.0 * fs, 300, 2.0)
+    assert kwargs["pressure_au"] == pytest.approx(2.0 * bar)
+    assert "externalstress" not in kwargs
+
+    # The pressure defaults to 0 bar for the NPT-family ensembles.
+    _, kwargs = _resolve_ensemble("npt_mtk", 1.0 * fs, 300, None)
+    assert kwargs["pressure_au"] == 0.0
+
+
+def test_resolve_ensemble_temperature_handling():
+    # An explicit 0 K is honored; only None means unset.
+    _, kwargs = _resolve_ensemble("nvt_langevin", 1.0 * fs, 0, None)
+    assert kwargs["temperature_K"] == 0
+
+    _, kwargs = _resolve_ensemble("nvt_langevin", 1.0 * fs, None, None)
+    assert kwargs["temperature_K"] is Remove
+
+    # NVE ignores the temperature and pressure entirely.
+    _, kwargs = _resolve_ensemble("nve", 1.0 * fs, 300, 1.0)
+    assert kwargs == {}
+
+
+def test_resolve_ensemble_unknown():
+    with pytest.raises(ValueError, match="Unsupported ensemble"):
+        _resolve_ensemble("nvt_gibberish", 1.0 * fs, 300, None)
+
+
+def test_upper_triangular_cell():
+    # The primitive fcc cell is not upper-triangular.
+    atoms = bulk("Cu")
+    old_cell = atoms.cell.copy()
+
+    transformed = _upper_triangular_cell(atoms)
+    new_cell = transformed.cell
+
+    assert transformed is not atoms
+    assert new_cell[1, 0] == new_cell[2, 0] == new_cell[2, 1] == 0.0
+    assert new_cell.cellpar() == pytest.approx(old_cell.cellpar())
+    # The input Atoms object should not be mutated.
+    assert atoms.cell == pytest.approx(old_cell[:])
+
+    # An already upper-triangular cell is returned as-is.
+    cubic = bulk("Cu", cubic=True)
+    assert _upper_triangular_cell(cubic) is cubic

--- a/tests/core/recipes/mlip_recipes/test_md_recipes.py
+++ b/tests/core/recipes/mlip_recipes/test_md_recipes.py
@@ -62,7 +62,9 @@ def test_md_job(tmp_path, monkeypatch, library):
     assert np.shape(output["results"]["forces"]) == (8, 3)
     # The velocities are seeded, so the initial temperature does not depend on
     # the MLIP library.
-    assert output["trajectory_log"][0]["temperature"] == pytest.approx(205.312, abs=0.01)
+    assert output["trajectory_log"][0]["temperature"] == pytest.approx(
+        205.312, abs=0.01
+    )
     # The input Atoms object should not be mutated.
     assert atoms.positions == pytest.approx(old_positions)
 

--- a/tests/core/utils/test_md.py
+++ b/tests/core/utils/test_md.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ase.build import bulk
+from ase.md.andersen import Andersen
+from ase.md.bussi import Bussi
+from ase.md.langevin import Langevin
+from ase.md.nose_hoover_chain import MTKNPT, IsotropicMTKNPT, NoseHooverChainNVT
+from ase.md.npt import NPT
+from ase.md.nptberendsen import Inhomogeneous_NPTBerendsen, NPTBerendsen
+from ase.md.nvtberendsen import NVTBerendsen
+from ase.md.verlet import VelocityVerlet
+from ase.units import bar, fs
+
+from quacc import Remove
+from quacc.utils.md import resolve_md_ensemble, upper_triangular_cell
+
+
+@pytest.mark.parametrize(
+    ("ensemble", "expected_class"),
+    [
+        ("nve", VelocityVerlet),
+        ("nvt", NoseHooverChainNVT),
+        ("nvt_berendsen", NVTBerendsen),
+        ("nvt_langevin", Langevin),
+        ("nvt_andersen", Andersen),
+        ("nvt_bussi", Bussi),
+        ("npt", NPT),
+        ("npt_berendsen", NPTBerendsen),
+        ("npt_inhomogeneous", Inhomogeneous_NPTBerendsen),
+        ("npt_mtk", MTKNPT),
+        ("npt_isotropic_mtk", IsotropicMTKNPT),
+    ],
+)
+def test_resolve_md_ensemble_classes(ensemble, expected_class):
+    dynamics, _ = resolve_md_ensemble(ensemble, 1.0 * fs, 300, None)
+    assert dynamics is expected_class
+
+
+def test_resolve_md_ensemble_is_case_insensitive():
+    dynamics, _ = resolve_md_ensemble("NVT_Langevin", 1.0 * fs, 300, None)
+    assert dynamics is Langevin
+
+
+def test_resolve_md_ensemble_coupling_times_scale_with_timestep():
+    _, kwargs = resolve_md_ensemble("npt_berendsen", 2.0 * fs, 300, 1.0)
+    assert kwargs["taut"] == pytest.approx(200 * fs)
+    assert kwargs["taup"] == pytest.approx(2000 * fs)
+
+    _, kwargs = resolve_md_ensemble("nvt", 2.0 * fs, 300, None)
+    assert kwargs["tdamp"] == pytest.approx(200 * fs)
+
+
+def test_resolve_md_ensemble_pressure_routing():
+    # ase.md.npt.NPT takes `externalstress`; the Berendsen and MTK families
+    # take `pressure_au`.
+    _, kwargs = resolve_md_ensemble("npt", 1.0 * fs, 300, 2.0)
+    assert kwargs["externalstress"] == pytest.approx(2.0 * bar)
+    assert "pressure_au" not in kwargs
+
+    _, kwargs = resolve_md_ensemble("npt_berendsen", 1.0 * fs, 300, 2.0)
+    assert kwargs["pressure_au"] == pytest.approx(2.0 * bar)
+    assert "externalstress" not in kwargs
+
+    # The pressure defaults to 0 bar for the NPT-family ensembles.
+    _, kwargs = resolve_md_ensemble("npt_mtk", 1.0 * fs, 300, None)
+    assert kwargs["pressure_au"] == 0.0
+
+
+def test_resolve_md_ensemble_temperature_handling():
+    # An explicit 0 K is honored; only None means unset.
+    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0 * fs, 0, None)
+    assert kwargs["temperature_K"] == 0
+
+    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0 * fs, None, None)
+    assert kwargs["temperature_K"] is Remove
+
+    # NVE ignores the temperature and pressure entirely.
+    _, kwargs = resolve_md_ensemble("nve", 1.0 * fs, 300, 1.0)
+    assert kwargs == {}
+
+
+def test_resolve_md_ensemble_unknown():
+    with pytest.raises(ValueError, match="Unsupported ensemble"):
+        resolve_md_ensemble("nvt_gibberish", 1.0 * fs, 300, None)
+
+
+def test_upper_triangular_cell():
+    # The primitive fcc cell is not upper-triangular.
+    atoms = bulk("Cu")
+    old_cell = atoms.cell.copy()
+
+    transformed = upper_triangular_cell(atoms)
+    new_cell = transformed.cell
+
+    assert transformed is not atoms
+    assert new_cell[1, 0] == new_cell[2, 0] == new_cell[2, 1] == 0.0
+    assert new_cell.cellpar() == pytest.approx(old_cell.cellpar())
+    # The input Atoms object should not be mutated.
+    assert atoms.cell == pytest.approx(old_cell[:])
+
+    # An already upper-triangular cell is returned as-is.
+    cubic = bulk("Cu", cubic=True)
+    assert upper_triangular_cell(cubic) is cubic
+
+
+def test_upper_triangular_cell_rotates_momenta():
+    atoms = bulk("Cu") * (2, 2, 2)
+    rng = np.random.default_rng(seed=42)
+    atoms.set_momenta(rng.normal(size=(len(atoms), 3)))
+    speeds = np.linalg.norm(atoms.get_momenta(), axis=1)
+
+    transformed = upper_triangular_cell(atoms)
+
+    # The momenta are rotated along with the cell: the magnitudes are
+    # unchanged, and the scaled (fractional) momenta are preserved.
+    assert np.linalg.norm(transformed.get_momenta(), axis=1) == pytest.approx(speeds)
+    assert transformed.get_momenta() @ np.linalg.inv(transformed.cell) == pytest.approx(
+        atoms.get_momenta() @ np.linalg.inv(atoms.cell)
+    )

--- a/tests/core/utils/test_md.py
+++ b/tests/core/utils/test_md.py
@@ -34,56 +34,56 @@ from quacc.utils.md import resolve_md_ensemble, upper_triangular_cell
     ],
 )
 def test_resolve_md_ensemble_classes(ensemble, expected_class):
-    dynamics, _ = resolve_md_ensemble(ensemble, 1.0 * fs, 300, None)
+    dynamics, _ = resolve_md_ensemble(ensemble, 1.0, 300, None)
     assert dynamics is expected_class
 
 
 def test_resolve_md_ensemble_is_case_insensitive():
-    dynamics, _ = resolve_md_ensemble("NVT_Langevin", 1.0 * fs, 300, None)
+    dynamics, _ = resolve_md_ensemble("NVT_Langevin", 1.0, 300, None)
     assert dynamics is Langevin
 
 
 def test_resolve_md_ensemble_coupling_times_scale_with_timestep():
-    _, kwargs = resolve_md_ensemble("npt_berendsen", 2.0 * fs, 300, 1.0)
+    _, kwargs = resolve_md_ensemble("npt_berendsen", 2.0, 300, 1.0)
     assert kwargs["taut"] == pytest.approx(200 * fs)
     assert kwargs["taup"] == pytest.approx(2000 * fs)
 
-    _, kwargs = resolve_md_ensemble("nvt", 2.0 * fs, 300, None)
+    _, kwargs = resolve_md_ensemble("nvt", 2.0, 300, None)
     assert kwargs["tdamp"] == pytest.approx(200 * fs)
 
 
 def test_resolve_md_ensemble_pressure_routing():
     # ase.md.npt.NPT takes `externalstress`; the Berendsen and MTK families
     # take `pressure_au`.
-    _, kwargs = resolve_md_ensemble("npt", 1.0 * fs, 300, 2.0)
+    _, kwargs = resolve_md_ensemble("npt", 1.0, 300, 2.0)
     assert kwargs["externalstress"] == pytest.approx(2.0 * bar)
     assert "pressure_au" not in kwargs
 
-    _, kwargs = resolve_md_ensemble("npt_berendsen", 1.0 * fs, 300, 2.0)
+    _, kwargs = resolve_md_ensemble("npt_berendsen", 1.0, 300, 2.0)
     assert kwargs["pressure_au"] == pytest.approx(2.0 * bar)
     assert "externalstress" not in kwargs
 
     # The pressure defaults to 0 bar for the NPT-family ensembles.
-    _, kwargs = resolve_md_ensemble("npt_mtk", 1.0 * fs, 300, None)
+    _, kwargs = resolve_md_ensemble("npt_mtk", 1.0, 300, None)
     assert kwargs["pressure_au"] == 0.0
 
 
 def test_resolve_md_ensemble_temperature_handling():
     # An explicit 0 K is honored; only None means unset.
-    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0 * fs, 0, None)
+    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0, 0, None)
     assert kwargs["temperature_K"] == 0
 
-    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0 * fs, None, None)
+    _, kwargs = resolve_md_ensemble("nvt_langevin", 1.0, None, None)
     assert kwargs["temperature_K"] is Remove
 
     # NVE ignores the temperature and pressure entirely.
-    _, kwargs = resolve_md_ensemble("nve", 1.0 * fs, 300, 1.0)
+    _, kwargs = resolve_md_ensemble("nve", 1.0, 300, 1.0)
     assert kwargs == {}
 
 
 def test_resolve_md_ensemble_unknown():
     with pytest.raises(ValueError, match="Unsupported ensemble"):
-        resolve_md_ensemble("nvt_gibberish", 1.0 * fs, 300, None)
+        resolve_md_ensemble("nvt_gibberish", 1.0, 300, None)
 
 
 def test_upper_triangular_cell():


### PR DESCRIPTION
## Summary of Changes

- I added MD recipe for MLIPs mirroring the EMT recipe.
- MD with MLIP accepts an ensemble name ("nve", "nvt", "nvt_langevin",...)
- Bug Fix: In previous code, temperature_K or pressure_bar of ) was discarded as falsy in emt/md.py.

## Things to discuss
- Ensemble stuff could be moved to Runner.run_md (or whatever you prefer) so it can be used for different calculator settings.
- The four MD recipes currently use three parameter conventions 
(`emt`/`mlip`: `steps`, `timestep_fs`, `temperature_K`, `pressure_bar`; `vasp`: `nsteps`, `timestep`, `temperature`, `pressure`; `torchsim`: `n_steps`, `timestep`, `temperature`)

Closes #3424.