### PR TITLE
Warn when VASP EDIFF exceeds 1e-4

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -64,6 +64,11 @@ def get_param_swaps(
     calc = Vasp_(**remove_unused_flags(user_calc_params))
     max_Z = input_atoms.get_atomic_numbers().max()
 
+    if (ediff := calc.parameters.get("ediff")) is not None and ediff > 1e-4:
+        LOGGER.warning(
+            f"EDIFF = {ediff} is greater than 1e-4, which may lead to inaccurate results."
+        )
+
     # ----------------------------
     # General INCAR swaps
     # ----------------------------

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1416,6 +1416,26 @@ def test_logging(caplog):
     caplog.clear()
 
 
+@pytest.mark.parametrize("ediff", [None, 1e-5, 1e-4])
+def test_ediff_warning_not_raised(ediff, caplog):
+    atoms = bulk("Cu")
+    kwargs = {} if ediff is None else {"ediff": ediff}
+
+    with caplog.at_level(WARNING):
+        Vasp(atoms, **kwargs)
+
+    assert "EDIFF" not in caplog.text
+
+
+def test_ediff_warning(caplog):
+    atoms = bulk("Cu")
+
+    with caplog.at_level(WARNING):
+        Vasp(atoms, ediff=1.01e-4, incar_copilot_mode="off")
+
+    assert "EDIFF = 0.000101 is greater than 1e-4" in caplog.text
+
+
 def test_bad_pmg_converter():
     with pytest.raises(ValueError, match="Either atoms or prev_dir must be provided"):
         MPtoASEConverter()


### PR DESCRIPTION
## Summary
- log a warning when the resolved VASP EDIFF parameter is greater than 1e-4
- preserve the user-provided value and apply the check in every INCAR co-pilot mode
- test values below, at, and above the threshold

## Testing
- 62 passed, 1 skipped: tests/core/calculators/vasp/test_vasp.py
- ruff check src/quacc/calculators/vasp/params.py tests/core/calculators/vasp/test_vasp.py