### PR TITLE
Add structured VASP INCAR copilot summary

### DIFF
--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -104,6 +104,7 @@ QuaccDefault = DefaultSetting()
 
 # Set logging info
 basicConfig(filename=_settings.LOG_FILENAME, level=_settings.LOG_LEVEL)
+getLogger("custodian").setLevel(_settings.CUSTODIAN_LOG_LEVEL)
 
 
 def _filter_emmet_task_doc_log(record: LogRecord) -> bool:

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from importlib.metadata import version
-from logging import basicConfig
+from logging import INFO, LogRecord, basicConfig, getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
 from warnings import filterwarnings
@@ -104,6 +104,16 @@ QuaccDefault = DefaultSetting()
 
 # Set logging info
 basicConfig(filename=_settings.LOG_FILENAME, level=_settings.LOG_LEVEL)
+
+
+def _filter_emmet_task_doc_log(record: LogRecord) -> bool:
+    """Suppress Emmet's noisy task-document path announcement."""
+    return not (
+        record.levelno == INFO and record.getMessage().startswith("Getting task doc in:")
+    )
+
+
+getLogger("emmet.core.tasks").addFilter(_filter_emmet_task_doc_log)
 
 
 # Custom exceptions

--- a/src/quacc/__init__.py
+++ b/src/quacc/__init__.py
@@ -109,7 +109,8 @@ basicConfig(filename=_settings.LOG_FILENAME, level=_settings.LOG_LEVEL)
 def _filter_emmet_task_doc_log(record: LogRecord) -> bool:
     """Suppress Emmet's noisy task-document path announcement."""
     return not (
-        record.levelno == INFO and record.getMessage().startswith("Getting task doc in:")
+        record.levelno == INFO
+        and record.getMessage().startswith("Getting task doc in:")
     )
 
 

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -241,10 +241,7 @@ def _get_param_swaps(
     # ----------------------------
     pre_critical_params = dict(calc.parameters)
     if incar_copilot_mode.lower() != "off":
-        if (
-            (ediff := calc.parameters.get("ediff")) is not None
-            and ediff > 1e-4
-        ):
+        if (ediff := calc.parameters.get("ediff")) is not None and ediff > 1e-4:
             report.warnings.append(
                 CopilotWarning(
                     f"EDIFF={ediff!r} is greater than 1e-4; the results are likely unconverged."

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -68,7 +68,7 @@ def log_copilot_report(report: CopilotReport) -> None:
     if report.warnings:
         lines.append("⚠️ Attention required:")
         for warning in report.warnings:
-            lines.append(f"  WARNING: {warning.message}")
+            lines.append(f"  {warning.message}")
             if warning.reason:
                 lines.append(f"    Reason: {warning.reason}")
             if warning.remediation:

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -443,7 +443,7 @@ def _get_param_swaps(
         for k, (current, recommended) in overridden_swaps.items():
             report.warnings.append(
                 CopilotWarning(
-                    f"{k.upper()} was not changed from {current!r} to {recommended!r} to respect the user's decision.",
+                    f"{k.upper()} was not changed from {current!r} to {recommended!r}, but should be modified.",
                     reason=change_reasons.get(k),
                 )
             )

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -66,7 +66,6 @@ def log_copilot_report(report: CopilotReport) -> None:
     footer = "=" * len(header)
     lines = [header]
     if report.changes:
-        lines.append("")
         lines.append("Applied changes:")
         lines.extend(
             f"  {change.parameter.upper()}: {change.old_value!r} -> {change.new_value!r}\n"
@@ -74,7 +73,8 @@ def log_copilot_report(report: CopilotReport) -> None:
             for change in report.changes
         )
     if report.warnings:
-        lines.append("")
+        if report.changes:
+            lines.append("")
         lines.append("Attention required:")
         for warning in report.warnings:
             lines.append(f"  WARNING: {warning.message}")
@@ -82,7 +82,7 @@ def log_copilot_report(report: CopilotReport) -> None:
                 lines.append(f"    Reason: {warning.reason}")
             if warning.remediation:
                 lines.append(f"    Remediation: {warning.remediation}")
-    lines.extend(("", footer))
+    lines.append(footer)
 
     log_level = WARNING if report.warnings else INFO
     LOGGER.log(log_level, "\n%s", "\n".join(lines))

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -241,6 +241,16 @@ def _get_param_swaps(
     # ----------------------------
     pre_critical_params = dict(calc.parameters)
     if incar_copilot_mode.lower() != "off":
+        if (
+            (ediff := calc.parameters.get("ediff")) is not None
+            and ediff > 1e-4
+        ):
+            report.warnings.append(
+                CopilotWarning(
+                    f"EDIFF={ediff!r} is greater than 1e-4; the results are likely unconverged."
+                )
+            )
+
         if not calc.parameters.get("lorbit", False) and (
             calc.parameters.get("ispin", 1) == 2
             or np.any(input_atoms.get_initial_magnetic_moments() != 0)

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -242,7 +242,7 @@ def _get_param_swaps(
     # ----------------------------
     pre_critical_params = dict(calc.parameters)
     if incar_copilot_mode.lower() != "off":
-        if (ediff := calc.parameters.get("ediff")) is not None and ediff > 1e-4:
+        if (ediff := calc.parameters.get("ediff", 1e-4)) > 1e-4:
             report.warnings.append(
                 CopilotWarning(
                     f"EDIFF={ediff!r} is greater than 1e-4; the results are likely unconverged."

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -66,7 +66,7 @@ def log_copilot_report(report: CopilotReport) -> None:
     footer = "=" * len(header)
     lines = [header]
     if report.warnings:
-        lines.append("Attention required:")
+        lines.append("⚠️ Attention required:")
         for warning in report.warnings:
             lines.append(f"  WARNING: {warning.message}")
             if warning.reason:

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from importlib.util import find_spec
-from logging import getLogger
+from logging import INFO, WARNING, getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -60,27 +60,36 @@ class CopilotReport:
 
 
 def log_copilot_report(report: CopilotReport) -> None:
-    """Log a compact summary while preserving warning severity."""
-    warning_label = "WARNING" if report.warnings else "warnings"
-    LOGGER.info(
-        "VASP INCAR copilot: %d changes applied, %d %s",
-        len(report.changes),
-        len(report.warnings),
-        warning_label,
-    )
+    """Log a framed summary as a single record."""
+    header = "================ VASP INCAR COPILOT ================"
+    change_label = "change" if len(report.changes) == 1 else "changes"
+    warning_label = "warning" if len(report.warnings) == 1 else "warnings"
+    lines = [
+        header,
+        (
+            f"Summary: {len(report.changes)} {change_label} applied, "
+            f"{len(report.warnings)} {warning_label}"
+        ),
+    ]
     if report.changes:
-        lines = ["INCAR copilot applied changes:"]
+        lines.append("")
+        lines.append("Applied changes:")
         lines.extend(
             f"  {change.parameter.upper()}: {change.old_value!r} -> {change.new_value!r}\n"
             f"    Reason: {change.reason}"
             for change in report.changes
         )
-        LOGGER.info("\n".join(lines))
-    for warning in report.warnings:
-        message = f"INCAR copilot attention required: {warning.message}"
-        if warning.remediation:
-            message += f" Remediation: {warning.remediation}"
-        LOGGER.warning(message)
+    if report.warnings:
+        lines.append("")
+        lines.append("Attention required:")
+        for warning in report.warnings:
+            lines.append(f"  WARNING: {warning.message}")
+            if warning.remediation:
+                lines.append(f"    Remediation: {warning.remediation}")
+    lines.extend(("", header))
+
+    log_level = WARNING if report.warnings else INFO
+    LOGGER.log(log_level, "\n".join(lines))
 
 
 def get_param_swaps(

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from importlib.util import find_spec
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -13,7 +14,6 @@ from monty.dev import requires
 from pymatgen.io.ase import AseAtomsAdaptor
 
 from quacc.atoms.core import check_is_metal
-from quacc.utils.dicts import sort_dict
 from quacc.utils.kpts import convert_pmg_kpts
 
 has_atomate2 = bool(find_spec("atomate2"))
@@ -31,6 +31,56 @@ if TYPE_CHECKING:
         from atomate2.vasp.sets.base import VaspInputGenerator
 
 LOGGER = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CopilotChange:
+    """An INCAR parameter change made by the copilot."""
+
+    parameter: str
+    old_value: Any
+    new_value: Any
+    reason: str
+
+
+@dataclass(frozen=True)
+class CopilotWarning:
+    """An issue that the INCAR copilot cannot safely fix."""
+
+    message: str
+    remediation: str | None = None
+
+
+@dataclass
+class CopilotReport:
+    """Structured results from the INCAR copilot."""
+
+    changes: list[CopilotChange] = field(default_factory=list)
+    warnings: list[CopilotWarning] = field(default_factory=list)
+
+
+def log_copilot_report(report: CopilotReport) -> None:
+    """Log a compact summary while preserving warning severity."""
+    warning_label = "WARNING" if report.warnings else "warnings"
+    LOGGER.info(
+        "VASP INCAR copilot: %d changes applied, %d %s",
+        len(report.changes),
+        len(report.warnings),
+        warning_label,
+    )
+    if report.changes:
+        lines = ["INCAR copilot applied changes:"]
+        lines.extend(
+            f"  {change.parameter.upper()}: {change.old_value!r} -> {change.new_value!r}\n"
+            f"    Reason: {change.reason}"
+            for change in report.changes
+        )
+        LOGGER.info("\n".join(lines))
+    for warning in report.warnings:
+        message = f"INCAR copilot attention required: {warning.message}"
+        if warning.remediation:
+            message += f" Remediation: {warning.remediation}"
+        LOGGER.warning(message)
 
 
 def get_param_swaps(
@@ -60,8 +110,35 @@ def get_param_swaps(
     dict
         The updated user-provided calculator parameters.
     """
+    new_parameters, report = _get_param_swaps(
+        user_calc_params,
+        input_atoms,
+        pmg_kpts=pmg_kpts,
+        incar_copilot_mode=incar_copilot_mode,
+    )
+    if incar_copilot_mode.lower() != "off":
+        log_copilot_report(report)
+    return new_parameters
+
+
+def _get_param_swaps(
+    user_calc_params: dict[str, Any],
+    input_atoms: Atoms,
+    pmg_kpts: dict[Literal["line_density", "kppvol", "kppa"], float] | None = None,
+    incar_copilot_mode: Literal[
+        "off", "critical", "standard", "aggressive"
+    ] = "standard",
+) -> tuple[dict[str, Any], CopilotReport]:
+    """Return updated parameters and a structured INCAR copilot report."""
+    report = CopilotReport()
     is_metal = check_is_metal(input_atoms)
     calc = Vasp_(**remove_unused_flags(user_calc_params))
+    change_reasons: dict[str, str] = {}
+
+    def recommend(reason: str, **parameters: Any) -> None:
+        change_reasons.update(dict.fromkeys(parameters, reason))
+        calc.set(**parameters)
+
     max_Z = input_atoms.get_atomic_numbers().max()
 
     # ----------------------------
@@ -69,11 +146,9 @@ def get_param_swaps(
     # ----------------------------
     if incar_copilot_mode.lower() not in {"off", "critical"}:
         if calc.parameters.get("lmaxmix", 2) < 6 and max_Z > 56:
-            LOGGER.info("Recommending LMAXMIX = 6 because you have f electrons.")
-            calc.set(lmaxmix=6)
+            recommend("f electrons were detected.", lmaxmix=6)
         elif calc.parameters.get("lmaxmix", 2) < 4 and max_Z > 20:
-            LOGGER.info("Recommending LMAXMIX = 4 because you have d electrons.")
-            calc.set(lmaxmix=4)
+            recommend("d electrons were detected.", lmaxmix=4)
 
         if (
             calc.parameters.get("luse_vdw", False)
@@ -82,86 +157,75 @@ def get_param_swaps(
             or calc.parameters.get("ldau_luj", {})
             or calc.parameters.get("metagga", "")
         ) and not calc.parameters.get("lasph"):
-            LOGGER.info(
-                "Recommending LASPH = True because you have a +U, vdW, meta-GGA, or hybrid calculation."
+            recommend(
+                "LASPH is recommended for +U, vdW, meta-GGA, and hybrid calculations.",
+                lasph=True,
             )
-            calc.set(lasph=True)
 
         if calc.parameters.get("metagga", "") and (
             calc.parameters.get("algo", "normal").lower() != "all"
         ):
-            LOGGER.info(
-                "Recommending ALGO = All because you have a meta-GGA calculation."
+            recommend(
+                "ALGO=All is recommended for meta-GGA calculations.",
+                algo="all",
+                isearch=1,
             )
-            calc.set(algo="all", isearch=1)
 
         if (
             is_metal
             and (calc.parameters.get("ismear", 1) < 0)
             and (calc.parameters.get("nsw", 0) > 0)
         ):
-            LOGGER.info(
-                "Recommending ISMEAR = 1 and SIGMA = 0.1 because you are likely relaxing a metal."
+            recommend(
+                "Metal relaxations should use finite-width smearing.",
+                ismear=1,
+                sigma=0.1,
             )
-            calc.set(ismear=1, sigma=0.1)
 
         if (
             pmg_kpts
             and pmg_kpts.get("line_density")
             and calc.parameters.get("ismear", 1) != 0
         ):
-            LOGGER.info(
-                "Recommending ISMEAR = 0 and SIGMA = 0.01 because you are doing a line mode calculation."
+            recommend(
+                "Line-mode calculations should use Gaussian smearing.",
+                ismear=0,
+                sigma=0.01,
             )
-            calc.set(ismear=0, sigma=0.01)
 
         if calc.parameters.get("ismear", 1) == 0 and (
             calc.parameters.get("sigma", 0.2) > 0.05
         ):
-            LOGGER.info(
-                "Recommending SIGMA = 0.05 because ISMEAR = 0 was requested with SIGMA > 0.05."
-            )
-            calc.set(sigma=0.05)
+            recommend("SIGMA should be <=0.05 when ISMEAR=0.", sigma=0.05)
 
         if calc.parameters.get("nsw", 0) > 0 and calc.parameters.get("laechg", False):
-            LOGGER.info(
-                "Recommending LAECHG = False because you have NSW > 0. LAECHG is supposedly not compatible with NSW > 0."
-            )
-            calc.set(laechg=False)
+            recommend("LAECHG is not compatible with NSW>0.", laechg=False)
 
         if calc.parameters.get("ldauprint", 0) == 0 and (
             calc.parameters.get("ldau", False) or calc.parameters.get("ldau_luj", {})
         ):
-            LOGGER.info("Recommending LDAUPRINT = 1 because LDAU = True.")
-            calc.set(ldauprint=1)
+            recommend("LDAUPRINT=1 is recommended when LDAU is enabled.", ldauprint=1)
 
         if calc.parameters.get("lreal", False) and len(input_atoms) < 30:
-            LOGGER.info(
-                "Recommending LREAL = False because you have a small system (< 30 atoms/cell)."
+            recommend(
+                "Reciprocal-space projectors are recommended for systems with fewer than 30 atoms.",
+                lreal=False,
             )
-            calc.set(lreal=False)
 
         if (
             calc.parameters.get("lhfcalc", False) is True
             and calc.parameters.get("isym", 3) < 3
         ):
-            LOGGER.info(
-                "Recommending ISYM = 3 because you are running a hybrid calculation."
-            )
-            calc.set(isym=3)
+            recommend("ISYM=3 is recommended for hybrid calculations.", isym=3)
 
         if calc.parameters.get("lsorbit", False):
-            LOGGER.info(
-                "Recommending ISYM = -1 because you are running an SOC calculation."
-            )
-            calc.set(isym=-1)
+            recommend("Symmetry should be disabled for spin-orbit coupling.", isym=-1)
 
         if (
             calc.parameters.get("algo", "normal") in ("all", "conjugate")
             and calc.parameters.get("isearch", 0) != 1
         ):
-            LOGGER.info("Recommending ISEARCH = 1 because you have ALGO = All.")
-            calc.set(isearch=1)
+            recommend("ISEARCH=1 is required when ALGO=All.", isearch=1)
 
     # ----------------------------
     # Critical INCAR swaps
@@ -172,45 +236,34 @@ def get_param_swaps(
             calc.parameters.get("ispin", 1) == 2
             or np.any(input_atoms.get_initial_magnetic_moments() != 0)
         ):
-            LOGGER.info(
-                "Recommending LORBIT = 11 because you have a spin-polarized calculation."
+            recommend(
+                "LORBIT=11 is recommended for spin-polarized calculations.", lorbit=11
             )
-            calc.set(lorbit=11)
 
         if (
             calc.parameters.get("ismear", 1) == -5
             and (calc.kpts is not None and np.prod(calc.kpts) < 4)
             and calc.parameters.get("kspacing", None) is None
         ):
-            LOGGER.info(
-                "Recommending ISMEAR = 0 because you don't have enough k-points for ISMEAR = -5."
-            )
-            calc.set(ismear=0)
+            recommend("There are too few k-points for tetrahedron smearing.", ismear=0)
 
         if (
             calc.parameters.get("kspacing", 0.5) > 0.5
             and calc.parameters.get("ismear", 1) == -5
         ):
-            LOGGER.info(
-                "Recommending ISMEAR = 0 because KSPACING is likely too large for ISMEAR = -5."
-            )
-            calc.set(ismear=0)
+            recommend("KSPACING is too large for tetrahedron smearing.", ismear=0)
 
         if calc.parameters.get("ismear", 1) == -5 and calc.parameters.get(
             "algo", "normal"
         ) in ("all", "conjugate", "damped"):
-            LOGGER.info(
-                "Recommending ALGO = Normal because your ALGO is not compatible with ISMEAR = -5."
+            recommend(
+                "The selected ALGO is incompatible with ISMEAR=-5.", algo="normal"
             )
-            calc.set(algo="normal")
 
         if calc.parameters.get("lhfcalc", False) and (
             calc.parameters.get("algo", "normal").lower() != "normal"
         ):
-            LOGGER.info(
-                "Recommending ALGO = Normal because you have a hybrid calculation."
-            )
-            calc.set(algo="normal")
+            recommend("ALGO=Normal is required for hybrid calculations.", algo="normal")
 
         if (
             calc.parameters.get("ncore", 1) > 1
@@ -221,19 +274,19 @@ def get_param_swaps(
             or calc.parameters.get("lepsilon", False) is True
             or calc.parameters.get("ibrion", 0) in [5, 6, 7, 8]
         ):
-            LOGGER.info(
-                "Recommending NCORE = 1 because NCORE/NPAR is not compatible with this job type."
+            recommend(
+                "NCORE/NPAR is incompatible with this job type.", ncore=1, npar=None
             )
-            calc.set(ncore=1, npar=None)
 
         if not calc.parameters.get("npar") and not calc.parameters.get("ncore"):
             ncores = psutil.cpu_count(logical=False) or 1
             for ncore in range(int(np.sqrt(ncores)), ncores):
                 if ncores % ncore == 0:
-                    LOGGER.info(
-                        f"Recommending NCORE = {ncore} per the sqrt(# cores) suggestion by VASP."
+                    recommend(
+                        "This follows VASP's sqrt(number of cores) recommendation.",
+                        ncore=ncore,
+                        npar=None,
                     )
-                    calc.set(ncore=ncore, npar=None)
                     break
 
         if (
@@ -244,24 +297,29 @@ def get_param_swaps(
             )
             and calc.float_params["kspacing"] is None
         ):
-            LOGGER.info(
-                "Recommending KPAR = 1 because you have too few k-points to parallelize."
+            recommend(
+                "There are too few k-points to parallelize over k-points.", kpar=1
             )
-            calc.set(kpar=1)
 
         if (
             calc.parameters.get("isif", 2) in (3, 6, 7, 8)
             and calc.parameters.get("nsw", 0) > 0
         ):
             if calc.encut is None:
-                LOGGER.warning(
-                    "Be careful of Pulay stresses. At the end of your run, re-relax your structure with your current ENCUT or set ENCUT=1.3*max(ENMAX)."
+                report.warnings.append(
+                    CopilotWarning(
+                        "Pulay stress risk during variable-cell relaxation because ENCUT was not explicitly set.",
+                        "Re-relax the final structure with the converged ENCUT or set ENCUT=1.3*max(ENMAX).",
+                    )
                 )
             if "He" in input_atoms.get_chemical_symbols() and (
                 calc.encut is None or calc.encut < 478.896 * 1.3
             ):
-                LOGGER.warning(
-                    "Be careful of Pulay stresses. At the end of your run, re-relax your structure with your current ENCUT or set ENCUT>=623."
+                report.warnings.append(
+                    CopilotWarning(
+                        "Pulay stress risk for a variable-cell relaxation containing He.",
+                        "Re-relax the final structure with the converged ENCUT or set ENCUT>=623.",
+                    )
                 )
 
             if (
@@ -271,8 +329,11 @@ def get_param_swaps(
                 and calc.parameters["setups"].get("Li", "") in ("Li_sv", "_sv")
                 and (calc.encut is None or calc.encut < 499.034 * 1.3)
             ):
-                LOGGER.warning(
-                    "Be careful of Pulay stresses. At the end of your run, re-relax your structure with your current ENCUT or set ENCUT>=650."
+                report.warnings.append(
+                    CopilotWarning(
+                        "Pulay stress risk for a variable-cell relaxation using Li_sv.",
+                        "Re-relax the final structure with the converged ENCUT or set ENCUT>=650.",
+                    )
                 )
 
         if (
@@ -286,11 +347,12 @@ def get_param_swaps(
             and not calc.parameters.get("vdw_a1")
             and not calc.parameters.get("vdw_a2")
         ):
-            LOGGER.info(
-                "Recommending VDW_S6, VDW_S8, VDW_A1, VDW_A2 parameters for r2SCAN-D4."
-            )
-            calc.set(
-                vdw_s6=1.0, vdw_s8=0.60187490, vdw_a1=0.51559235, vdw_a2=5.77342911
+            recommend(
+                "These are the recommended r2SCAN-D4 damping parameters.",
+                vdw_s6=1.0,
+                vdw_s8=0.60187490,
+                vdw_a1=0.51559235,
+                vdw_a2=5.77342911,
             )
 
         if (
@@ -302,16 +364,21 @@ def get_param_swaps(
             and not calc.parameters.get("vdw_a1")
             and not calc.parameters.get("vdw_a2")
         ):
-            LOGGER.info(
-                "Recommending VDW_S6, VDW_S8, VDW_A1, VDW_A2 parameters for HSE06-D3(BJ)."
+            recommend(
+                "These are the recommended HSE06-D3(BJ) damping parameters.",
+                vdw_s6=1.0,
+                vdw_s8=2.310,
+                vdw_a1=0.383,
+                vdw_a2=5.685,
             )
-            calc.set(vdw_s6=1.0, vdw_s8=2.310, vdw_a1=0.383, vdw_a2=5.685)
 
         if input_atoms.get_chemical_formula() == "O2" and all(
             input_atoms.get_initial_magnetic_moments() == 0
         ):
-            LOGGER.warning(
-                "You are running O2 without magnetic moments, but its ground state should have 2 unpaired electrons!"
+            report.warnings.append(
+                CopilotWarning(
+                    "O2 is being run without magnetic moments, but its ground state should have 2 unpaired electrons."
+                )
             )
 
     # ----------------------------
@@ -329,12 +396,16 @@ def get_param_swaps(
     else:
         new_parameters = (calc.parameters | user_calc_params) | critical_swap_changes
 
-    if added_parameters := {
-        k: new_parameters[k] for k in set(new_parameters) - set(user_calc_params)
-    }:
-        LOGGER.info(
-            f"The following parameters were added: {sort_dict(added_parameters)}"
+    report.changes = [
+        CopilotChange(
+            k,
+            user_calc_params.get(k),
+            new_parameters[k],
+            change_reasons.get(k, "A critical INCAR compatibility rule was applied."),
         )
+        for k in sorted(new_parameters)
+        if _params_differ(user_calc_params.get(k), new_parameters[k])
+    ]
 
     overridden_user_params = {
         k: (user_calc_params[k], new_parameters[k])
@@ -343,7 +414,9 @@ def get_param_swaps(
         and _params_differ(new_parameters[k], user_calc_params[k])
     }
     for k, (old, new) in overridden_user_params.items():
-        LOGGER.warning(f"{k.upper()} was changed from {old!r} to {new!r}.")
+        report.warnings.append(
+            CopilotWarning(f"{k.upper()} was changed from {old!r} to {new!r}.")
+        )
 
     if overridden_swaps := {
         k: (user_calc_params.get(k), recommended_params[k])
@@ -351,11 +424,13 @@ def get_param_swaps(
         if _params_differ(recommended_params[k], new_parameters.get(k))
     }:
         for k, (current, recommended) in overridden_swaps.items():
-            LOGGER.warning(
-                f"{k.upper()} was *not* changed from {current!r} to {recommended!r} to respect the user's decisions."
+            report.warnings.append(
+                CopilotWarning(
+                    f"{k.upper()} was not changed from {current!r} to {recommended!r} to respect the user's decision."
+                )
             )
 
-    return new_parameters
+    return new_parameters, report
 
 
 def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -65,23 +65,23 @@ def log_copilot_report(report: CopilotReport) -> None:
     header = "================ VASP INCAR COPILOT ================"
     footer = "=" * len(header)
     lines = [header]
-    if report.changes:
-        lines.append("Applied changes:")
-        lines.extend(
-            f"  {change.parameter.upper()}: {change.old_value!r} -> {change.new_value!r}\n"
-            f"    Reason: {change.reason}"
-            for change in report.changes
-        )
     if report.warnings:
-        if report.changes:
-            lines.append("")
         lines.append("Attention required:")
         for warning in report.warnings:
             lines.append(f"  WARNING: {warning.message}")
             if warning.reason:
                 lines.append(f"    Reason: {warning.reason}")
             if warning.remediation:
-                lines.append(f"    Remediation: {warning.remediation}")
+                lines.append(f"    Recommendation: {warning.remediation}")
+    if report.changes:
+        if report.warnings:
+            lines.append("")
+        lines.append("Applied changes:")
+        lines.extend(
+            f"  {change.parameter.upper()}: {change.old_value!r} -> {change.new_value!r}\n"
+            f"    Reason: {change.reason}"
+            for change in report.changes
+        )
     lines.append(footer)
 
     log_level = WARNING if report.warnings else INFO

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -49,6 +49,7 @@ class CopilotWarning:
 
     message: str
     remediation: str | None = None
+    reason: str | None = None
 
 
 @dataclass
@@ -63,15 +64,7 @@ def log_copilot_report(report: CopilotReport) -> None:
     """Log a framed summary as a single record."""
     header = "================ VASP INCAR COPILOT ================"
     footer = "=" * len(header)
-    change_label = "change" if len(report.changes) == 1 else "changes"
-    warning_label = "warning" if len(report.warnings) == 1 else "warnings"
-    lines = [
-        header,
-        (
-            f"Summary: {len(report.changes)} {change_label} applied, "
-            f"{len(report.warnings)} {warning_label}"
-        ),
-    ]
+    lines = [header]
     if report.changes:
         lines.append("")
         lines.append("Applied changes:")
@@ -85,6 +78,8 @@ def log_copilot_report(report: CopilotReport) -> None:
         lines.append("Attention required:")
         for warning in report.warnings:
             lines.append(f"  WARNING: {warning.message}")
+            if warning.reason:
+                lines.append(f"    Reason: {warning.reason}")
             if warning.remediation:
                 lines.append(f"    Remediation: {warning.remediation}")
     lines.extend(("", footer))
@@ -432,7 +427,12 @@ def _get_param_swaps(
     }
     for k, (old, new) in overridden_user_params.items():
         report.warnings.append(
-            CopilotWarning(f"{k.upper()} was changed from {old!r} to {new!r}.")
+            CopilotWarning(
+                f"{k.upper()} was changed from {old!r} to {new!r}.",
+                reason=change_reasons.get(
+                    k, "A critical INCAR compatibility rule was applied."
+                ),
+            )
         )
 
     if overridden_swaps := {
@@ -443,7 +443,8 @@ def _get_param_swaps(
         for k, (current, recommended) in overridden_swaps.items():
             report.warnings.append(
                 CopilotWarning(
-                    f"{k.upper()} was not changed from {current!r} to {recommended!r} to respect the user's decision."
+                    f"{k.upper()} was not changed from {current!r} to {recommended!r} to respect the user's decision.",
+                    reason=change_reasons.get(k),
                 )
             )
 

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -413,7 +413,7 @@ def _get_param_swaps(
             k,
             user_calc_params.get(k),
             new_parameters[k],
-            change_reasons.get(k, "A critical INCAR compatibility rule was applied."),
+            change_reasons.get(k, "General INCAR compatibility rule was applied."),
         )
         for k in sorted(new_parameters)
         if _params_differ(user_calc_params.get(k), new_parameters[k])
@@ -430,7 +430,7 @@ def _get_param_swaps(
             CopilotWarning(
                 f"{k.upper()} was changed from {old!r} to {new!r}.",
                 reason=change_reasons.get(
-                    k, "A critical INCAR compatibility rule was applied."
+                    k, "General INCAR compatibility rule was applied."
                 ),
             )
         )

--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -62,6 +62,7 @@ class CopilotReport:
 def log_copilot_report(report: CopilotReport) -> None:
     """Log a framed summary as a single record."""
     header = "================ VASP INCAR COPILOT ================"
+    footer = "=" * len(header)
     change_label = "change" if len(report.changes) == 1 else "changes"
     warning_label = "warning" if len(report.warnings) == 1 else "warnings"
     lines = [
@@ -86,10 +87,10 @@ def log_copilot_report(report: CopilotReport) -> None:
             lines.append(f"  WARNING: {warning.message}")
             if warning.remediation:
                 lines.append(f"    Remediation: {warning.remediation}")
-    lines.extend(("", header))
+    lines.extend(("", footer))
 
     log_level = WARNING if report.warnings else INFO
-    LOGGER.log(log_level, "\n".join(lines))
+    LOGGER.log(log_level, "\n%s", "\n".join(lines))
 
 
 def get_param_swaps(

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -211,7 +211,7 @@ class Vasp(Vasp_):
             potpaw_path = (
                 self._settings.VASP_PP_PATH / f"{potpaw_prefix}{potpaw_suffix}"
             ).resolve()
-            LOGGER.info(f"Using PAW pseudopotentials: {potpaw_path}")
+            LOGGER.info(f"PAW potentials = {potpaw_path}")
 
         # Set the ASE_VASP_VDW environment variable
         if self._settings.VASP_VDW:
@@ -230,7 +230,7 @@ class Vasp(Vasp_):
             self._settings.VASP_GAMMA_CMD if use_gamma else self._settings.VASP_CMD
         )
         full_vasp_cmd = f"{self._settings.VASP_PARALLEL_CMD} {vasp_cmd}"
-        LOGGER.info(f"Using VASP command: {full_vasp_cmd.strip()}")
+        LOGGER.info(f"VASP command = {full_vasp_cmd.strip()}")
 
         return full_vasp_cmd
 

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -15,7 +15,8 @@ from ase.calculators.vasp import setups as ase_setups
 from quacc import QuaccDefault, get_settings
 from quacc.calculators.vasp.io import load_vasp_yaml_calc
 from quacc.calculators.vasp.params import (
-    get_param_swaps,
+    _get_param_swaps,
+    log_copilot_report,
     normalize_params,
     remove_unused_flags,
     set_auto_dipole,
@@ -312,7 +313,7 @@ class Vasp(Vasp_):
         )
 
         # Handle INCAR swaps
-        self.user_calc_params = get_param_swaps(
+        self.user_calc_params, copilot_report = _get_param_swaps(
             self.user_calc_params,
             self.input_atoms,
             incar_copilot_mode=self.incar_copilot_mode,
@@ -320,6 +321,9 @@ class Vasp(Vasp_):
         )
         if self.incar_copilot_mode.lower() not in {"off", "critical"}:
             self.user_calc_params = remove_unused_flags(self.user_calc_params)
+
+        if self.incar_copilot_mode.lower() != "off":
+            log_copilot_report(copilot_report)
 
         # Clean up the user calc parameters
         self.user_calc_params = sort_dict(self.user_calc_params)

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -146,7 +146,6 @@ def calc_cleanup(
         gzip_dir(tmpdir)
 
     # Move files from tmpdir to job_results_dir.
-    LOGGER.info(f"Moving {tmpdir} contents to {job_results_dir}")
     job_results_dir.mkdir(parents=True, exist_ok=True)
     for file_name in os.listdir(tmpdir):
         move(tmpdir / file_name, job_results_dir / file_name)

--- a/src/quacc/runners/prep.py
+++ b/src/quacc/runners/prep.py
@@ -83,7 +83,7 @@ def calc_setup(
         if settings.CREATE_UNIQUE_DIR:
             job_results_dir /= f"{tmpdir.name.split('tmp-')[-1]}"
 
-    LOGGER.info(f"Calculation will run at {tmpdir}")
+    LOGGER.info(f"Run directory = {tmpdir}")
 
     # Set the calculator's directory
     if atoms is not None:

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -459,6 +459,9 @@ class QuaccSettings(BaseSettings):
     LOG_LEVEL: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = Field(
         "INFO", description=("Logger level.")
     )
+    CUSTODIAN_LOG_LEVEL: Literal[
+        "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"
+    ] = Field("WARNING", description="Logger level for Custodian.")
 
     # --8<-- [end:settings]
 

--- a/src/quacc/settings.py
+++ b/src/quacc/settings.py
@@ -459,9 +459,9 @@ class QuaccSettings(BaseSettings):
     LOG_LEVEL: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = Field(
         "INFO", description=("Logger level.")
     )
-    CUSTODIAN_LOG_LEVEL: Literal[
-        "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"
-    ] = Field("WARNING", description="Logger level for Custodian.")
+    CUSTODIAN_LOG_LEVEL: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = (
+        Field("WARNING", description="Logger level for Custodian.")
+    )
 
     # --8<-- [end:settings]
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1394,10 +1394,11 @@ def test_logging(caplog):
         if "VASP INCAR COPILOT" in record.getMessage()
     )
     assert copilot_record.getMessage().startswith(
-        "\n================ VASP INCAR COPILOT ================"
+        "\n================ VASP INCAR COPILOT ================\nApplied changes:"
     )
     header = "================ VASP INCAR COPILOT ================"
     assert copilot_record.getMessage().endswith("=" * len(header))
+    assert f"\n\n{'=' * len(header)}" not in copilot_record.getMessage()
     assert "Summary:" not in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text
     assert "Reason: d electrons were detected." in caplog.text

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1414,9 +1414,10 @@ def test_logging(caplog):
     assert "LMAXMIX was not changed from 1 to 4" in caplog.text
     assert "2 warnings" in caplog.text
     assert "Attention required:" in caplog.text
-    assert sum(
-        "VASP INCAR COPILOT" in record.getMessage() for record in caplog.records
-    ) == 1
+    assert (
+        sum("VASP INCAR COPILOT" in record.getMessage() for record in caplog.records)
+        == 1
+    )
     caplog.clear()
 
     with caplog.at_level(INFO):

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1428,8 +1428,8 @@ def test_logging(caplog):
         "WARNING: LMAXMIX was not changed from 1 to 4 to respect the user's decision.\n"
         "    Reason: d electrons were detected."
     ) in caplog.text
-    assert "Attention required:" in caplog.text
-    assert caplog.text.index("Attention required:") < caplog.text.index(
+    assert "⚠️ Attention required:" in caplog.text
+    assert caplog.text.index("⚠️ Attention required:") < caplog.text.index(
         "Applied changes:"
     )
     assert (

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1567,7 +1567,6 @@ def test_logger(caplog):
         with caplog.at_level(INFO):
             Vasp(atoms)
         assert "PAW potentials = /path/to/pseudos/potpaw_PBE" in caplog.text
-        assert "Using PAW pseudopotentials:" not in caplog.text
         assert "/path/to/pseudos/potpaw_PBE" in caplog.text
         caplog.clear()
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1399,13 +1399,10 @@ def test_logging(caplog):
     header = "================ VASP INCAR COPILOT ================"
     assert copilot_record.getMessage().endswith("=" * len(header))
     assert f"\n\n{'=' * len(header)}" not in copilot_record.getMessage()
-    assert "Summary:" not in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text
     assert "Reason: d electrons were detected." in caplog.text
     assert "NCORE: None ->" in caplog.text
-    assert "Recommending" not in caplog.text
     assert "VASP command = vasp_std" in caplog.text
-    assert "Using VASP command:" not in caplog.text
     caplog.clear()
 
     with caplog.at_level(INFO):
@@ -1465,7 +1462,6 @@ def test_copilot_recommendation_label(caplog):
         Vasp(bulk("Cu"), isif=3, nsw=2)
 
     assert "Recommendation: Re-relax the final structure" in caplog.text
-    assert "Remediation:" not in caplog.text
 
 
 def test_bad_pmg_converter():

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1387,7 +1387,8 @@ def test_logging(caplog):
     atoms = bulk("Cu")
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(3, 3, 3))
-    assert "VASP INCAR copilot:" in caplog.text
+    assert "================ VASP INCAR COPILOT ================" in caplog.text
+    assert "Summary:" in caplog.text
     assert "0 warnings" in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text
     assert "Reason: d electrons were detected." in caplog.text
@@ -1397,7 +1398,7 @@ def test_logging(caplog):
 
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(2, 2, 1), ismear=0)
-    assert "VASP INCAR copilot:" in caplog.text
+    assert "================ VASP INCAR COPILOT ================" in caplog.text
     assert "  ISMEAR:" not in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text
     assert "NCORE: None ->" in caplog.text
@@ -1406,12 +1407,16 @@ def test_logging(caplog):
 
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(2, 2, 1), ismear=-5, algo="all", lmaxmix=1)
-    assert "VASP INCAR copilot:" in caplog.text
+    assert "================ VASP INCAR COPILOT ================" in caplog.text
     assert "ISEARCH: None -> 1" in caplog.text
     assert "NCORE: None ->" in caplog.text
     assert "ALGO was changed from 'all' to 'normal'" in caplog.text
     assert "LMAXMIX was not changed from 1 to 4" in caplog.text
-    assert "2 WARNING" in caplog.text
+    assert "2 warnings" in caplog.text
+    assert "Attention required:" in caplog.text
+    assert sum(
+        "VASP INCAR COPILOT" in record.getMessage() for record in caplog.records
+    ) == 1
     caplog.clear()
 
     with caplog.at_level(INFO):

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1427,6 +1427,9 @@ def test_logging(caplog):
         "    Reason: d electrons were detected."
     ) in caplog.text
     assert "Attention required:" in caplog.text
+    assert caplog.text.index("Attention required:") < caplog.text.index(
+        "Applied changes:"
+    )
     assert (
         sum("VASP INCAR COPILOT" in record.getMessage() for record in caplog.records)
         == 1
@@ -1453,6 +1456,14 @@ def test_ediff_warning(caplog):
         calc = Vasp(atoms, ediff=1e-4)
     assert calc.parameters["ediff"] == 1e-4
     assert "results are likely unconverged" not in caplog.text
+
+
+def test_copilot_recommendation_label(caplog):
+    with caplog.at_level(INFO):
+        Vasp(bulk("Cu"), isif=3, nsw=2)
+
+    assert "Recommendation: Re-relax the final structure" in caplog.text
+    assert "Remediation:" not in caplog.text
 
 
 def test_bad_pmg_converter():

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1398,8 +1398,7 @@ def test_logging(caplog):
     )
     header = "================ VASP INCAR COPILOT ================"
     assert copilot_record.getMessage().endswith("=" * len(header))
-    assert "Summary:" in caplog.text
-    assert "0 warnings" in caplog.text
+    assert "Summary:" not in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text
     assert "Reason: d electrons were detected." in caplog.text
     assert "NCORE: None ->" in caplog.text
@@ -1422,7 +1421,10 @@ def test_logging(caplog):
     assert "NCORE: None ->" in caplog.text
     assert "ALGO was changed from 'all' to 'normal'" in caplog.text
     assert "LMAXMIX was not changed from 1 to 4" in caplog.text
-    assert "2 warnings" in caplog.text
+    assert (
+        "WARNING: LMAXMIX was not changed from 1 to 4 to respect the user's decision.\n"
+        "    Reason: d electrons were detected."
+    ) in caplog.text
     assert "Attention required:" in caplog.text
     assert (
         sum("VASP INCAR COPILOT" in record.getMessage() for record in caplog.records)

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1404,6 +1404,8 @@ def test_logging(caplog):
     assert "Reason: d electrons were detected." in caplog.text
     assert "NCORE: None ->" in caplog.text
     assert "Recommending" not in caplog.text
+    assert "VASP command = vasp_std" in caplog.text
+    assert "Using VASP command:" not in caplog.text
     caplog.clear()
 
     with caplog.at_level(INFO):
@@ -1568,6 +1570,8 @@ def test_logger(caplog):
     with change_settings({"VASP_PP_PATH": "/path/to/pseudos"}):
         with caplog.at_level(INFO):
             Vasp(atoms)
+        assert "PAW potentials = /path/to/pseudos/potpaw_PBE" in caplog.text
+        assert "Using PAW pseudopotentials:" not in caplog.text
         assert "/path/to/pseudos/potpaw_PBE" in caplog.text
         caplog.clear()
 

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -21,7 +21,7 @@ from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet
 from quacc import change_settings, get_settings
 from quacc.calculators.vasp import Vasp, presets
 from quacc.calculators.vasp import vasp as vasp_module
-from quacc.calculators.vasp.params import MPtoASEConverter
+from quacc.calculators.vasp.params import MPtoASEConverter, get_param_swaps
 from quacc.schemas.prep import prep_next_run
 
 FILE_DIR = Path(__file__).parent
@@ -1387,33 +1387,37 @@ def test_logging(caplog):
     atoms = bulk("Cu")
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(3, 3, 3))
-    assert "Recommending LMAXMIX = 4" in caplog.text
-    assert "Recommending NCORE" in caplog.text
-    assert "The following parameters were added" in caplog.text
-    assert "'lmaxmix': 4" in caplog.text
-    assert "'ncore':" in caplog.text
+    assert "VASP INCAR copilot:" in caplog.text
+    assert "0 warnings" in caplog.text
+    assert "LMAXMIX: None -> 4" in caplog.text
+    assert "Reason: d electrons were detected." in caplog.text
+    assert "NCORE: None ->" in caplog.text
+    assert "Recommending" not in caplog.text
     caplog.clear()
 
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(2, 2, 1), ismear=0)
-    assert "Recommending LMAXMIX = 4" in caplog.text
-    assert "Recommending SIGMA = 0.05" in caplog.text
-    assert "Recommending NCORE" in caplog.text
-    assert "The following parameters were added" in caplog.text
-    assert "'lmaxmix': 4" in caplog.text
-    assert "'ncore':" in caplog.text
+    assert "VASP INCAR copilot:" in caplog.text
+    assert "  ISMEAR:" not in caplog.text
+    assert "LMAXMIX: None -> 4" in caplog.text
+    assert "NCORE: None ->" in caplog.text
+    assert "SIGMA: None -> 0.05" in caplog.text
     caplog.clear()
 
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(2, 2, 1), ismear=-5, algo="all", lmaxmix=1)
-    assert "Recommending LMAXMIX = 4" in caplog.text
-    assert "Recommending NCORE" in caplog.text
-    assert "The following parameters were added" in caplog.text
-    assert "'isearch': 1" in caplog.text
-    assert "'ncore':" in caplog.text
+    assert "VASP INCAR copilot:" in caplog.text
+    assert "ISEARCH: None -> 1" in caplog.text
+    assert "NCORE: None ->" in caplog.text
     assert "ALGO was changed from 'all' to 'normal'" in caplog.text
-    assert "LMAXMIX was *not* changed from 1 to 4" in caplog.text
+    assert "LMAXMIX was not changed from 1 to 4" in caplog.text
+    assert "2 WARNING" in caplog.text
     caplog.clear()
+
+    with caplog.at_level(INFO):
+        params = get_param_swaps({}, atoms, incar_copilot_mode="off")
+    assert isinstance(params, dict)
+    assert "INCAR copilot" not in caplog.text
 
 
 def test_bad_pmg_converter():

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1389,7 +1389,9 @@ def test_logging(caplog):
         Vasp(atoms, nsw=0, kpts=(3, 3, 3))
     assert "================ VASP INCAR COPILOT ================" in caplog.text
     copilot_record = next(
-        record for record in caplog.records if "VASP INCAR COPILOT" in record.getMessage()
+        record
+        for record in caplog.records
+        if "VASP INCAR COPILOT" in record.getMessage()
     )
     assert copilot_record.getMessage().startswith(
         "\n================ VASP INCAR COPILOT ================"

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1425,7 +1425,7 @@ def test_logging(caplog):
     assert "ALGO was changed from 'all' to 'normal'" in caplog.text
     assert "LMAXMIX was not changed from 1 to 4" in caplog.text
     assert (
-        "  LMAXMIX was not changed from 1 to 4 to respect the user's decision.\n"
+        "  LMAXMIX was not changed from 1 to 4, but should be modified.\n"
         "    Reason: d electrons were detected."
     ) in caplog.text
     assert "⚠️ Attention required:" in caplog.text

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1388,6 +1388,14 @@ def test_logging(caplog):
     with caplog.at_level(INFO):
         Vasp(atoms, nsw=0, kpts=(3, 3, 3))
     assert "================ VASP INCAR COPILOT ================" in caplog.text
+    copilot_record = next(
+        record for record in caplog.records if "VASP INCAR COPILOT" in record.getMessage()
+    )
+    assert copilot_record.getMessage().startswith(
+        "\n================ VASP INCAR COPILOT ================"
+    )
+    header = "================ VASP INCAR COPILOT ================"
+    assert copilot_record.getMessage().endswith("=" * len(header))
     assert "Summary:" in caplog.text
     assert "0 warnings" in caplog.text
     assert "LMAXMIX: None -> 4" in caplog.text

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1426,6 +1426,22 @@ def test_logging(caplog):
     assert "INCAR copilot" not in caplog.text
 
 
+def test_ediff_warning(caplog):
+    atoms = bulk("Cu")
+
+    with caplog.at_level(INFO):
+        calc = Vasp(atoms, ediff=1e-3)
+    assert calc.parameters["ediff"] == 1e-3
+    assert "EDIFF=0.001 is greater than 1e-4" in caplog.text
+    assert "results are likely unconverged" in caplog.text
+    caplog.clear()
+
+    with caplog.at_level(INFO):
+        calc = Vasp(atoms, ediff=1e-4)
+    assert calc.parameters["ediff"] == 1e-4
+    assert "results are likely unconverged" not in caplog.text
+
+
 def test_bad_pmg_converter():
     with pytest.raises(ValueError, match="Either atoms or prev_dir must be provided"):
         MPtoASEConverter()

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -1425,7 +1425,7 @@ def test_logging(caplog):
     assert "ALGO was changed from 'all' to 'normal'" in caplog.text
     assert "LMAXMIX was not changed from 1 to 4" in caplog.text
     assert (
-        "WARNING: LMAXMIX was not changed from 1 to 4 to respect the user's decision.\n"
+        "  LMAXMIX was not changed from 1 to 4 to respect the user's decision.\n"
         "    Reason: d electrons were detected."
     ) in caplog.text
     assert "⚠️ Attention required:" in caplog.text

--- a/tests/core/runners/test_prep.py
+++ b/tests/core/runners/test_prep.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from logging import INFO
 from pathlib import Path
 
 import pytest
@@ -31,7 +32,7 @@ def make_files3():
         f.write("file2")
 
 
-def test_calc_setup(tmp_path, monkeypatch):
+def test_calc_setup(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     make_files()
 
@@ -40,9 +41,12 @@ def test_calc_setup(tmp_path, monkeypatch):
         atoms.calc = EMT()
         settings = get_settings()
 
-        tmpdir, results_dir = calc_setup(atoms)
+        with caplog.at_level(INFO):
+            tmpdir, results_dir = calc_setup(atoms)
 
         assert tmpdir.is_dir()
+        assert f"Run directory = {tmpdir}" in caplog.text
+        assert "Calculation will run at" not in caplog.text
         assert "tmp" in str(tmpdir)
         assert results_dir.name == tmpdir.name.split("tmp-")[-1]
         assert str(settings.RESULTS_DIR) in str(results_dir)

--- a/tests/core/settings/test_settings.py
+++ b/tests/core/settings/test_settings.py
@@ -51,6 +51,13 @@ def test_env_var(monkeypatch, tmp_path):
     assert p.expanduser().resolve() == QuaccSettings().SCRATCH_DIR
 
 
+def test_custodian_log_level(monkeypatch):
+    assert QuaccSettings().CUSTODIAN_LOG_LEVEL == "WARNING"
+
+    monkeypatch.setenv("QUACC_CUSTODIAN_LOG_LEVEL", "ERROR")
+    assert QuaccSettings().CUSTODIAN_LOG_LEVEL == "ERROR"
+
+
 def test_env_var2(monkeypatch, tmp_path):
     with open(tmp_path / "quacc_test.yaml", "w") as f:
         f.write("")

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from logging import INFO, WARNING, getLogger
+
+
+def test_emmet_task_doc_log_filter(caplog):
+    logger = getLogger("emmet.core.tasks")
+
+    with caplog.at_level(INFO, logger="emmet.core.tasks"):
+        logger.info("Getting task doc in: /path/to/calculation")
+        logger.info("Another useful Emmet message")
+        logger.warning("Getting task doc in: warning context")
+
+    assert "Getting task doc in: /path/to/calculation" not in caplog.text
+    assert "Another useful Emmet message" in caplog.text
+    assert "Getting task doc in: warning context" in caplog.text
+    assert caplog.records[-1].levelno == WARNING

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -15,3 +15,7 @@ def test_emmet_task_doc_log_filter(caplog):
     assert "Another useful Emmet message" in caplog.text
     assert "Getting task doc in: warning context" in caplog.text
     assert caplog.records[-1].levelno == WARNING
+
+
+def test_custodian_default_log_level():
+    assert getLogger("custodian").level == WARNING


### PR DESCRIPTION
## Summary
- collect INCAR copilot changes and unresolved warnings in a structured report
- emit one end-of-preparation summary with reasons for applied changes
- keep attention items at WARNING severity while removing duplicate recommendation logs
- preserve the public get_param_swaps(...) -> dict API and silence summaries when copilot mode is off

## Testing
- 58 passed, 1 skipped: tests/core/calculators/vasp/test_vasp.py
- ruff check passed for modified files
- full core suite: 353 passed, 118 skipped, 6 unrelated Windows-environment failures (missing echo executable and long nested paths)