### PR TITLE
Exclude ASE-derived parameters from INCAR copilot reports

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -416,7 +416,8 @@ def _get_param_swaps(
             change_reasons.get(k, "General INCAR compatibility rule was applied."),
         )
         for k in sorted(new_parameters)
-        if _params_differ(user_calc_params.get(k), new_parameters[k])
+        if k in change_reasons
+        and _params_differ(user_calc_params.get(k), new_parameters[k])
     ]
 
     overridden_user_params = {

--- a/tests/core/calculators/vasp/test_vasp.py
+++ b/tests/core/calculators/vasp/test_vasp.py
@@ -21,7 +21,11 @@ from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet
 from quacc import change_settings, get_settings
 from quacc.calculators.vasp import Vasp, presets
 from quacc.calculators.vasp import vasp as vasp_module
-from quacc.calculators.vasp.params import MPtoASEConverter, get_param_swaps
+from quacc.calculators.vasp.params import (
+    MPtoASEConverter,
+    _get_param_swaps,
+    get_param_swaps,
+)
 from quacc.schemas.prep import prep_next_run
 
 FILE_DIR = Path(__file__).parent
@@ -1210,6 +1214,9 @@ def test_lorbit():
 
 def test_dispersion():
     atoms = bulk("Cu")
+    _, report = _get_param_swaps({"xc": "r2scan"}, atoms)
+    assert all(change.parameter != "metagga" for change in report.changes)
+
     calc = Vasp(atoms, xc="r2scan", ivdw=13)
     assert calc.parameters["vdw_s6"] == 1.0
     assert calc.parameters["vdw_s8"] == 0.60187490


### PR DESCRIPTION
## Summary

- restrict applied-change reporting to parameters explicitly touched by the INCAR copilot
- avoid misclassifying ASE-derived parameters such as `METAGGA` from `xc="r2scan"` as copilot changes
- add a regression test for the r2SCAN case

## Testing

- 60 passed, 1 skipped: `tests/core/calculators/vasp/test_vasp.py`
- Ruff passed for the modified files
