### PR TITLE
Handle graceful MD wall-time interruptions

### DIFF
--- a/src/quacc/runners/ase.py
+++ b/src/quacc/runners/ase.py
@@ -9,6 +9,7 @@ from importlib.util import find_spec
 from logging import getLogger
 from pathlib import Path
 from shutil import copy, copytree
+from time import monotonic
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -166,6 +167,7 @@ class Runner(BaseRunner):
         run_kwargs: dict[str, Any] | None = None,
         filter_kwargs: dict[str, Any] | None = None,
         write_files: bool = True,
+        stop_condition: Callable[[Dynamics], bool] | None = None,
     ) -> Optimizer:
         """
         This is a wrapper around the optimizers in ASE.
@@ -198,6 +200,10 @@ class Runner(BaseRunner):
             Dictionary of kwargs for the `FrechetCellFilter` if relax_cell is True.
         write_files
             Whether to write the optimizer log, restart, and trajectory files.
+        stop_condition
+            A callable evaluated after each step. The run exits cleanly when it
+            returns True, allowing trajectory files and calculation outputs to be
+            finalized normally.
 
         Returns
         -------
@@ -268,6 +274,8 @@ class Runner(BaseRunner):
                             )
                         if fn_hook:
                             fn_hook(dyn)
+                        if stop_condition and stop_condition(dyn):
+                            break
         except Exception as exception:
             terminate(self.tmpdir, exception)
 
@@ -323,6 +331,9 @@ class Runner(BaseRunner):
         maxwell_boltzmann_kwargs: MaxwellBoltzmanDistributionKwargs | None = None,
         set_com_stationary: bool = False,
         set_zero_rotation: bool = False,
+        stop_condition: Callable[[MolecularDynamics], bool] | None = None,
+        max_runtime: float | None = None,
+        stop_reason: str = "walltime",
     ) -> MolecularDynamics:
         """
         Run an ASE-based MD in a scratch directory and copy the results back to
@@ -347,6 +358,15 @@ class Runner(BaseRunner):
         set_zero_rotation
             Whether to set the total angular momentum to zero. This would be applied after
             any `MaxwellBoltzmannDistribution` is set.
+        stop_condition
+            A callable evaluated after each MD step. The run exits cleanly when it
+            returns True. This can be backed by a flag set from a scheduler signal
+            handler.
+        max_runtime
+            Maximum runtime in seconds. The MD run exits cleanly after the first
+            completed step at or beyond this limit.
+        stop_reason
+            Reason recorded on the dynamics object when the run is stopped early.
 
         Returns
         -------
@@ -366,12 +386,29 @@ class Runner(BaseRunner):
         if set_zero_rotation:
             ZeroRotation(self.atoms)
 
