### PR TITLE
Aqcat25 static recipe

### DIFF
--- a/docs/user/recipes/mlip_recipes.md
+++ b/docs/user/recipes/mlip_recipes.md
@@ -11,6 +11,7 @@ Several popular datasets used to train machine-learned interatomic potentials (M
 | [OMC25](https://www.nature.com/articles/s41597-026-06628-2) | [quacc.recipes.vasp.fairchem.omc_static_job][] | `quacc[fairchem]` |
 | [OMol25](https://arxiv.org/abs/2505.08762) | [quacc.recipes.orca.fairchem.omol_static_job][] | `quacc[fairchem]` |
 | [ODAC25](https://arxiv.org/abs/2508.03162) | [quacc.recipes.vasp.fairchem.odac_static_job][] | none |
+| [AQCat25](https://www.nature.com/articles/s41524-026-02099-6) | [quacc.recipes.vasp.aqcat.aqcat25_static_job][] | none |
 | [MPtrj](https://www.nature.com/articles/s42256-023-00716-3) / [WBM](https://www.nature.com/articles/s41524-020-00481-6) / [sAlex](https://matbench-discovery.materialsproject.org/data/salex) / [MatterSim](https://arxiv.org/abs/2405.04967) | [quacc.recipes.vasp.mp_legacy.mp_relax_set_job][] | none |
 | [MatPES](https://arxiv.org/abs/2503.04070) | [quacc.recipes.vasp.matpes.matpes_static_job][] | `quacc[atomate2]` |
 | [MP-ALOE](https://www.nature.com/articles/s41524-025-01834-9) | [quacc.recipes.vasp.mp_aloe.mp_aloe_static_job][] | none |

--- a/src/quacc/recipes/vasp/aqcat.py
+++ b/src/quacc/recipes/vasp/aqcat.py
@@ -1,0 +1,117 @@
+"""AQCat25-compatible slab recipes"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from quacc import job
+from quacc.recipes.vasp._base import run_and_summarize
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ase.atoms import Atoms
+
+    from quacc.types import CopyFiles, VaspSchema
+
+
+@job
+def aqcat25_static_job(
+    atoms: Atoms,
+    copy_files: CopyFiles | None = None,
+    additional_fields: dict[str, Any] | None = None,
+    **calc_kwargs: Any,
+) -> VaspSchema:
+    """
+    Carry out a static calculation with AQCat25 slab settings.
+
+    By default, use the slab k-point sampling from the AQCat25 paper's
+    fairchem implementation: max(1, round(40 / L)) in each in-plane direction,
+    where L is the largest absolute Cartesian component of that cell vector
+    in angstroms, and one k-point along the third cell vector (vacuum).
+    Override this sampling with `kpts` or `kspacing` in `calc_kwargs`.
+
+    Parameters
+    ----------
+    atoms
+        Atoms object
+    copy_files
+        Files to copy (and decompress) from source to the runtime directory.
+    additional_fields
+        Additional fields to add to the results dictionary.
+    **calc_kwargs
+        Custom kwargs for the Vasp calculator. Set a value to
+        `None` to remove a pre-existing key entirely. For a list of available
+        keys, refer to [quacc.calculators.vasp.vasp.Vasp][]. All of the ASE
+        Vasp calculator keyword arguments are supported.
+
+    Returns
+    -------
+    VaspSchema
+        Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
+        See the type-hint for the data structure.
+    """
+    # Initial magnetic moments of the spin-polarized elements (AQCat25 paper, Table 6)
+    magmoms = {
+        "V": 5.0,
+        "Cr": 5.0,
+        "Mn": 5.0,
+        "Fe": 5.0,
+        "Co": 5.0,
+        "Ni": 5.0,
+        "Cu": 1.73,
+        "Mo": 5.0,
+        "Ru": 2.2,
+        "W": 5.0,
+        "Os": 2.2,
+        "Ce": 5.0,
+    }
+    spin_polarized = not set(atoms.get_chemical_symbols()).isdisjoint(magmoms)
+
+    calc_defaults = {
+        "ibrion": 2,
+        "nsw": 0,
+        "isif": 0,
+        "ispin": 2 if spin_polarized else 1,
+        "isym": 0,
+        "algo": "normal",
+        "ismear": 0,
+        "sigma": 0.1,
+        "ediffg": -0.03,
+        "encut": 500.0,
+        "prec": "accurate",
+        "potim": 0.5,
+        "nelm": 250,
+        "lwave": False,
+        "lvhar": False,
+        "lcharg": False,
+        "laechg": False,
+        "xc": "rpbe",
+        "lasph": False,
+        "ediff": 1e-4,
+        "symprec": 1e-10,
+        "lreal": "auto",
+        "pp_version": "54",
+        "incar_copilot_mode": "critical",
+        "use_custodian": False,
+    }
+    if spin_polarized:
+        calc_defaults |= {"elemental_magmoms": magmoms, "preset_mag_default": 0.0}
+    if "kpts" not in calc_kwargs and "kspacing" not in calc_kwargs:
+        # Match fairchem's calculate_surface_k_points used by AQCat25.
+        cell = atoms.get_cell()
+        calc_defaults["kpts"] = (
+            max(1, round(40 / np.linalg.norm(cell[0], ord=np.inf))),
+            max(1, round(40 / np.linalg.norm(cell[1], ord=np.inf))),
+            1,
+        )
+
+    return run_and_summarize(
+        atoms,
+        calc_defaults=calc_defaults,
+        calc_swaps=calc_kwargs,
+        additional_fields={"name": "AQCat25 Static"} | (additional_fields or {}),
+        copy_files=copy_files,
+    )

--- a/src/quacc/recipes/vasp/aqcat.py
+++ b/src/quacc/recipes/vasp/aqcat.py
@@ -97,7 +97,14 @@ def aqcat25_static_job(
         elemental_overrides.get(atom.symbol, 0.0) != 0.0 for atom in atoms
     )
 
+    # Match fairchem's calculate_surface_k_points used by AQCat25.
+    cell = atoms.get_cell()
     calc_defaults = {
+        "kpts": (
+            max(1, round(40 / np.linalg.norm(cell[0], ord=np.inf))),
+            max(1, round(40 / np.linalg.norm(cell[1], ord=np.inf))),
+            1,
+        ),
         "ibrion": 2,
         "nsw": 0,
         "isif": 0,
@@ -126,14 +133,6 @@ def aqcat25_static_job(
     }
     if spin_polarized:
         calc_defaults["magmom"] = [magmoms.get(atom.symbol, 0.0) for atom in atoms]
-    if "kpts" not in calc_kwargs and "kspacing" not in calc_kwargs:
-        # Match fairchem's calculate_surface_k_points used by AQCat25.
-        cell = atoms.get_cell()
-        calc_defaults["kpts"] = (
-            max(1, round(40 / np.linalg.norm(cell[0], ord=np.inf))),
-            max(1, round(40 / np.linalg.norm(cell[1], ord=np.inf))),
-            1,
-        )
 
     return run_and_summarize(
         atoms,

--- a/src/quacc/recipes/vasp/aqcat.py
+++ b/src/quacc/recipes/vasp/aqcat.py
@@ -33,6 +33,21 @@ def aqcat25_static_job(
     in angstroms, and one k-point along the third cell vector (vacuum).
     Override this sampling with `kpts` or `kspacing` in `calc_kwargs`.
 
+    For spin-polarized systems, initial magnetic moments are chosen in this
+    order: explicit `magmom` list > `elemental_magmoms` overrides > AQCat25
+    Table 6 defaults. `elemental_magmoms` sets the same value for every atom of
+    a selected element; unlisted elements keep their AQCat25 defaults (zero
+    for elements absent from Table 6). `magmom` supplies one value per atom,
+    in input atom order, and replaces the entire list, even when
+    `elemental_magmoms` is also supplied. Values are in Bohr magnetons.
+
+    These recipe defaults override moments stored on the atoms or their
+    calculator. Pass `magmom=None` to remove the recipe's explicit list and
+    use quacc's normal handling of stored moments instead. A nonzero elemental
+    override for an element present in the structure also enables spin
+    polarization by default. Pass `ispin=1` to disable spin polarization.
+    These are initial moments, not constraints on the final magnetization.
+
     Parameters
     ----------
     atoms
@@ -52,6 +67,13 @@ def aqcat25_static_job(
     VaspSchema
         Dictionary of results from [quacc.schemas.vasp.VaspSummarize.run][].
         See the type-hint for the data structure.
+
+    Examples
+    --------
+    >>> aqcat25_static_job(atoms)
+    >>> aqcat25_static_job(atoms, elemental_magmoms={"Fe": 3.0, "O": 0.5})
+    >>> aqcat25_static_job(atoms, magmom=[2.0, -2.0, 0.0])
+    >>> aqcat25_static_job(atoms, kpts=(4, 4, 1), ispin=1)
     """
     # Initial magnetic moments of the spin-polarized elements (AQCat25 paper, Table 6)
     magmoms = {
@@ -69,6 +91,11 @@ def aqcat25_static_job(
         "Ce": 5.0,
     }
     spin_polarized = not set(atoms.get_chemical_symbols()).isdisjoint(magmoms)
+    elemental_overrides = calc_kwargs.get("elemental_magmoms") or {}
+    magmoms |= elemental_overrides
+    spin_polarized = spin_polarized or any(
+        elemental_overrides.get(atom.symbol, 0.0) != 0.0 for atom in atoms
+    )
 
     calc_defaults = {
         "ibrion": 2,
@@ -98,7 +125,7 @@ def aqcat25_static_job(
         "use_custodian": False,
     }
     if spin_polarized:
-        calc_defaults |= {"elemental_magmoms": magmoms, "preset_mag_default": 0.0}
+        calc_defaults["magmom"] = [magmoms.get(atom.symbol, 0.0) for atom in atoms]
     if "kpts" not in calc_kwargs and "kspacing" not in calc_kwargs:
         # Match fairchem's calculate_surface_k_points used by AQCat25.
         cell = atoms.get_cell()

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1628,8 +1628,105 @@ def test_fairchem_oc20(patch_nonmetallic_taskdoc):
     }
 
 
+def test_aqcat25(patch_nonmetallic_taskdoc):
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+
+    atoms = bulk("Si")
+    output = aqcat25_static_job(atoms)
+    output["parameters"].pop("ncore")
+    assert output["parameters"] == {
+        "kpts": (15, 15, 1),
+        "ibrion": 2,
+        "nsw": 0,
+        "isif": 0,
+        "ispin": 1,
+        "isym": 0,
+        "algo": "normal",
+        "ismear": 0,
+        "sigma": 0.1,
+        "ediffg": -0.03,
+        "encut": 500.0,
+        "prec": "accurate",
+        "potim": 0.5,
+        "nelm": 250,
+        "lwave": False,
+        "lvhar": False,
+        "lcharg": False,
+        "laechg": False,
+        "lasph": False,
+        "ediff": 1e-4,
+        "symprec": 1e-10,
+        "lreal": "auto",
+        "gga": "RP",
+        "pp": "PBE",
+        "xc": "rpbe",
+        "pp_version": "54",
+    }
+
+    output = aqcat25_static_job(atoms, kpts=(3, 2, 1))
+    assert output["parameters"]["kpts"] == (3, 2, 1)
+
+
+@pytest.mark.parametrize(
+    ("cell", "expected"),
+    [
+        ([10, 16, 20], (4, 2, 1)),
+        ([[8, 6, 0], [0, 12, 0], [0, 0, 20]], (5, 3, 1)),
+        ([100, 100, 20], (1, 1, 1)),
+    ],
+)
+def test_aqcat25_slab_kpoints(monkeypatch, cell, expected):
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.aqcat.run_and_summarize", mock_run_and_summarize
+    )
+    atoms = bulk("Si")
+    atoms.set_cell(cell)
+    assert aqcat25_static_job(atoms)["parameters"]["kpts"] == expected
+
+
+def test_aqcat25_kspacing_override(monkeypatch):
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.aqcat.run_and_summarize", mock_run_and_summarize
+    )
+    assert "kpts" not in aqcat25_static_job(bulk("Si"), kspacing=0.2)["parameters"]
+
+
 def mock_run_and_summarize(atoms, *args, **kwargs):
     return {"parameters": kwargs["calc_defaults"]}
+
+
+def test_aqcat25_spin_polarized(monkeypatch):
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.aqcat.run_and_summarize", mock_run_and_summarize
+    )
+
+    parameters = aqcat25_static_job(bulk("Fe"))["parameters"]
+    assert parameters["ispin"] == 2
+    assert parameters["elemental_magmoms"] == {
+        "V": 5.0,
+        "Cr": 5.0,
+        "Mn": 5.0,
+        "Fe": 5.0,
+        "Co": 5.0,
+        "Ni": 5.0,
+        "Cu": 1.73,
+        "Mo": 5.0,
+        "Ru": 2.2,
+        "W": 5.0,
+        "Os": 2.2,
+        "Ce": 5.0,
+    }
+    assert parameters["preset_mag_default"] == 0.0
+
+    parameters = aqcat25_static_job(bulk("Si"))["parameters"]
+    assert parameters["ispin"] == 1
+    assert "elemental_magmoms" not in parameters
 
 
 def test_md_job_nvt(monkeypatch):

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1686,13 +1686,23 @@ def test_aqcat25_slab_kpoints(monkeypatch, cell, expected):
     assert aqcat25_static_job(atoms)["parameters"]["kpts"] == expected
 
 
-def test_aqcat25_kspacing_override(monkeypatch):
+def test_aqcat25_kspacing_override(monkeypatch, tmp_path):
+    from quacc.calculators.vasp import Vasp
     from quacc.recipes.vasp.aqcat import aqcat25_static_job
+    from quacc.utils.dicts import recursive_dict_merge
+
+    def capture_calculator(atoms, calc_defaults, calc_swaps, **kwargs):
+        return Vasp(atoms, **recursive_dict_merge(calc_defaults, calc_swaps))
 
     monkeypatch.setattr(
-        "quacc.recipes.vasp.aqcat.run_and_summarize", mock_run_and_summarize
+        "quacc.recipes.vasp.aqcat.run_and_summarize", capture_calculator
     )
-    assert "kpts" not in aqcat25_static_job(bulk("Si"), kspacing=0.2)["parameters"]
+    atoms = bulk("Si")
+    calc = aqcat25_static_job(atoms, kspacing=0.2)
+    assert calc.float_params["kspacing"] == 0.2
+    # KSPACING in the INCAR takes precedence, so ASE writes no KPOINTS file.
+    calc.write_kpoints(atoms=atoms, directory=tmp_path)
+    assert not (tmp_path / "KPOINTS").exists()
 
 
 def mock_run_and_summarize(atoms, *args, **kwargs):

--- a/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
+++ b/tests/core/recipes/vasp_recipes/mocked/test_vasp_recipes.py
@@ -1700,33 +1700,128 @@ def mock_run_and_summarize(atoms, *args, **kwargs):
 
 
 def test_aqcat25_spin_polarized(monkeypatch):
+    from ase import Atoms
+
     from quacc.recipes.vasp.aqcat import aqcat25_static_job
 
     monkeypatch.setattr(
         "quacc.recipes.vasp.aqcat.run_and_summarize", mock_run_and_summarize
     )
 
-    parameters = aqcat25_static_job(bulk("Fe"))["parameters"]
+    atoms = Atoms("VCrMnFeCoNiCuMoRuWOsCeO", cell=[10, 10, 20])
+    parameters = aqcat25_static_job(atoms)["parameters"]
     assert parameters["ispin"] == 2
-    assert parameters["elemental_magmoms"] == {
-        "V": 5.0,
-        "Cr": 5.0,
-        "Mn": 5.0,
-        "Fe": 5.0,
-        "Co": 5.0,
-        "Ni": 5.0,
-        "Cu": 1.73,
-        "Mo": 5.0,
-        "Ru": 2.2,
-        "W": 5.0,
-        "Os": 2.2,
-        "Ce": 5.0,
-    }
-    assert parameters["preset_mag_default"] == 0.0
+    assert parameters["magmom"] == [
+        5.0,
+        5.0,
+        5.0,
+        5.0,
+        5.0,
+        5.0,
+        1.73,
+        5.0,
+        2.2,
+        5.0,
+        2.2,
+        5.0,
+        0.0,
+    ]
 
     parameters = aqcat25_static_job(bulk("Si"))["parameters"]
     assert parameters["ispin"] == 1
-    assert "elemental_magmoms" not in parameters
+    assert "magmom" not in parameters
+
+
+@pytest.mark.parametrize("with_results", [False, True])
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({}, [5.0, 5.0, 0.0]),
+        ({"magmom": [3.0, -3.0, 0.0]}, [3.0, -3.0, 0.0]),
+        ({"magmom": None}, None),
+        ({"ispin": 1}, [5.0, 5.0, 0.0]),
+    ],
+)
+def test_aqcat25_magnetic_initialization(
+    monkeypatch, with_results, overrides, expected
+):
+    from ase import Atoms
+    from ase.calculators.singlepoint import SinglePointCalculator
+    from ase.calculators.vasp.create_input import set_magmom
+
+    from quacc.calculators.vasp import Vasp
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+    from quacc.utils.dicts import recursive_dict_merge
+
+    # Exercise real calculator initialization without launching VASP.
+    def capture_calculator(atoms, calc_defaults, calc_swaps, **kwargs):
+        return Vasp(atoms, **recursive_dict_merge(calc_defaults, calc_swaps))
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.aqcat.run_and_summarize", capture_calculator
+    )
+    atoms = Atoms("Fe2O", cell=[10, 10, 20])
+    atoms.set_initial_magnetic_moments([1.0, -1.0, 0.1])
+    if with_results:
+        atoms.calc = SinglePointCalculator(atoms, magmoms=[0.2, -0.2, 0.0])
+
+    calc = aqcat25_static_job(atoms, **overrides)
+    assert calc.list_float_params["magmom"] == expected
+    assert calc.int_params["ispin"] == overrides.get("ispin", 2)
+    if expected is None:
+        inherited = [0.2, -0.2, 0.0] if with_results else [1.0, -1.0, 0.1]
+        np.testing.assert_array_equal(
+            calc.input_atoms.get_initial_magnetic_moments(), inherited
+        )
+    elif calc.int_params["ispin"] == 2:
+        # Verify the MAGMOM text ASE writes uses the explicit values, even
+        # when quacc has copied different moments from a previous calculator.
+        _, incar = set_magmom(
+            2, True, calc.input_atoms, calc.list_float_params["magmom"], [0, 1, 2]
+        )
+        expected_line = (
+            "1*3.0000 1*-3.0000 1*0.0000"
+            if "magmom" in overrides
+            else "2*5.0000 1*0.0000"
+        )
+        assert incar["magmom"] == expected_line
+
+
+@pytest.mark.parametrize(
+    ("symbols", "overrides", "expected", "ispin"),
+    [
+        ("Fe2O", {"elemental_magmoms": {"Fe": 3.0, "O": 0.5}}, [3.0, 3.0, 0.5], 2),
+        ("Fe2O", {"elemental_magmoms": {"O": 0.5}}, [5.0, 5.0, 0.5], 2),
+        (
+            "Fe2O",
+            {"elemental_magmoms": {"Fe": 3.0}, "magmom": [2.0, -2.0, 0.0]},
+            [2.0, -2.0, 0.0],
+            2,
+        ),
+        ("O2", {"elemental_magmoms": {"O": 0.5}}, [0.5, 0.5], 2),
+        ("O2", {"elemental_magmoms": {"O": 0.5}, "ispin": 1}, [0.5, 0.5], 1),
+        ("O2", {"elemental_magmoms": {"Fe": 3.0}}, None, 1),
+    ],
+)
+def test_aqcat25_elemental_magmoms(monkeypatch, symbols, overrides, expected, ispin):
+    from ase import Atoms
+    from ase.calculators.singlepoint import SinglePointCalculator
+
+    from quacc.calculators.vasp import Vasp
+    from quacc.recipes.vasp.aqcat import aqcat25_static_job
+    from quacc.utils.dicts import recursive_dict_merge
+
+    def capture_calculator(atoms, calc_defaults, calc_swaps, **kwargs):
+        return Vasp(atoms, **recursive_dict_merge(calc_defaults, calc_swaps))
+
+    monkeypatch.setattr(
+        "quacc.recipes.vasp.aqcat.run_and_summarize", capture_calculator
+    )
+    atoms = Atoms(symbols, cell=[10, 10, 20])
+    atoms.calc = SinglePointCalculator(atoms, magmoms=[0.0] * len(atoms))
+    calc = aqcat25_static_job(atoms, **overrides)
+    assert calc.list_float_params["magmom"] == expected
+    assert calc.int_params["ispin"] == ispin
 
 
 def test_md_job_nvt(monkeypatch):


### PR DESCRIPTION
- I added in aqcat25_static_job (RPBE, ENCUT 500, ISMEAR 0 / SIGMA 0.1, EDIFF 1e-4, NELM 250, NSW 0).
- Calculates k points using the same technique implemented inthe fairchem repository for slabs and adsorbate-slab systems. 
- Uses magnetic moments used by AQCat25 as a default, which can be turned off.
-Added in a feature to overide default elemental_magmoms if the user wants.
