### PR TITLE
Clarify mlip docstrings

### DIFF
--- a/src/quacc/recipes/mlip/_base.py
+++ b/src/quacc/recipes/mlip/_base.py
@@ -78,6 +78,9 @@ def pick_calculator(
               checkpoint file, e.g. `name_or_path="uma-s-1p1"`.
             - `task_name` (required for UMA checkpoints): one of `"omol"`,
               `"omat"`, `"oc20"`, `"odac"`, or `"omc"`.
+            - Optional: `inference_settings`, `overrides`, `device`, and
+              `workers`; see `FAIRChemCalculator.from_model_checkpoint` for
+              details.
             - Downloading gated checkpoints requires Hugging Face
               authentication.
         - `matcalc`:

--- a/src/quacc/recipes/mlip/_base.py
+++ b/src/quacc/recipes/mlip/_base.py
@@ -58,6 +58,7 @@ def pick_calculator(
     library: Literal["fairchem", "matcalc", "rootstock"], **calc_kwargs: Any
 ) -> BaseCalculator:
     """
+    Instantiate an ASE calculator from one of the supported MLIP libraries.
 
     Parameters
     ----------
@@ -67,7 +68,27 @@ def pick_calculator(
         - `matcalc` passes `**calc_kwargs` to `matcalc.load_fp()`
         - `rootstock` passes `**calc_kwargs` to `rootstock.RootstockCalculator()`
     **calc_kwargs
-        Custom kwargs for the underlying MLIP library.
+        Keyword arguments forwarded to the loader function listed above for
+        the given `library`. Every argument must be passed by keyword, even
+        ones that are positional in the underlying function. Per library:
+
+        - `fairchem`:
+            - `name_or_path` (required): a model name from
+              `fairchem.core.pretrained_mlip.available_models` or a path to a
+              checkpoint file, e.g. `name_or_path="uma-s-1p1"`.
+            - `task_name` (required for UMA checkpoints): one of `"omol"`,
+              `"omat"`, `"oc20"`, `"odac"`, or `"omc"`.
+            - Downloading gated checkpoints requires Hugging Face
+              authentication.
+        - `matcalc`:
+            - `name` (required): the name of the foundation potential, e.g.
+              `name="TensorNet-MatPES-PBE-2025.2"`. The supported names are
+              the entries of `matcalc.UNIVERSAL_CALCULATOR_NAMES`
+              (case-insensitive; common aliases are also accepted).
+        - `rootstock`:
+            - `checkpoint` (required): the checkpoint identifier, e.g.
+              `checkpoint="mace-mp-0-medium"`. The corresponding environment
+              must be pre-built via `rootstock install`.
 
     Returns
     -------

--- a/src/quacc/recipes/mlip/core.py
+++ b/src/quacc/recipes/mlip/core.py
@@ -41,7 +41,11 @@ def static_job(
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
-        Custom kwargs for the underlying MLIP library.
+        Custom kwargs for the underlying MLIP library, all passed by keyword.
+        `matcalc` requires `name`, `rootstock` requires `checkpoint`, and
+        `fairchem` requires `name_or_path` (plus `task_name` for UMA
+        checkpoints). See [quacc.recipes.mlip._base.pick_calculator][] for
+        details and examples.
 
     Returns
     -------
@@ -89,7 +93,11 @@ def relax_job(
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
-        Custom kwargs for the underlying MLIP library.
+        Custom kwargs for the underlying MLIP library, all passed by keyword.
+        `matcalc` requires `name`, `rootstock` requires `checkpoint`, and
+        `fairchem` requires `name_or_path` (plus `task_name` for UMA
+        checkpoints). See [quacc.recipes.mlip._base.pick_calculator][] for
+        details and examples.
 
     Returns
     -------

--- a/src/quacc/recipes/mlip/core.py
+++ b/src/quacc/recipes/mlip/core.py
@@ -52,6 +52,12 @@ def static_job(
     RunSchema
         Dictionary of results from [quacc.schemas.ase.Summarize.run][].
         See the type-hint for the data structure.
+
+    Examples
+    --------
+    >>> static_job(atoms, "fairchem", name_or_path="uma-s-1p1", task_name="omat")
+    >>> static_job(atoms, "matcalc", name="TensorNet-MatPES-PBE-2025.2")
+    >>> static_job(atoms, "rootstock", checkpoint="mace-mp-0-medium")
     """
     calc = pick_calculator(library, **calc_kwargs)
     final_atoms = Runner(atoms, calc).run_calc()

--- a/src/quacc/recipes/mlip/elastic.py
+++ b/src/quacc/recipes/mlip/elastic.py
@@ -32,21 +32,21 @@ def elastic_tensor_flow(
 
     1. Bulk structure relaxation (if pre_relax is True)
         - name: "relax_job"
-        - job: [quacc.recipes.emt.core.relax_job][]
+        - job: [quacc.recipes.mlip.core.relax_job][]
 
     2. Bulk structure static calculation (if run_static is True)
         - name: "static_job"
-        - job: [quacc.recipes.emt.core.static_job][]
+        - job: [quacc.recipes.mlip.core.static_job][]
 
     3. Deformed structures generation
 
     4. Deformed structures relaxations
         - name: "relax_job"
-        - job: [quacc.recipes.emt.core.relax_job][]
+        - job: [quacc.recipes.mlip.core.relax_job][]
 
     5. Deformed structures statics (if run_static is True)
         - name: "static_job"
-        - job: [quacc.recipes.emt.core.static_job][]
+        - job: [quacc.recipes.mlip.core.static_job][]
 
     6. Elastic tensor calculation
 
@@ -63,6 +63,11 @@ def elastic_tensor_flow(
     job_params
         Custom parameters to pass to each Job in the Flow. This is a dictionary where
         the keys are the names of the jobs and the values are dictionaries of parameters.
+        This is also where the MLIP `library` and its calculator kwargs are supplied
+        to each job, e.g. `job_params={"relax_job": {"library": "matcalc", "name":
+        "TensorNet-MatPES-PBE-2025.2"}}`. See
+        [quacc.recipes.mlip._base.pick_calculator][] for the kwargs each library
+        requires.
     job_decorators
         Custom decorators to apply to each Job in the Flow. This is a dictionary where
         the keys are the names of the jobs and the values are decorators.

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -112,6 +112,12 @@ def md_job(
     DynSchema
         Dictionary of results, specified in [quacc.schemas.ase.Summarize.md][].
         See the type-hint for the data structure.
+
+    Examples
+    --------
+    >>> md_job(atoms, "fairchem", name_or_path="uma-s-1p1", task_name="omat")
+    >>> md_job(atoms, "matcalc", name="tensornet", dynamics="nvt", temperature_K=300)
+    >>> md_job(atoms, "rootstock", checkpoint="mace-mp-0-medium", steps=1000)
     """
     if isinstance(dynamics, str):
         dynamics, dynamics_defaults = resolve_md_ensemble(

--- a/src/quacc/recipes/mlip/md.py
+++ b/src/quacc/recipes/mlip/md.py
@@ -101,7 +101,11 @@ def md_job(
     additional_fields
         Additional fields to add to the results dictionary.
     **calc_kwargs
-        Custom kwargs for the underlying MLIP library.
+        Custom kwargs for the underlying MLIP library, all passed by keyword.
+        `matcalc` requires `name`, `rootstock` requires `checkpoint`, and
+        `fairchem` requires `name_or_path` (plus `task_name` for UMA
+        checkpoints). See [quacc.recipes.mlip._base.pick_calculator][] for
+        details and examples.
 
     Returns
     -------

--- a/src/quacc/recipes/mlip/phonons.py
+++ b/src/quacc/recipes/mlip/phonons.py
@@ -84,6 +84,11 @@ def phonon_flow(
     job_params
         Custom parameters to pass to each Job in the Flow. This is a dictionary where
         the keys are the names of the jobs and the values are dictionaries of parameters.
+        This is also where the MLIP `library` and its calculator kwargs are supplied
+        to each job, e.g. `job_params={"static_job": {"library": "matcalc", "name":
+        "TensorNet-MatPES-PBE-2025.2"}}`. See
+        [quacc.recipes.mlip._base.pick_calculator][] for the kwargs each library
+        requires.
     job_decorators
         Custom decorators to apply to each Job in the Flow. This is a dictionary where
         the keys are the names of the jobs and the values are decorators.


### PR DESCRIPTION
Closes #3423

- `pick_calculator` now documents the required keyword arguments per library
  (matcalc `name`, fairchem `name_or_path` + `task_name` for UMA, rootstock
  `checkpoint`).
- The job docstrings (`static_job`, `relax_job`, `md_job`) carry a condensed
  version and cross-reference `pick_calculator`.
- Added `Examples` sections to `static_job` and `md_job`
- The flow docstrings (`elastic`, `phonons`) now say that `library` and the
  calculator kwargs are supplied via `job_params`, with an example.
- Fixed the elastic flow docstring cross-references, which pointed at the
  `emt` jobs instead of the `mlip` ones (copy-paste leftover).