-        return self.run_opt(
+        start_time = monotonic()
+
+        def _should_stop(dyn: MolecularDynamics) -> bool:
+            return bool(
+                (stop_condition and stop_condition(dyn))
+                or (max_runtime is not None and monotonic() - start_time >= max_runtime)
+            )
+
+        dyn = self.run_opt(
             fmax=None,
             max_steps=steps,
             optimizer=dynamics,
             optimizer_kwargs=dynamics_kwargs,
+            stop_condition=_should_stop
+            if stop_condition or max_runtime is not None
+            else None,
         )
+        dyn.requested_steps = steps
+        dyn.completed_steps = dyn.nsteps
+        if dyn.nsteps < steps:
+            dyn.stop_reason = stop_reason
+
+        return dyn
 
     def run_neb(
         self,

--- a/src/quacc/schemas/ase.py
+++ b/src/quacc/schemas/ase.py
@@ -236,6 +236,16 @@ class Summarize:
             )
 
         md_fields = {"parameters_md": parameters_md, "trajectory_log": trajectory_log}
+        requested_steps = getattr(dyn, "requested_steps", dyn.nsteps)
+        completed_steps = getattr(dyn, "completed_steps", dyn.nsteps)
+        is_partial = completed_steps < requested_steps
+        md_fields |= {
+            "state": "partial" if is_partial else "completed",
+            "requested_steps": requested_steps,
+            "completed_steps": completed_steps,
+        }
+        if is_partial and (stop_reason := getattr(dyn, "stop_reason", None)):
+            md_fields["stop_reason"] = stop_reason
 
         # Create a dictionary of the inputs/outputs
         unsorted_task_doc = base_task_doc | md_fields | self.additional_fields

--- a/src/quacc/types.py
+++ b/src/quacc/types.py
@@ -94,6 +94,9 @@ if TYPE_CHECKING:
         maxwell_boltzmann_kwargs: MaxwellBoltzmanDistributionKwargs | None
         set_com_stationary: bool
         set_zero_rotation: bool
+        stop_condition: Callable[[MolecularDynamics], bool] | None
+        max_runtime: float | None
+        stop_reason: str
 
     class VibKwargs(TypedDict, total=False):
         """
@@ -496,6 +499,10 @@ if TYPE_CHECKING:
         trajectory: list[Atoms]
         trajectory_log: TrajectoryLog
         trajectory_results: list[Results]
+        state: Literal["completed", "partial"]
+        stop_reason: NotRequired[str]
+        requested_steps: int
+        completed_steps: int
 
     class ParametersVib(TypedDict):
         delta: float

--- a/tests/core/recipes/emt_recipes/test_emt_recipes.py
+++ b/tests/core/recipes/emt_recipes/test_emt_recipes.py
@@ -130,7 +130,25 @@ def test_md_job1():
     assert output["trajectory_log"][0]["temperature"] == pytest.approx(0.0)
     assert output["trajectory_log"][1]["temperature"] == pytest.approx(759.680)
     assert output["trajectory_log"][10]["time"] == pytest.approx(10 * fs)
+    assert output["state"] == "completed"
+    assert output["requested_steps"] == 500
+    assert output["completed_steps"] == 500
     assert atoms.positions == pytest.approx(old_positions)
+
+
+def test_md_job_partial():
+    output = md_job(
+        molecule("H2O"),
+        timestep_fs=1.0,
+        steps=10,
+        md_params={"stop_condition": lambda dyn: dyn.nsteps >= 3},
+    )
+
+    assert output["state"] == "partial"
+    assert output["stop_reason"] == "walltime"
+    assert output["requested_steps"] == 10
+    assert output["completed_steps"] == 3
+    assert len(output["trajectory"]) == 4
 
 
 def test_md_job2():

--- a/tests/core/runners/test_ase.py
+++ b/tests/core/runners/test_ase.py
@@ -20,9 +20,11 @@ from ase.build import bulk, molecule
 from ase.calculators.emt import EMT
 from ase.calculators.lj import LennardJones
 from ase.io import read, write
+from ase.md.verlet import VelocityVerlet
 from ase.mep.neb import NEBOptimizer
 from ase.optimize import BFGS, BFGSLineSearch
 from ase.optimize.sciopt import SciPyFminBFGS
+from ase.units import fs
 
 from quacc import JobFailure, change_settings, get_settings
 from quacc.runners._base import BaseRunner
@@ -348,6 +350,22 @@ def test_fn_hook(tmp_path, monkeypatch):
         Runner(bulk("Cu"), EMT()).run_opt(fn_hook=fn_hook)
     with pytest.raises(ValueError, match="Test error"):
         raise err.value.parent_error
+
+
+def test_run_md_stop_condition(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    dyn = Runner(molecule("H2"), LennardJones()).run_md(
+        VelocityVerlet,
+        dynamics_kwargs={"timestep": fs},
+        steps=10,
+        stop_condition=lambda dyn: dyn.nsteps >= 3,
+    )
+
+    assert dyn.nsteps == 3
+    assert dyn.requested_steps == 10
+    assert dyn.completed_steps == 3
+    assert dyn.stop_reason == "walltime"
+    assert len(read(dyn.trajectory.filename, index=":")) == 4
 
 
 def test_copy_intermediate_files_copies_files_and_directories(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary of Changes

Closes #2408. Unfortunately though, it does not address MD runs where the MD is done in the simulation package itself rather than quacc. For instance, if one does an AIMD run with VASP, this PR will not resolve that problem... :(

### Requirements

- [x] My PR is focused on a [single feature addition or bugfix](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs).
- [x] My PR has relevant, comprehensive [unit tests](https://quantum-accelerators.github.io/quacc/dev/contributing.html#unit-tests).
- [x] My PR is on a [custom branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) (i.e. is _not_ named `main`).