### PR TITLE
Refactor VASP parameter swaps

### DIFF
--- a/src/quacc/calculators/vasp/params.py
+++ b/src/quacc/calculators/vasp/params.py
@@ -115,26 +115,6 @@ def get_param_swaps(
     dict
         The updated user-provided calculator parameters.
     """
-    new_parameters, report = _get_param_swaps(
-        user_calc_params,
-        input_atoms,
-        pmg_kpts=pmg_kpts,
-        incar_copilot_mode=incar_copilot_mode,
-    )
-    if incar_copilot_mode.lower() != "off":
-        log_copilot_report(report)
-    return new_parameters
-
-
-def _get_param_swaps(
-    user_calc_params: dict[str, Any],
-    input_atoms: Atoms,
-    pmg_kpts: dict[Literal["line_density", "kppvol", "kppa"], float] | None = None,
-    incar_copilot_mode: Literal[
-        "off", "critical", "standard", "aggressive"
-    ] = "standard",
-) -> tuple[dict[str, Any], CopilotReport]:
-    """Return updated parameters and a structured INCAR copilot report."""
     report = CopilotReport()
     is_metal = check_is_metal(input_atoms)
     calc = Vasp_(**remove_unused_flags(user_calc_params))
@@ -448,7 +428,10 @@ def _get_param_swaps(
                 )
             )
 
-    return new_parameters, report
+    if incar_copilot_mode.lower() != "off":
+        log_copilot_report(report)
+
+    return new_parameters
 
 
 def remove_unused_flags(user_calc_params: dict[str, Any]) -> dict[str, Any]:

--- a/src/quacc/calculators/vasp/vasp.py
+++ b/src/quacc/calculators/vasp/vasp.py
@@ -15,8 +15,7 @@ from ase.calculators.vasp import setups as ase_setups
 from quacc import QuaccDefault, get_settings
 from quacc.calculators.vasp.io import load_vasp_yaml_calc
 from quacc.calculators.vasp.params import (
-    _get_param_swaps,
-    log_copilot_report,
+    get_param_swaps,
     normalize_params,
     remove_unused_flags,
     set_auto_dipole,
@@ -313,7 +312,7 @@ class Vasp(Vasp_):
         )
 
         # Handle INCAR swaps
-        self.user_calc_params, copilot_report = _get_param_swaps(
+        self.user_calc_params = get_param_swaps(
             self.user_calc_params,
             self.input_atoms,
             incar_copilot_mode=self.incar_copilot_mode,
@@ -321,9 +320,6 @@ class Vasp(Vasp_):
         )
         if self.incar_copilot_mode.lower() not in {"off", "critical"}:
             self.user_calc_params = remove_unused_flags(self.user_calc_params)
-
-        if self.incar_copilot_mode.lower() != "off":
-            log_copilot_report(copilot_report)
 
         # Clean up the user calc parameters
         self.user_calc_params = sort_dict(self.user_calc_params)


### PR DESCRIPTION
## Summary

- merge the private `_get_param_swaps` implementation into the public `get_param_swaps` function
- have the VASP calculator call the public function directly
- keep copilot report logging and the public return type unchanged

## Testing

- `python -m pytest tests/core/calculators/vasp/test_vasp.py -q --basetemp=.pytest-temp` (60 passed, 1 skipped)
- `python -m ruff check src/quacc/calculators/vasp/params.py src/quacc/calculators/vasp/vasp.py tests/core/calculators/vasp/test_vasp.py`
- `python -m ruff format --check src/quacc/calculators/vasp/params.py src/quacc/calculators/vasp/vasp.py tests/core/calculators/vasp/test_vasp.py`
